### PR TITLE
Prevent NPE without recording dir

### DIFF
--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
@@ -203,7 +203,7 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	
 	@Override
 	public Direction getDirection() {
-		return Direction.FULL_DUPLEX;
+		return this.recordingDir() != null ? Direction.FULL_DUPLEX : Direction.SEND_ONLY;
 	}
 
 	/**


### PR DESCRIPTION
Currently the Program throws a NPE when run without a recording dir. The `Direction` must be set to `Direction.SEND_ONLY` to fix this.