### PR TITLE
Prevent NPE if user could not read files from directory

### DIFF
--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -133,8 +133,13 @@ public class AnswerBot extends MultipleUAS {
 				
 				ArrayList<File> files = new ArrayList<>();
 				audioFragments.put(type, files);
-				for (File wav : typeDir.listFiles(f -> f.isFile() && f.getName().endsWith(".wav"))) {
-					files.add(wav);
+				File[] filesInTypeDir = typeDir.listFiles(f -> f.isFile() && f.getName().endsWith(".wav"));
+				if (filesInTypeDir == null) {
+					LOG.warn("could not read audio fragment from {}", typeDir.getAbsolutePath());
+				} else {
+					for (File wav : filesInTypeDir) {
+						files.add(wav);
+					}
 				}
 				int cnt = files.size();
 				if (cnt == 0) {


### PR DESCRIPTION
If the user could not read files from the stateDir the program crashes with a NPE. I added a check to prevent the crash and instead log a warning.