### PR TITLE
use StandardCharsets.UTF_8

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/analysis/NumberAnalyzer.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/analysis/NumberAnalyzer.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -360,7 +361,7 @@ public class NumberAnalyzer {
 		
 		// See https://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Nummerierung/Rufnummern/ONRufnr/Vorwahlverzeichnis_ONB.zip.html
 		try (InputStream in = NumberAnalyzer.class.getResourceAsStream("NVONB.INTERNET.20220727.ONB.csv")) {
-			try (Reader r = new InputStreamReader(in, "utf-8")) {
+			try (Reader r = new InputStreamReader(in, StandardCharsets.UTF_8)) {
 				Node germany = root.find("+49", 1, root);
 				
 				ICSVParser parser = new CSVParserBuilder().withSeparator(';').withStrictQuotes(false).build();

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -6,7 +6,7 @@ package de.haumacher.phoneblock.db;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -114,7 +114,7 @@ public class DB {
 
 	private boolean _sendHelpMails;
 
-	public DB(DataSource dataSource, SchedulerService scheduler) throws SQLException, UnsupportedEncodingException {
+	public DB(DataSource dataSource, SchedulerService scheduler) throws SQLException {
 		this(false, dataSource, IndexUpdateService.NONE, scheduler, null);
 	}
 	
@@ -124,7 +124,7 @@ public class DB {
 	 *
 	 * @param dataSource
 	 */
-	public DB(boolean sendHelpMails, DataSource dataSource, IndexUpdateService indexer, SchedulerService scheduler, MailService mailService) throws SQLException, UnsupportedEncodingException {
+	public DB(boolean sendHelpMails, DataSource dataSource, IndexUpdateService indexer, SchedulerService scheduler, MailService mailService) throws SQLException {
 		_sendHelpMails = sendHelpMails;
 		_dataSource = dataSource;
 		_indexer = indexer;
@@ -154,7 +154,7 @@ public class DB {
 		        ScriptRunner sr = new ScriptRunner(session.getConnection());
 		        sr.setAutoCommit(true);
 		        sr.setDelimiter(";");
-		        sr.runScript(new InputStreamReader(getClass().getResourceAsStream("db-schema.sql"), "utf-8"));
+		        sr.runScript(new InputStreamReader(getClass().getResourceAsStream("db-schema.sql"), StandardCharsets.UTF_8));
 			}
 		}
 		
@@ -217,7 +217,7 @@ public class DB {
 	 * @param login The user name (e.g. e-mail address) of the new account.
 	 * @return The randomly generated password for the account.
 	 */
-	public String createUser(String clientName, String extId, String login, String displayName) throws UnsupportedEncodingException {
+	public String createUser(String clientName, String extId, String login, String displayName) {
 		String passwd = createPassword(20);
 		addUser(clientName, extId, login, displayName, passwd);
 		return passwd;
@@ -709,7 +709,7 @@ public class DB {
 	/** 
 	 * Adds the given user with the given password.
 	 */
-	public void addUser(String clientName, String extId, String login, String displayName, String passwd) throws UnsupportedEncodingException {
+	public void addUser(String clientName, String extId, String login, String displayName, String passwd) {
 		try (SqlSession session = openSession()) {
 			Users users = session.getMapper(Users.class);
 			users.addUser(login, clientName, extId, displayName, pwhash(passwd), System.currentTimeMillis());
@@ -722,7 +722,7 @@ public class DB {
 	 * 
 	 * @return The new password, or <code>null</code>, if the given user does not exist.
 	 */
-	public String resetPassword(String login) throws UnsupportedEncodingException {
+	public String resetPassword(String login) {
 		try (SqlSession session = openSession()) {
 			Users users = session.getMapper(Users.class);
 			
@@ -810,7 +810,7 @@ public class DB {
 		if (authHeader.startsWith(BASIC_PREFIX)) {
 			String credentials = authHeader.substring(BASIC_PREFIX.length());
 			byte[] decodedBytes = Base64.getDecoder().decode(credentials);
-			String decoded = new String(decodedBytes, "utf-8");
+			String decoded = new String(decodedBytes, StandardCharsets.UTF_8);
 			int sepIndex = decoded.indexOf(':');
 			if (sepIndex >= 0) {
 				String login = decoded.substring(0, sepIndex);
@@ -827,7 +827,7 @@ public class DB {
 	 * 
 	 * @return The authorized user name, if authorization was successful, <code>null</code> otherwise.
 	 */
-	public String login(String login, String passwd) throws UnsupportedEncodingException, IOException {
+	public String login(String login, String passwd) throws IOException {
 		byte[] pwhash = pwhash(passwd);
 		
 		try (SqlSession session = openSession()) {
@@ -878,8 +878,8 @@ public class DB {
 		return result.toString();
 	}
 
-	private byte[] pwhash(String passwd) throws UnsupportedEncodingException {
-		return _sha256.digest(passwd.getBytes("utf-8"));
+	private byte[] pwhash(String passwd) {
+		return _sha256.digest(passwd.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/** 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBService.java
@@ -3,7 +3,6 @@
  */
 package de.haumacher.phoneblock.db;
 
-import java.io.UnsupportedEncodingException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -64,7 +63,7 @@ public class DBService implements ServletContextListener {
             org.h2.Driver.load();
 			DBConfig config = lookupConfig(servletContextEvent);
 			startDB(config);
-		} catch (SQLException | UnsupportedEncodingException ex) {
+		} catch (SQLException ex) {
 			LOG.error("Failed to start DB.", ex);
 		}
 	}
@@ -96,7 +95,7 @@ public class DBService implements ServletContextListener {
 		return config;
 	}
 
-	private void startDB(DBConfig config) throws SQLException, UnsupportedEncodingException {
+	private void startDB(DBConfig config) throws SQLException {
 		LOG.info("Opening H2 database: " + config.getUrl() + " for user '" + config.getUser() + "'.");
 		JdbcDataSource dataSource = new JdbcDataSource();
 		dataSource.setUrl(config.getUrl());

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/index/google/GoogleUpdateService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/index/google/GoogleUpdateService.java
@@ -6,8 +6,8 @@ package de.haumacher.phoneblock.index.google;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import javax.naming.Context;
@@ -120,10 +120,10 @@ public class GoogleUpdateService implements IndexUpdateService {
 		}
 	}
 
-	private byte[] toByteArray(UpdateMessage message) throws IOException, UnsupportedEncodingException {
+	private byte[] toByteArray(UpdateMessage message) throws IOException {
 		StringW buffer = new StringW();
 		message.writeTo(new JsonWriter(buffer));
-		byte[] content = buffer.toString().getBytes("utf-8");
+		byte[] content = buffer.toString().getBytes(StandardCharsets.UTF_8);
 		return content;
 	}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/index/indexnow/IndexNowUpdateService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/index/indexnow/IndexNowUpdateService.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -76,7 +77,7 @@ public class IndexNowUpdateService implements IndexUpdateService {
 		}
 		String url = "https://phoneblock.net" + _contextPath + path;
 		try {
-			URL indexnowUrl = new URL("https://www.bing.com/indexnow?url=" + URLEncoder.encode(url, "utf-8") + "&key=" + _apiKey);
+			URL indexnowUrl = new URL("https://www.bing.com/indexnow?url=" + URLEncoder.encode(url, StandardCharsets.UTF_8) + "&key=" + _apiKey);
 			HttpURLConnection connection = (HttpURLConnection) indexnowUrl.openConnection();
 			connection.connect();
 			int code = connection.getResponseCode();

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/mail/MailService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/mail/MailService.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -248,7 +249,7 @@ public class MailService {
 		StringBuilder result = new StringBuilder();
 		char[] buffer = new char[4096];
 		try (InputStream in = getClass().getResourceAsStream(resource)) {
-			try (Reader r = new InputStreamReader(in, "utf-8")) {
+			try (Reader r = new InputStreamReader(in, StandardCharsets.UTF_8)) {
 				while (true) {
 					int direct = r.read(buffer);
 					if (direct < 0) {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/namegen/NameGenerator.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/namegen/NameGenerator.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -51,7 +52,7 @@ public class NameGenerator {
 	
 	private static List<String> load(String string) {
 		List<String> result = new ArrayList<>();
-		try (BufferedReader r = new BufferedReader(new InputStreamReader(NameGenerator.class.getResourceAsStream(string), "utf-8"))) {
+		try (BufferedReader r = new BufferedReader(new InputStreamReader(NameGenerator.class.getResourceAsStream(string), StandardCharsets.UTF_8))) {
 			String line;
 			while ((line = r.readLine()) != null) {
 				String name = line.trim();

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -6,9 +6,8 @@ package de.haumacher.phoneblock.db;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Base64;
@@ -62,7 +61,7 @@ public class TestDB {
 	}
 
 	@Test
-	public void testTopSearches() throws UnsupportedEncodingException, SQLException {
+	public void testTopSearches() {
 		_db.addRating("0", Rating.C_PING, null, 0);
 		_db.addRating("1", Rating.C_PING, null, 0);
 		_db.addRating("2", Rating.C_PING, null, 0);
@@ -98,7 +97,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testSpamReports() throws UnsupportedEncodingException, SQLException {
+	public void testSpamReports() {
 		assertFalse(_db.hasSpamReportFor("123"));
 
 		_db.processVotes("123", 2, 1000);
@@ -138,7 +137,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testBlocklist() throws UnsupportedEncodingException, SQLException {
+	public void testBlocklist() {
 		try (SqlSession session = _db.openSession()) {
 			BlockList blockList = session.getMapper(BlockList.class);
 			
@@ -176,7 +175,7 @@ public class TestDB {
 	}
 
 	@Test
-	public void testDuplicateAdd() throws UnsupportedEncodingException, SQLException {
+	public void testDuplicateAdd() {
 		try (SqlSession session = _db.openSession()) {
 			BlockList blockList = session.getMapper(BlockList.class);
 
@@ -191,7 +190,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testUserManagement() throws SQLException, IOException {
+	public void testUserManagement() throws IOException {
 		_db.addUser("none", "1", "foo@bar.com", "Mr. X", "123");
 		_db.addUser("none", "2", "baz@bar.com", "Mr. Y", "123");
 		
@@ -209,8 +208,8 @@ public class TestDB {
 		}
 	}
 	
-	private String header(String user, String pw) throws UnsupportedEncodingException {
-		return "Basic " + Base64.getEncoder().encodeToString((user + ':' + pw).getBytes("utf-8"));
+	private String header(String user, String pw) {
+		return "Basic " + Base64.getEncoder().encodeToString((user + ':' + pw).getBytes(StandardCharsets.UTF_8));
 	}
 	
 	@Test


### PR DESCRIPTION
By using the Java `StandardCharsets.UTF_8` instead of an string, the lookup of the charset could be avoided. In addition no `UnsupportedEncodingException` could be thrown.