### PR TITLE
modernize junit5 usage

### DIFF
--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -241,8 +241,8 @@
 
 		<dependency>
 		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter-api</artifactId>
-		    <version>5.9.3</version>
+		    <artifactId>junit-jupiter</artifactId>
+		    <version>5.10.2</version>
 		    <scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/TestDomUtil.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/TestDomUtil.java
@@ -24,10 +24,10 @@ import de.haumacher.phoneblock.util.DomUtil;
 /**
  * Test case for {@link DomUtil}.
  */
-public class TestDomUtil {
+class TestDomUtil {
 
 	@Test
-	public void testNavigate() throws SAXException, IOException {
+	void testNavigate() throws SAXException, IOException {
 		Document doc = doc("<?xml version=\"1.0\" encoding=\"utf-8\"?><d:propfind xmlns:d=\"DAV:\"><d:prop><d:current-user-principal/></d:prop></d:propfind>");
 		Set<QName> names = toList(elements(doc, qname("DAV:", "propfind", ""), qname("DAV:", "prop", ""))).stream().map(DomUtil::qname).collect(Collectors.toSet());
 		assertEquals(Collections.singleton(qname("DAV:", "current-user-principal", "")), names);

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberAnalyzer.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberAnalyzer.java
@@ -5,33 +5,36 @@ package de.haumacher.phoneblock.analysis;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Test for {@link NumberAnalyzer}.
  */
-public class TestNumberAnalyzer {
+class TestNumberAnalyzer {
 	
-	@Test
-	public void testFindInfo() {
-		assertCountry("+1684" + "123456789", "Amerikanisch-Samoa");
-		assertCountry("+49", "Deutschland");
-		assertCity("+49" + "7041", "Mühlacker");
-		assertCountry("+49" + "704187650", "Deutschland");
-		assertCity("+49" + "704187650", "Mühlacker");
-		assertCity("+49-7041 87650", "Mühlacker");
-		assertCountry("+1" + "241" + "123456789", "Vereinigte Staaten oder Kanada");
-		assertCountry("+999999999", "Unbekannt");
-		assertCountry("+9", "Unbekannt");
-	}
-
-	private void assertCountry(String phone, String label) {
+	@ParameterizedTest
+	@CsvSource({"+1684" + "123456789,Amerikanisch-Samoa",
+			"+49,Deutschland",
+			"+49" + "704187650,Deutschland",
+			"+1" + "241" + "123456789,Vereinigte Staaten oder Kanada",
+			"+999999999,Unbekannt",
+			"+9,Unbekannt"
+	})
+	void testCountry(String phone, String label) {
 		PhoneNumer info = NumberAnalyzer.analyze(phone);
+		assertNotNull(info);
 		assertEquals(label, info.getCountry());
 	}
 
-	private void assertCity(String phone, String label) {
+	@ParameterizedTest
+	@CsvSource({"+49" + "7041,Mühlacker",
+			"+49" + "704187650,Mühlacker",
+			"+49-7041 87650,Mühlacker"
+	})
+	void testCity(String phone, String label) {
 		PhoneNumer info = NumberAnalyzer.analyze(phone);
+		assertNotNull(info);
 		assertEquals(label, info.getCity());
 	}
 	

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberTree.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberTree.java
@@ -7,20 +7,19 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test of {@link NumberTree}.
  */
-@SuppressWarnings("javadoc")
-public class TestNumberTree {
+class TestNumberTree {
 	
 	@Test
-	public void testLeve1Wildcard() {
+	void testLeve1Wildcard() {
 		NumberTree tree = new NumberTree();
 		tree.insert("0201234567");
 		tree.insert("0305200156399");
@@ -37,11 +36,11 @@ public class TestNumberTree {
 		tree.markWildcards();
 		List<String> entries = tree.createBlockEntries();
 		
-		Assertions.assertEquals(Arrays.asList("0201234567", "030520015632*", "030520015633*", "0305200156399"), entries);
+		assertEquals(List.of("0201234567", "030520015632*", "030520015633*", "0305200156399"), entries);
 	}
 
 	@Test
-	public void testWhitelistBreaksWildcard() {
+	void testWhitelistBreaksWildcard() {
 		NumberTree tree = new NumberTree();
 		tree.insert("0100001");
 		tree.insert("0100002");
@@ -56,11 +55,11 @@ public class TestNumberTree {
 		tree.markWildcards();
 		List<String> entries = tree.createBlockEntries();
 		
-		Assertions.assertEquals(Arrays.asList("0100001", "0100002", "0100003", "0100005", "020000*"), entries);
+		assertEquals(List.of("0100001", "0100002", "0100003", "0100005", "020000*"), entries);
 	}
 	
 	@Test
-	public void testWhitelistBreaksWildcardLevel2() {
+	void testWhitelistBreaksWildcardLevel2() {
 		NumberTree tree = new NumberTree();
 		tree.insert("01000015");
 		tree.insert("01000016");
@@ -76,11 +75,11 @@ public class TestNumberTree {
 		tree.markWildcards();
 		List<String> entries = tree.createBlockEntries();
 		
-		Assertions.assertEquals(Arrays.asList("0100001*", "0100002*", "0100003", "0100005*"), entries);
+		assertEquals(List.of("0100001*", "0100002*", "0100003", "0100005*"), entries);
 	}
 	
 	@Test
-	public void testLeve2Wildcard() {
+	void testLeve2Wildcard() {
 		NumberTree tree = new NumberTree();
 		tree.insert("030123010");
 		tree.insert("030123011");
@@ -94,11 +93,11 @@ public class TestNumberTree {
 		tree.markWildcards();
 		List<String> entries = tree.createBlockEntries();
 		
-		Assertions.assertEquals(Arrays.asList("0301230*"), entries);
+		assertEquals(List.of("0301230*"), entries);
 	}
 	
 	@Test
-	public void testRealData() throws IOException {
+	void testRealData() throws IOException {
 		NumberTree tree = new NumberTree();
 
 		int cnt = 0;
@@ -144,6 +143,10 @@ public class TestNumberTree {
 		System.out.println("Output numbers: " + numbers);
 		System.out.println("Wildcards: " + wildcard);
 		System.out.println("Blocks: " + blocks.size());
+		assertEquals(10049, cnt);
+		assertEquals(266, wildcard);
+		assertEquals(300, numbers);
+		assertEquals(99, blocks.size());
 	}
 	
 }

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Statement;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +29,7 @@ import de.haumacher.phoneblock.scheduler.SchedulerService;
 /**
  * Test case for {@link DB}.
  */
-public class TestDB {
+class TestDB {
 	
 	private DB _db;
 	private SchedulerService _scheduler;
@@ -61,7 +60,7 @@ public class TestDB {
 	}
 
 	@Test
-	public void testTopSearches() {
+	void testTopSearches() {
 		_db.addRating("0", Rating.C_PING, null, 0);
 		_db.addRating("1", Rating.C_PING, null, 0);
 		_db.addRating("2", Rating.C_PING, null, 0);
@@ -97,7 +96,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testSpamReports() {
+	void testSpamReports() {
 		assertFalse(_db.hasSpamReportFor("123"));
 
 		_db.processVotes("123", 2, 1000);
@@ -137,7 +136,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testBlocklist() {
+	void testBlocklist() {
 		try (SqlSession session = _db.openSession()) {
 			BlockList blockList = session.getMapper(BlockList.class);
 			
@@ -147,35 +146,35 @@ public class TestDB {
 			blockList.addExclude(1, "678");
 			blockList.addExclude(2, "999");
 			
-			assertEquals(new HashSet<>(Arrays.asList("123", "345", "678")), blockList.getExcluded(1));
+			assertEquals(new HashSet<>(List.of("123", "345", "678")), blockList.getExcluded(1));
 			
 			blockList.removeExclude(1, "345");
 			
-			assertEquals(new HashSet<>(Arrays.asList("123", "678")), blockList.getExcluded(1));
+			assertEquals(new HashSet<>(List.of("123", "678")), blockList.getExcluded(1));
 			
 			blockList.removeExclude(2, "123");
 			
-			assertEquals(new HashSet<>(Arrays.asList("123", "678")), blockList.getExcluded(1));
+			assertEquals(new HashSet<>(List.of("123", "678")), blockList.getExcluded(1));
 			
 			blockList.addPersonalization(1, "654");
 			blockList.addPersonalization(1, "321");
 			blockList.addPersonalization(2, "321");
 			blockList.addPersonalization(2, "987");
 			
-			assertEquals(Arrays.asList("321", "654"), blockList.getPersonalizations(1));
+			assertEquals(List.of("321", "654"), blockList.getPersonalizations(1));
 			
 			blockList.removePersonalization(1, "654");
 			
-			assertEquals(Arrays.asList("321"), blockList.getPersonalizations(1));
+			assertEquals(List.of("321"), blockList.getPersonalizations(1));
 			
 			blockList.removePersonalization(2, "321");
 			
-			assertEquals(Arrays.asList("321"), blockList.getPersonalizations(1));
+			assertEquals(List.of("321"), blockList.getPersonalizations(1));
 		}
 	}
 
 	@Test
-	public void testDuplicateAdd() {
+	void testDuplicateAdd() {
 		try (SqlSession session = _db.openSession()) {
 			BlockList blockList = session.getMapper(BlockList.class);
 
@@ -190,21 +189,21 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testUserManagement() throws IOException {
+	void testUserManagement() throws IOException {
 		_db.addUser("none", "1", "foo@bar.com", "Mr. X", "123");
 		_db.addUser("none", "2", "baz@bar.com", "Mr. Y", "123");
 		
 		assertEquals("foo@bar.com", _db.basicAuth(header("foo@bar.com", "123")));
-		assertEquals(null, _db.basicAuth(header("foo@bar.com", "321")));
-		assertEquals(null, _db.basicAuth(header("xxx@bar.com", "123")));
+        assertNull(_db.basicAuth(header("foo@bar.com", "321")));
+        assertNull(_db.basicAuth(header("xxx@bar.com", "123")));
 		
 		try (SqlSession session = _db.openSession()) {
 			long userA = session.getMapper(Users.class).getUserId("foo@bar.com");
 			long userB = session.getMapper(Users.class).getUserId("baz@bar.com");
-			
-			assertTrue(userA != 0);
-			assertTrue(userB != 0);
-			assertTrue(userA != userB);
+
+			assertNotEquals(0, userA);
+			assertNotEquals(0, userB);
+			assertNotEquals(userA, userB);
 		}
 	}
 	
@@ -213,7 +212,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testRatings() {
+	void testRatings() {
 		long now = 1;
 		
 		_db.addRating("123", Rating.G_FRAUD, null, now++);
@@ -236,7 +235,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testSearchHistory() {
+	void testSearchHistory() {
 		
 		_db.addSearchHit("123");
 		_db.addSearchHit("123");
@@ -256,13 +255,13 @@ public class TestDB {
 		_db.addSearchHit("456");
 		_db.addSearchHit("789");
 		
-		assertEquals(Arrays.asList(2, 0, 1, 0), _db.getSearchHistory("123"));
-		assertEquals(Arrays.asList(1, 1, 0, 1), _db.getSearchHistory("456"));
-		assertEquals(Arrays.asList(0, 1, 0, 1), _db.getSearchHistory("789"));
+		assertEquals(List.of(2, 0, 1, 0), _db.getSearchHistory("123"));
+		assertEquals(List.of(1, 1, 0, 1), _db.getSearchHistory("456"));
+		assertEquals(List.of(0, 1, 0, 1), _db.getSearchHistory("789"));
 	}
 	
 	@Test
-	public void testSearchHistoryCleanup() {
+	void testSearchHistoryCleanup() {
 		for (int n = 0; n < 100; n++) {
 			_db.addSearchHit("123");
 			_db.cleanupSearchHistory(30);
@@ -273,7 +272,7 @@ public class TestDB {
 	}
 	
 	@Test
-	public void testQuote() {
+	void testQuote() {
 		assertEquals("\"\" 0x0 \"33a0a838-7b11-427a-\" 0x9 \"\" 0xD \"\" 0xA \"\" 0xC \"9c84-59b6ab6d3b0e\" 0x20 \"\"", DB.saveChars("\00033a0a838-7b11-427a-\t\r\n\f9c84-59b6ab6d3b0e "));
 	}
 

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDbService.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDbService.java
@@ -5,10 +5,8 @@ package de.haumacher.phoneblock.db;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
 import java.net.ConnectException;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,10 +17,10 @@ import de.haumacher.phoneblock.scheduler.SchedulerService;
  *
  * @author <a href="mailto:haui@haumacher.de">Bernhard Haumacher</a>
  */
-public class TestDbService {
+class TestDbService {
 
 	@Test
-	public void testStart() throws UnknownHostException, IOException {
+	void testStart() {
 		SchedulerService scheduler = new SchedulerService();
 		DBService service = new DBService(scheduler) {
 			@Override
@@ -41,14 +39,9 @@ public class TestDbService {
 		
 		service.contextDestroyed(null);
 		scheduler.contextDestroyed(null);
-		
-		try {
-			Socket socket = new Socket("localhost", 12345);
-			assertNotNull(socket);
-			fail("Must have been shut down.");
-		} catch (ConnectException ex) {
-			// expected.
-		}
+
+		assertThrows(ConnectException.class, () -> new Socket("localhost", 12345),
+				"Must have been shut down.");
 	}
 	
 }


### PR DESCRIPTION
I modernized the junit5 usage:

- I switched from `junit-jupiter-api`  to `junit-jupiter` to get the all junit5 features.
- In junit5 tests and test-classes no longer need to be public, so I removed the public modifier.
- I made use of `@ParameterizedTestthe` in `TestNumberAnalyzer` this allows a to run a test multiple times with different arguments (see also [https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests)
- I simplified some assertions 
- I added the missing assertions to `testRealData`

As we are both from Germany let me know if you prefer if I write to you in English or German.