### PR TITLE
Report to api opt in option

### DIFF
--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -24,10 +24,14 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
@@ -35,6 +39,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Function;
 
+import de.haumacher.msgbuf.io.StringW;
+import de.haumacher.msgbuf.json.JsonWriter;
+import de.haumacher.phoneblock.app.api.model.RateRequest;
 import org.mjsip.config.OptionParser;
 import org.mjsip.media.MediaDesc;
 import org.mjsip.media.MediaSpec;
@@ -240,7 +247,7 @@ public class AnswerBot extends MultipleUAS {
 				return rejectHandler();
 			}
 			
-			if (info.getVotes() < _botConfig.getMinVotes()) {
+			if (info.getVotes() < _botConfig.getMinVotes() && !"A_LEGITIMATE".equals(info.getRating())) {
 				// Not considered SPAM.
 				LOG.info("Not spam: " + from + " (" + info.getVotes() + " votes)");
 				return rejectHandler();
@@ -310,6 +317,41 @@ public class AnswerBot extends MultipleUAS {
 	protected void processCallData(String userName, String from, long startTime, long talkDuration) {
 		float seconds = Math.round(talkDuration) / 1000.0f;
 		LOG.info("Completed SPAM call for '" + userName + "' with '" + from + "' started " + new Date(startTime) + " talked for " + seconds + " seconds.");
+		if (_botConfig.getSendRatings()) {
+			try {
+				URL url = new URL("https://phoneblock.net/phoneblock/api/rate?format=json");
+				HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+				connection.addRequestProperty("accept", "application/json");
+				String version = "PhoneBlock-AB/" + VERSION;
+				connection.addRequestProperty("User-Agent", version);
+				String auth = _botConfig.getPhoneblockUsername() + ":" + _botConfig.getPhoneblockPassword();
+				byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes());
+				String authHeader = "Basic " + new String(encodedAuth);
+				connection.setRequestProperty("Authorization", authHeader);
+				connection.setRequestMethod("POST");
+				connection.setDoOutput(true);
+				try (OutputStream out = connection.getOutputStream()) {
+					RateRequest rateRequest = RateRequest.create().setPhone(from)
+							.setRating(seconds > 1 ? "B_MISSED" : "C_PING").setComment(version);
+					StringW stringWriter = new StringW();
+					JsonWriter jsonWriter = new JsonWriter(stringWriter);
+					rateRequest.writeContent(jsonWriter);
+					out.write(stringWriter.toString().getBytes(StandardCharsets.UTF_8));
+				}
+				int responseCode = connection.getResponseCode();
+				if (responseCode != 200 && LOG.isWarnEnabled()) {
+					try (InputStream errorMessage = connection.getErrorStream()) {
+						LOG.warn("Sending spam call to PhoneBlock was not accepted {} ",
+								new String(errorMessage.readAllBytes()));
+					} catch (IOException ex) {
+						LOG.warn("Sending spam call to PhoneBlock was not accepted response code {}", responseCode);
+					}
+
+				}
+			} catch (IOException ex) {
+				LOG.warn("Sending spam call to PhoneBlock failed: {}", ex.getMessage());
+			}
+		}
 	}
 
 	/**

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -247,7 +247,7 @@ public class AnswerBot extends MultipleUAS {
 				return rejectHandler();
 			}
 			
-			if (info.getVotes() < _botConfig.getMinVotes() && !"A_LEGITIMATE".equals(info.getRating())) {
+			if (info.getVotes() < _botConfig.getMinVotes()) {
 				// Not considered SPAM.
 				LOG.info("Not spam: " + from + " (" + info.getVotes() + " votes)");
 				return rejectHandler();

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -347,6 +347,8 @@ public class AnswerBot extends MultipleUAS {
 						LOG.warn("Sending spam call to PhoneBlock was not accepted response code {}", responseCode);
 					}
 
+				} else {
+					LOG.info("Spam call {} send to PhoneBlock", from);
 				}
 			} catch (IOException ex) {
 				LOG.warn("Sending spam call to PhoneBlock failed: {}", ex.getMessage());

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
@@ -56,6 +56,12 @@ public class AnswerbotConfig implements AnswerbotOptions {
 
 	@Option(name = "--min-votes", usage = "The minimum number of PhoneBlock votes for a number to be consideres SPAM.")
 	private int _minVotes = 4;
+
+	private String _username;
+
+	private String _password;
+
+	private boolean _sendRatings = false;
 	
 	@Override
 	public int bufferTime() {
@@ -209,9 +215,16 @@ public class AnswerbotConfig implements AnswerbotOptions {
 			System.err.println("Conversation directory does not exist: " + conversationDir().getAbsolutePath());
 			System.exit(1);
 		}
-		if (_testPrefix != null && _testPrefix.isBlank()) {
-			_testPrefix = null;
+		_testPrefix = getNoneBlank(_testPrefix);
+		_username = getNoneBlank(_username);
+		_password = getNoneBlank(_password);
+		if (_username == null || _password == null) {
+			_sendRatings = false;
 		}
+	}
+
+	private static String getNoneBlank(String s) {
+		return  s == null || s.isBlank() ? null : s;
 	}
 	
 }

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
@@ -54,13 +54,16 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	@Option(name = "--accept-anonymous", handler = YesNoHandler.class, usage = "Whether to let PhoneBlock accept anonymous calls. This is not recommended. Better configure a separate answering machine in you router to handle anonymous calls.")
 	private boolean _acceptAnonymous = false;
 
-	@Option(name = "--min-votes", usage = "The minimum number of PhoneBlock votes for a number to be consideres SPAM.")
+	@Option(name = "--min-votes", handler = GreaterThanZeroIntOptionHandler.class, usage = "The minimum number of PhoneBlock votes for a number to be consideres SPAM.")
 	private int _minVotes = 4;
 
-	private String _username;
+	@Option(name = "--phoneblock-username", usage = "phoneblock username")
+	private String _phoneblockUsername;
 
-	private String _password;
+	@Option(name = "--phoneblock-password", usage = "phoneblock password")
+	private String _phoneblockPassword;
 
+	@Option(name = "--send-rating", handler = YesNoHandler.class, usage = "Enables the report of spam calls to the phoneblock project")
 	private boolean _sendRatings = false;
 	
 	@Override
@@ -216,9 +219,9 @@ public class AnswerbotConfig implements AnswerbotOptions {
 			System.exit(1);
 		}
 		_testPrefix = getNoneBlank(_testPrefix);
-		_username = getNoneBlank(_username);
-		_password = getNoneBlank(_password);
-		if (_username == null || _password == null) {
+		_phoneblockUsername = getNoneBlank(_phoneblockUsername);
+		_phoneblockPassword = getNoneBlank(_phoneblockPassword);
+		if (_phoneblockUsername == null || _phoneblockPassword == null) {
 			_sendRatings = false;
 		}
 	}
@@ -226,5 +229,31 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	private static String getNoneBlank(String s) {
 		return  s == null || s.isBlank() ? null : s;
 	}
-	
+
+	@Override
+	public String getPhoneblockUsername() {
+		return _phoneblockUsername;
+	}
+
+	public void setPhoneblockUsername(String phoneblockUsername) {
+		_phoneblockUsername = phoneblockUsername;
+	}
+
+	@Override
+	public String getPhoneblockPassword() {
+		return _phoneblockPassword;
+	}
+
+	public void setPhoneblockPassword(String phoneblockPassword) {
+		_phoneblockPassword = phoneblockPassword;
+	}
+
+	@Override
+	public boolean getSendRatings() {
+		return _sendRatings;
+	}
+
+	public void setSendRatings(boolean sendRatings) {
+		this._sendRatings = sendRatings;
+	}
 }

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotOptions.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotOptions.java
@@ -54,4 +54,9 @@ public interface AnswerbotOptions extends DialogOptions, StaticOptions {
 	 */
 	String getTestPrefix();
 
+	String getPhoneblockUsername();
+
+	String getPhoneblockPassword();
+
+	boolean getSendRatings();
 }

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/GreaterThanZeroIntOptionHandler.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/GreaterThanZeroIntOptionHandler.java
@@ -1,0 +1,23 @@
+package de.haumacher.phoneblock.answerbot;
+
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.IntOptionHandler;
+import org.kohsuke.args4j.spi.Setter;
+
+public class GreaterThanZeroIntOptionHandler extends IntOptionHandler {
+    public GreaterThanZeroIntOptionHandler(CmdLineParser parser, OptionDef option, Setter<? super Integer> setter) {
+        super(parser, option, setter);
+    }
+
+    @Override
+    protected Integer parse(String argument) throws NumberFormatException {
+        int value =  super.parse(argument);
+        if ( value < 1) {
+            throw new NumberFormatException("value less than one");
+        }
+        return value;
+    }
+
+
+}


### PR DESCRIPTION
I added an opt in option to report spam calls from  a local instance to the phoneblock API.
To prevent wrong reports with bad configs I added a validation for `--min-votes`. Now only numbers with a rating greater than zero are accepted. In addition I also check that no number with rating `A_LEGITIMATE` could be treated as a Spam call.

Let me know what you think.