### PR TITLE
add X-Content-Type-Options header

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentSecurityPolicyFilter.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentSecurityPolicyFilter.java
@@ -26,6 +26,13 @@ public class ContentSecurityPolicyFilter implements Filter {
 
     private static boolean addWebsiteHeaders(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
+        int webappIndex = request.getContextPath().length();
+        
+		if (requestURI.startsWith("/ab", webappIndex)) {
+        	// The flutter UI is breaks with content security policy enabled.
+        	return false;
+        }
+        
         return  !requestURI.contains("/contacts") &&
                 (!requestURI.contains("/api/") || requestURI.lastIndexOf("/") == requestURI.length() - 1);
     }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentSecurityPolicyFilter.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentSecurityPolicyFilter.java
@@ -1,0 +1,32 @@
+package de.haumacher.phoneblock.app;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebFilter(urlPatterns = "/*", dispatcherTypes = DispatcherType.REQUEST)
+public class ContentSecurityPolicyFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        if (addWebsiteHeaders((HttpServletRequest) request)) {
+            httpResponse.setHeader("Content-Security-Policy", "default-src 'none'; img-src 'self' http://fritz.box/favicon.ico https://fritz.box/favicon.ico data: w3.org/svg/2000; font-src 'self'; style-src 'self'; script-src 'self'; frame-ancestors 'none'; connect-src 'self';");
+        }
+        chain.doFilter(request, response);
+    }
+
+    private static boolean addWebsiteHeaders(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        return  !requestURI.contains("/contacts") &&
+                (!requestURI.contains("/api/") || requestURI.lastIndexOf("/") == requestURI.length() - 1);
+    }
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentTypeOptionFilter.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/ContentTypeOptionFilter.java
@@ -1,0 +1,33 @@
+package de.haumacher.phoneblock.app;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ *  {@link Filter} disable MIME sniffing by setting  X-Content-Type-Options header.
+ */
+@WebFilter(urlPatterns = "/*", dispatcherTypes = DispatcherType.REQUEST)
+public class ContentTypeOptionFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+        if (contentTypeOption((HttpServletRequest) request)) {
+            httpResponse.setHeader("X-Content-Type-Options", "nosniff");
+        }
+        chain.doFilter(request, response);
+    }
+
+    private static boolean contentTypeOption(HttpServletRequest request) {
+        return  !request.getRequestURI().contains("/contacts");
+    }
+}

--- a/phoneblock/src/main/webapp/anrufbeantworter/anrufbeantworter.js
+++ b/phoneblock/src/main/webapp/anrufbeantworter/anrufbeantworter.js
@@ -1,0 +1,40 @@
+function showFB() {
+    if (window.fbWindow != null && !window.fbWindow.closed) {
+        window.fbWindow.focus();
+    } else {
+        window.fbWindow = window.open("http://fritz.box", "fritzbox");
+    }
+    return false;
+}
+function showAB() {
+    if (window.abWindow != null && !window.abWindow.closed) {
+        window.abWindow.focus();
+    } else {
+        window.abWindow = window.open(window.location.host + "/ab/", "phoneblock-ab");
+    }
+    return false;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    let links = document.querySelectorAll('.showAB');
+    links.forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            const result = showAB()
+            if (!result) {
+                event.preventDefault();
+            }
+        });
+    });
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+    let links = document.querySelectorAll('.showFB');
+    links.forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            const result = showFB()
+            if (!result) {
+                event.preventDefault();
+            }
+        });
+    });
+});

--- a/phoneblock/src/main/webapp/anrufbeantworter/anrufbeantworter.js
+++ b/phoneblock/src/main/webapp/anrufbeantworter/anrufbeantworter.js
@@ -10,7 +10,7 @@ function showAB() {
     if (window.abWindow != null && !window.abWindow.closed) {
         window.abWindow.focus();
     } else {
-        window.abWindow = window.open(window.location.host + "/ab/", "phoneblock-ab");
+        window.abWindow = window.open(getContextBasePath() + "/ab/", "phoneblock-ab");
     }
     return false;
 }

--- a/phoneblock/src/main/webapp/anrufbeantworter/index.jsp
+++ b/phoneblock/src/main/webapp/anrufbeantworter/index.jsp
@@ -8,24 +8,6 @@
 %>
 <head>
 <jsp:include page="../head-content.jspf"></jsp:include>
-<script type="text/javascript">
-function showFB() {
-	if (window.fbWindow != null && !window.fbWindow.closed) {
-		window.fbWindow.focus();
-	} else {
-		window.fbWindow = window.open("http://fritz.box", "fritzbox");
-	}
-	return false;
-}
-function showAB() {
-	if (window.abWindow != null && !window.abWindow.closed) {
-		window.abWindow.focus();
-	} else {
-		window.abWindow = window.open("<%=request.getContextPath() %>/ab/", "phoneblock-ab");
-	}
-	return false;
-}
-</script>
 </head>
 
 <body>
@@ -33,7 +15,7 @@ function showAB() {
 
 <section class="section">
 	<div class="content">
-		<div style="float: right; max-width: 15%;">
+		<div class="logo-animation">
 			<img alt="PhoneBlock-Anrufbeantworter-Logo" src="logo/ab-logo.svg">
 		</div>
 	
@@ -113,14 +95,14 @@ function showAB() {
 		<h2 id="create">Schritt 2: Anrufbeantworter erstellen</h2>
 		
 		<p>
-			Wenn Du hier klickst öffnet sich Fenster mit der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">PhoneBlock-Anrufbeantworter-App</a>. 
+			Wenn Du hier klickst öffnet sich Fenster mit der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">PhoneBlock-Anrufbeantworter-App</a>.
 			Beim ersten Öffnen ist die Liste Deiner Anrufbeantworter leer und unten rechts befindet sich ein Knopf, 
 			mit dem Du Dir einen Anrufbeantworter erstellen kannst. Drücke diesen Plus-Knopf.
 		</p>
 		
 		<div class="columns">
 		  <div class="column is-half is-offset-one-quarter">
-			<a class="button is-medium is-primary is-fullwidth" href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">
+			<a class="button is-medium is-primary is-fullwidth showAB" href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab">
 			    <span class="icon">
 					<i class="fa-solid fa-arrow-up-right-from-square"></i>
 			    </span>
@@ -145,7 +127,7 @@ function showAB() {
 		<h3>PhoneBlock-DynDNS aktivieren</h3>
 		
 		<p>
-			Aktiviere in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a> 
+			Aktiviere in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a>
 			den Schalter "PhoneBlock-DynDNS verwenden" (Wenn Du Dich gut auskennst und bereits einen anderen DynDNS-Provider verwendest, kannst Du auch direkt
 			den Host-Namen deiner Fritz!Box eintragen).
 		</p>
@@ -174,19 +156,19 @@ function showAB() {
 		<h3>Anmeldedaten in der Fritz!Box eintragen</h3>
 		
 		<p>
-			Dieser Link <a href="http://fritz.box" target="fritzbox" onclick="return showFB();">öffnet ein Fenster für Deine Fritz!Box</a>. 
+			Dieser Link <a href="http://fritz.box" target="fritzbox" class="showFB">öffnet ein Fenster für Deine Fritz!Box</a>.
 			Melde dich dort mit Deinem Fritz!Box-Kennwort an. Wenn Du das noch nie getan hast, dann findest Du 
 			das Kennwort auf der Unterseite der Fritz!Box. 
 		</p>
 		
 		<p>
-			In Deiner <a href="http://fritz.box" target="fritzbox" onclick="return showFB();">Fritz!Box</a> navigiere in der Seitenleiste zu "Internet &gt; Freigaben" und wähle 
+			In Deiner <a href="http://fritz.box" target="fritzbox" class="showFB">Fritz!Box</a> navigiere in der Seitenleiste zu "Internet &gt; Freigaben" und wähle
 			den Reiter "DynDNS".
 		</p>
 
 		<div class="columns">
 		  <div class="column is-half is-offset-one-quarter">
-			<a class="button is-medium is-primary is-fullwidth" href="http://fritz.box" target="fritzbox" onclick="return showFB();">
+			<a class="button is-medium is-primary is-fullwidth showFB" href="http://fritz.box" target="fritzbox">
 			    <span class="icon">
 					<i class="fa-solid fa-arrow-up-right-from-square"></i>
 			    </span>
@@ -202,8 +184,8 @@ function showAB() {
 		</div>
 		
 		<p>
-			Kopiere aus der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a> die Daten für 
-			"Update-Url", "Domainname", "Benutzername" und "Kennwort" und trage sie in Deiner <a href="http://fritz.box" target="fritzbox" onclick="return showFB();">Fritz!Box</a> 
+			Kopiere aus der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a> die Daten für
+			"Update-Url", "Domainname", "Benutzername" und "Kennwort" und trage sie in Deiner <a href="http://fritz.box" target="fritzbox" class="showFB">Fritz!Box</a>
 			ein. Und bestätige mit "Übernehmen" (Punkt 5 im Bild unten). 
 		</p>
 		
@@ -216,7 +198,7 @@ function showAB() {
 		<h3>DynDNS überprüfen</h3>
 
 		<p>
-			Gehe jetzt zurück zu der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a> und 
+			Gehe jetzt zurück zu der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a> und
 			lass die Einstellungen überprüfen (Punkt 6 im Bild oben).
 			Wenn PhoneBlock Deine Fritz!Box gefunden hat, kommst zu zur nächsten Seite mit den Zugangsdaten für den eigentlichen Anrufbeantworter.
 		</p>
@@ -225,7 +207,7 @@ function showAB() {
 		
 		<p>
 			Jetzt wird der Anrufbeantworter als Telefoniegerät in der Fritz!Box eingerichtet. Öffne hierzu wieder 
-			Deine <a href="http://fritz.box" target="fritzbox" onclick="return showFB();">Fritz!Box-Oberfläche</a>.
+			Deine <a href="http://fritz.box" target="fritzbox" class="showFB">Fritz!Box-Oberfläche</a>.
 		</p>
 
 		<h3>Telefoniegerät einrichten</h3>
@@ -271,7 +253,7 @@ function showAB() {
 
 		<p>
 			Auf der nächsten Seite "Einstellungen im IP-Telefon übernehmen" wirst Du nach "Benutzername" und "Kennwort" gefragt. 
-			Kopiere hier die entsprechenden Daten, die Dir in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a>
+			Kopiere hier die entsprechenden Daten, die Dir in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a>
 			angezeigt werden. Klicke auf "Weiter". 
 		</p>
 		
@@ -359,7 +341,7 @@ function showAB() {
 
 		<p>
 			Im Reiter "Anmeldedaten" musst Du jetzt noch die Option "Anmeldung aus dem Internet erlauben" aktivieren und das Kennwort 
-			erneut aus der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a> kopieren und in das Feld "Kennwort" eintragen. 
+			erneut aus der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a> kopieren und in das Feld "Kennwort" eintragen.
 			Klicke erst dann auf den Knopf "Übernehmen".
 		</p>
 		
@@ -372,7 +354,7 @@ function showAB() {
 		<h2 id="enable">Schritt 5: Anrufbeantworter einschalten</h2>
 		
 		<p>
-			Die Konfiguration Deines Anrufbeantworters ist jetzt abgeschlossen. Wechsele zurück in die <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a>
+			Die Konfiguration Deines Anrufbeantworters ist jetzt abgeschlossen. Wechsele zurück in die <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a>
 			und schalte Deinen neuen Anrufbeantworter ein.
 		</p>
 		
@@ -383,7 +365,7 @@ function showAB() {
 		</div>
 		
 		<p>
-			Gratuliere, wenn alles geklappt hat, sollte der Anrufbeantworter in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" onclick="return showAB();">Anrufbeantworter-App</a> 
+			Gratuliere, wenn alles geklappt hat, sollte der Anrufbeantworter in der <a href="<%=request.getContextPath() %>/ab/" target="phoneblock-ab" class="showAB">Anrufbeantworter-App</a>
 			jetzt grün als "eingeschaltet" angezeigt werden. Die nächsten unliebsamen Anrufer können in Zukunft mit PhoneBlock diskutieren.
 		</p>
 
@@ -411,7 +393,7 @@ function showAB() {
 		
 	</div>
 </section>
-
+<script type="text/javascript" src="anrufbeantworter.js"></script>
 <jsp:include page="../footer.jspf"></jsp:include>
 </body>
 </html>

--- a/phoneblock/src/main/webapp/anrufbeantworter/index.jsp
+++ b/phoneblock/src/main/webapp/anrufbeantworter/index.jsp
@@ -13,6 +13,8 @@
 <body>
 <jsp:include page="../header.jspf"></jsp:include>
 
+<input type="hidden" id="context-path" value="<%=request.getContextPath()%>">
+
 <section class="section">
 	<div class="content">
 		<div class="logo-animation">

--- a/phoneblock/src/main/webapp/api/api.js
+++ b/phoneblock/src/main/webapp/api/api.js
@@ -1,0 +1,7 @@
+window.onload = () => {
+    const contextPath = document.getElementById("context-path").value;
+    window.ui = SwaggerUIBundle({
+        url: contextPath + '/api/phoneblock.json',
+        dom_id: '#swagger-ui',
+    });
+};

--- a/phoneblock/src/main/webapp/api/index.jsp
+++ b/phoneblock/src/main/webapp/api/index.jsp
@@ -14,15 +14,8 @@
 </section>
 
 <script src="<%=request.getContextPath() %><%=UIProperties.SWAGGER_PATH %>/swagger-ui-bundle.js"></script>
-<script>
-  window.onload = () => {
-    window.ui = SwaggerUIBundle({
-      url: '<%=request.getContextPath()%>/api/phoneblock.json',
-      dom_id: '#swagger-ui',
-    });
-  };
-</script>
-
+<script type="text/javascript" src="api.js"></script>
+<input type="hidden" id="context-path" value="<%=request.getContextPath()%>">
 <jsp:include page="../footer.jspf"></jsp:include>
 </body>
 </html>

--- a/phoneblock/src/main/webapp/bulma.js
+++ b/phoneblock/src/main/webapp/bulma.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function () {
+    bulmaCollapsible.attach();
+});

--- a/phoneblock/src/main/webapp/datenschutz.jsp
+++ b/phoneblock/src/main/webapp/datenschutz.jsp
@@ -54,7 +54,7 @@
 				Sollte Deine Telefonnummer irrtümlicherweise auf die Blocklist
 				gelangt sein, kannst Du selbstvertändlich um Löschung ersuchen.
 				Schreib eine E-Mail an 
-				<code>Bernhard Haumacher &lt;<button onclick="return showaddr(this);">...</button>&gt;</code>.
+				<code>Bernhard Haumacher &lt;<button class="showaddr">...</button>&gt;</code>.
 			</p>
 
 			<h2>Anrufbeantworter</h2>

--- a/phoneblock/src/main/webapp/error-service-unavail.html
+++ b/phoneblock/src/main/webapp/error-service-unavail.html
@@ -23,6 +23,7 @@
 
 <link rel="stylesheet" href="https://www.haumacher.de/cdn/webjars/bulma/0.9.4/css/bulma.min.css">
 <link rel="stylesheet" href="https://www.haumacher.de/cdn/webjars/font-awesome/6.1.2/css/all.min.css">
+<link rel="stylesheet" href="phoneblock-style.css">
 
 </head>
 
@@ -81,7 +82,7 @@
 			</div>
 			
 			<a class="navbar-item" title="Zur Facebook-Seite" href="https://www.facebook.com/PhoneBlock" target="_blank">
-				<span class="icon" style="color: #1877F2;">
+				<span class="icon facebook-color">
 			    	<i class="fa-brands fa-lg fa-facebook"></i>
 		        </span>
 		    </a>
@@ -91,11 +92,11 @@
 </nav>
 
 <section class="hero is-primary">
-	<div class="hero-body" style="position: relative;">
+	<div class="hero-body">
 		<p class="title">PhoneBlock</p>
 		<p class="subtitle">Der Spam-Filter für Deinen Telefonanschluss</p>
 		<a href="https://github.com/haumacher/phoneblock" target="_blank">
-			<img alt="Fork me on GitHub" width="149" height="149" style="position: absolute; top: 0px; right: 0px;"
+			<img alt="Fork me on GitHub" width="149" height="149" class="github-image"
 				src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png?resize=149%2C149" />
 		</a>
 	</div>

--- a/phoneblock/src/main/webapp/faq.jsp
+++ b/phoneblock/src/main/webapp/faq.jsp
@@ -248,7 +248,7 @@
 		<p>
 			Wenn Du einen GitHub-Account hast, kannst Du auf der <a target="_blank" href="<%=request.getContextPath()%>/link/issues">PhoneBlock Projekt-Seite</a> 
 			ein Ticket öffnen und den Wunsch beschreiben. Gerne kannst Du den Vorschlag aber auch mit mir per E-Mail 
-			diskutieren: <code>Bernhard Haumacher &lt;<button onclick="return showaddr(this);">...</button>&gt;</code>  
+			diskutieren: <code>Bernhard Haumacher &lt;<button class="showaddr">...</button>&gt;</code>
 		</p>
 		
 		<h2>Wie kann ich PhoneBlock wieder deinstallieren?</h2>
@@ -273,7 +273,7 @@
 			Schreib doch einen Kommentar auf auf der <a target="_blank" href="<%=request.getContextPath()%>/link/facebook">Facebook-Seite von PhoneBlock</a>, 
 			dann können alle die Frage lesen. 
 			Gerne kannst Du mir auch eine persönliche Nachricht per E-Mail zukommen lassen: 
-			<code>Bernhard Haumacher &lt;<button onclick="return showaddr(this);">...</button>&gt;</code>  
+			<code>Bernhard Haumacher &lt;<button class="showaddr">...</button>&gt;</code>
 		</p>
 
 <!-- 

--- a/phoneblock/src/main/webapp/footer.jspf
+++ b/phoneblock/src/main/webapp/footer.jspf
@@ -36,6 +36,4 @@
 	</div>
 </footer>
 
-<script type="text/javascript">
-bulmaCollapsible.attach();
-</script>
+<script type="text/javascript" src="<%= request.getContextPath() %>/bulma.js"></script>

--- a/phoneblock/src/main/webapp/head-content.jspf
+++ b/phoneblock/src/main/webapp/head-content.jspf
@@ -59,85 +59,8 @@
 <link rel="stylesheet" href="<%= request.getContextPath() %><%=UIProperties.FA_PATH %>/css/all.min.css">
 
 <link rel="alternate" type="application/rss+xml" title="PhoneBlock Updates" href="https://rss.app/feeds/2BQDpMNxPek9Yal2.xml" />
-  
-<style type="text/css">
 
-.swagger-ui pre {
-	background-color: inherit;
-}
-
-.navbar-dropdown {
-	background-color:#00d1b2;
-}
-
-.hero.is-primary .navbar-item, .hero.is-primary .navbar-link {
-    color: rgba(255,255,255);
-}
-
-/* Reduce spacing around rating images */
-.content figure {
-	margin-left: 0px;
-	margin-right: 0px;
-}
-
-@media screen and (min-width: 1024px) {
-	.navbar-item.has-dropdown.is-active .navbar-link,
-	.navbar-item.has-dropdown:focus .navbar-link,
-	.navbar-item.has-dropdown:hover .navbar-link {
-		background-color:#00b89c;
-	}
-	
-	.navbar-link.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, a.navbar-item.is-active, a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover {
-	  background-color: #00b89c;
-	}
-	
-	.navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
-		background-color: #00b89c;
-	}
-}
-
-.tag:not(body).is-legitimate,
-.button.is-legitimate {
-	background-color: rgba(72, 199, 142, 1);
-	color: #fff;
-}
-
-.tag:not(body).is-missed,
-.button.is-missed {
-	background-color: rgba(170, 172, 170, 1);
-	color: #fff;
-}
-
-.tag:not(body).is-ping,
-.button.is-ping {
-	background-color: rgba(31, 94, 220, 1);
-	color: #fff;
-}
-
-.tag:not(body).is-poll,
-.button.is-poll {
-	background-color: rgba(157, 31, 220, 1);
-	color: #fff;
-}
-
-.tag:not(body).is-advertising,
-.button.is-advertising {
-	background-color: rgba(255, 224, 138, 1);
-	color: rgba(0,0,0,.7);
-}
-
-.tag:not(body).is-gamble,
-.button.is-gamble {
-	background-color: rgba(241, 122, 70, 1);
-	color: #fff;
-}
-
-.tag:not(body).is-fraud,
-.button.is-fraud {
-	background-color: rgba(241, 70, 104, 1);
-	color: #fff;
-}
-</style>
+<link rel="stylesheet" href="<%= request.getContextPath() %>/phoneblock-style.css">
 
 <script type="text/javascript" src="<%=request.getContextPath() %><%=UIProperties.JQUERY_PATH %>/jquery.min.js"></script>
 <script type="text/javascript" src="<%=request.getContextPath() %>/phoneblock.js?v=4"></script>

--- a/phoneblock/src/main/webapp/header.jspf
+++ b/phoneblock/src/main/webapp/header.jspf
@@ -10,14 +10,14 @@
 
 
 <section class="hero is-small is-primary">
-	<div class="hero-body" style="position: relative;">
+	<div class="hero-body">
 		<p class="title">
-			<img alt="PhoneBlock Logo" src="<%=request.getContextPath()%>/app-logo.svg" style="height: 37px; vertical-align: bottom" height="37">
+			<img alt="PhoneBlock Logo" src="<%=request.getContextPath()%>/app-logo.svg" class="logo-image">
 			PhoneBlock
 		</p>
 		<p class="subtitle">Der Spam-Filter fürs Telefon</p>
 		<a href="<%=request.getContextPath()%>/link/github" target="_blank">
-			<img alt="Fork me on GitHub" width="149" height="149" style="position: absolute; top: 0px; right: 0px;"
+			<img alt="Fork me on GitHub" width="149" height="149" class="github-image"
 				src="<%=request.getContextPath()%>/assets/forkme.png" />
 		</a>
 	</div>
@@ -47,7 +47,7 @@
 			<a class="navbar-item" href="<%=request.getContextPath() %>/">Home</a>
 
 			<div class="navbar-item has-dropdown is-hoverable">
-				<a class="navbar-link" href="#" onclick="return false;">Installation</a>
+				<a class="navbar-link prevent-default" href="#">Installation</a>
 
 				<div class="navbar-dropdown">
 					<a class="navbar-item" href="<%=request.getContextPath() %>/anrufbeantworter/">Anrufbeantworter</a>
@@ -61,7 +61,7 @@
 			<a class="navbar-item" href="<%=request.getContextPath() %>/status.jsp">Status</a>
 
 			<div class="navbar-item has-dropdown is-hoverable">
-				<a class="navbar-link" href="#" onclick="return false;">More</a>
+				<a class="navbar-link prevent-default">More</a>
 
 				<div class="navbar-dropdown">
 					<a class="navbar-item" href="<%=request.getContextPath() %>/support.jsp">An PhoneBlock spenden</a>
@@ -78,7 +78,7 @@
 
 		<div class="navbar-end">
 			<a class="navbar-item" title="Zur Facebook-Seite" href="<%=request.getContextPath()%>/link/facebook" target="_blank">
-				<span class="icon" style="color: #1877F2;">
+				<span class="icon facebook-color">
 			    	<i class="fa-brands fa-lg fa-facebook"></i>
 		        </span>
 		    </a>

--- a/phoneblock/src/main/webapp/index.jsp
+++ b/phoneblock/src/main/webapp/index.jsp
@@ -13,7 +13,7 @@
 
 <section class="section">
 	<div class="content">
-		<div style="float: right; max-width: 15%;">
+		<div class="logo-animation">
 			<img alt="PhoneBlock Logo" src="animation.svg">
 		</div>
 
@@ -108,7 +108,7 @@
 
 		<h2>Was sind die Vorausetzungen?</h2>
 
-		<div style="float: right;">
+		<div class="fritzbox-position">
 			<a href="<%=request.getContextPath()%>/link/fritzbox"> <img id="fritzbox" width="200" alt="AVM Fritz!Box 7590"
 				src="<%=request.getContextPath() %>/fritzbox.png" />
 			</a>
@@ -122,7 +122,8 @@
 		
 		<div class="columns">
 		  <div class="column is-half is-offset-one-quarter">
-			<a id="search-fritzbox" class="button is-medium is-info is-fullwidth" href="#" onclick="return checkFritzBox('<%=request.getContextPath() %>', this);">
+			  <input type="hidden" id="context-path" value="<%=request.getContextPath()%>">
+			<a id="search-fritzbox" class="button is-medium is-info is-fullwidth" href="#">
 				<span class="icon is-small is-left">
 					<i class="fa-solid fa-magnifying-glass"></i>
 				</span>

--- a/phoneblock/src/main/webapp/phone-info.jsp
+++ b/phoneblock/src/main/webapp/phone-info.jsp
@@ -196,9 +196,9 @@
 <% if (relatedNumbers.size() > 1) { %>
 
 	<p>Die Nummer ☎ <%= info.getPhone()%> könnte zum selben Anschluss gehören wie die folgenden Nummern in der Datenbank:</p>
-	<blockquote style="display: flex; flex-wrap: wrap; column-gap: 64px; row-gap: 0px;">
+	<blockquote class="related-numbers">
 <% for (String related : relatedNumbers) { %>
-		<span><a href="<%= request.getContextPath()%>/nums/<%= related%>" onclick="return showNumber('<%= related%>');">☎ <%= related %></a></span>
+		<span><a href="<%= request.getContextPath()%>/nums/<%= related%>" class="showNumber">☎ <%= related %></a></span>
 <% } %>	
 	</blockquote>
 
@@ -217,7 +217,7 @@
 	String votePath = request.getContextPath() + CommentVoteServlet.PATH; 
 	%>
 	<% for (UserComment comment : comments.subList(0, Math.min(10, comments.size()))) { %>
-
+	<input type="hidden" id="votePath" value="<%=votePath%>">
 <div class="box">
   <article class="media">
     <div class="media-left">
@@ -259,13 +259,13 @@
       %>
       <nav class="level is-mobile">
         <div class="level-left">
-          <a class="level-item thumbs-up" aria-label="Guter Hinweis" title="Guter Hinweis!" href="#" onclick="return commentVote('<%=votePath %>', '<%=comment.getId()%>', 1, '<%=upId%>', '<%=downId%>');">
+          <a class="level-item thumbs-up commentVote" aria-label="Guter Hinweis" title="Guter Hinweis!" href="#" data-comment-id="<%=comment.getId()%>" data-vote-up-id="<%=upId%>" data-vote-down-id="<%=downId%>">
             <span class="icon">
               <i class="fa-solid fa-thumbs-up"></i>
             </span>
             &nbsp;<span id="<%=upId%>"><%=up%></span>
           </a>
-          <a class="level-item thumbs-down" aria-label="Unsinn" title="Unsinn!" href="#" onclick="return commentVote('<%=votePath %>', '<%=comment.getId()%>', -1, '<%=upId%>', '<%=downId%>');">
+          <a class="level-item thumbs-down commentVote" aria-label="Unsinn" title="Unsinn!" href="#" data-comment-id="<%=comment.getId()%>" data-vote-up-id="<%=upId%>" data-vote-down-id="<%=downId%>">
             <span class="icon">
               <i class="fa-solid fa-thumbs-down"></i>
             </span>&nbsp;<span id="<%=downId%>"><%=down%></span>
@@ -578,10 +578,10 @@
 	
 	<nav class="pagination is-centered" role="navigation" aria-label="pagination">
 	<% if (prev != null) { %>
-		<a class="pagination-previous" href="<%= request.getContextPath()%>/nums/<%= prev%>" onclick="return showNumber('<%= prev%>');">Vorherige Nummer</a>
+		<a class="pagination-previous showNumber" href="<%= request.getContextPath()%>/nums/<%= prev%>">Vorherige Nummer</a>
 	<% } %>
 	<% if (next != null) { %>
-		<a class="pagination-next" href="<%= request.getContextPath()%>/nums/<%= next%>" onclick="return showNumber('<%= next%>');">Nächste Nummer</a>
+		<a class="pagination-next showNumber" href="<%= request.getContextPath()%>/nums/<%= next%>">Nächste Nummer</a>
 	<% } %>
 	</nav>
 </div>

--- a/phoneblock/src/main/webapp/phoneblock-style.css
+++ b/phoneblock/src/main/webapp/phoneblock-style.css
@@ -1,0 +1,110 @@
+.swagger-ui pre {
+    background-color: inherit;
+}
+
+.navbar-dropdown {
+    background-color:#00d1b2;
+}
+
+.hero.is-primary .navbar-item, .hero.is-primary .navbar-link {
+    color: rgba(255,255,255);
+}
+
+/* Reduce spacing around rating images */
+.content figure {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+@media screen and (min-width: 1024px) {
+    .navbar-item.has-dropdown.is-active .navbar-link,
+    .navbar-item.has-dropdown:focus .navbar-link,
+    .navbar-item.has-dropdown:hover .navbar-link {
+        background-color:#00b89c;
+    }
+
+    .navbar-link.is-active, .navbar-link:focus, .navbar-link:focus-within, .navbar-link:hover, a.navbar-item.is-active, a.navbar-item:focus, a.navbar-item:focus-within, a.navbar-item:hover {
+        background-color: #00b89c;
+    }
+
+    .navbar-dropdown a.navbar-item:focus, .navbar-dropdown a.navbar-item:hover {
+        background-color: #00b89c;
+    }
+}
+
+.tag:not(body).is-legitimate,
+.button.is-legitimate {
+    background-color: rgba(72, 199, 142, 1);
+    color: #fff;
+}
+
+.tag:not(body).is-missed,
+.button.is-missed {
+    background-color: rgba(170, 172, 170, 1);
+    color: #fff;
+}
+
+.tag:not(body).is-ping,
+.button.is-ping {
+    background-color: rgba(31, 94, 220, 1);
+    color: #fff;
+}
+
+.tag:not(body).is-poll,
+.button.is-poll {
+    background-color: rgba(157, 31, 220, 1);
+    color: #fff;
+}
+
+.tag:not(body).is-advertising,
+.button.is-advertising {
+    background-color: rgba(255, 224, 138, 1);
+    color: rgba(0,0,0,.7);
+}
+
+.tag:not(body).is-gamble,
+.button.is-gamble {
+    background-color: rgba(241, 122, 70, 1);
+    color: #fff;
+}
+
+.tag:not(body).is-fraud,
+.button.is-fraud {
+    background-color: rgba(241, 70, 104, 1);
+    color: #fff;
+}
+
+.logo-image {
+    height: 37px;
+    vertical-align: bottom;
+}
+
+.github-image {
+    position: absolute;
+    top: 0;
+    right: 0;
+}
+
+.hero-body {
+    position: relative;
+}
+
+.logo-animation {
+    float: right;
+    max-width: 15%;
+}
+
+.facebook-color {
+    color: #1877F2;
+}
+
+.fritzbox-position {
+    float: right;
+}
+
+.related-numbers {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 64px;
+    row-gap: 0;
+}

--- a/phoneblock/src/main/webapp/phoneblock.js
+++ b/phoneblock/src/main/webapp/phoneblock.js
@@ -51,6 +51,20 @@ function searchNumber(inputId) {
 	return false;
 }
 
+document.addEventListener('DOMContentLoaded', function () {
+	let links = document.querySelectorAll('.showNumber');
+	links.forEach(function (link) {
+		link.addEventListener('click', function (event) {
+			const href = link.href;
+			const inputId = href.substring(href.lastIndexOf("/") + 1)
+			const result = searchNumber(inputId)
+			if (!result) {
+				event.preventDefault();
+			}
+		});
+	});
+});
+
 function showNumber(number) {
 	displayNumber(number, true);
 	return false;
@@ -75,6 +89,18 @@ function showaddr(target) {
   target.parentNode.replaceChild(link, target);
   return false;
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+	let links = document.querySelectorAll('.showaddr');
+	links.forEach(function (link) {
+		link.addEventListener('click', function (event) {
+			const result = showaddr(event.target)
+			if (!result) {
+				event.preventDefault();
+			}
+		});
+	});
+});
 
 function checkFritzBox(contextPath, button) {
 	if (!button.classList.contains("is-info")) {
@@ -107,11 +133,63 @@ function checkFritzBox(contextPath, button) {
 	return false;
 }
 
+function getContextBasePath() {
+	return  document.getElementById("context-path").value;
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+	let link = document.getElementById('search-fritzbox');
+	if (link) {
+		link.addEventListener('click', function (event) {
+			const result = checkFritzBox(getContextBasePath(), this);
+			if (!result) {
+				event.preventDefault();
+			}
+		});
+	}
+});
+
 function copyToClipboard(id) {
 	var element = document.getElementById(id);
 	window.navigator.clipboard.writeText(element.textContent); 
 	return false;
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+	let links = document.querySelectorAll('.copyToClipboard');
+	links.forEach(function (link) {
+		link.addEventListener('click', function (event) {
+			const idSource = link.id;
+			const id = idSource.substring(0, idSource.indexOf("_"))
+			const result = copyToClipboard(id)
+			if (!result) {
+				event.preventDefault();
+			}
+		});
+	});
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+	const voteLinks = document.querySelectorAll('.commentVote');
+
+	voteLinks.forEach(function (link) {
+		link.addEventListener('click', function (event) {
+			const votePath = document.getElementById("votePath");
+			if(!votePath?.value) {
+				throw new Error("no vote path");
+			}
+			const commentId = link.getAttribute('data-comment-id');
+			const upId = link.getAttribute('data-vote-up-id');
+			const downId = link.getAttribute('data-vote-down-id');
+			if (link.classList.contains("thumbs-up")) {
+				commentVote(votePath, commentId, 1, upId, downId);
+			} else if (link.classList.contains("thumbs-down")) {
+				commentVote(votePath, commentId, -1, upId, downId);
+			}
+			event.preventDefault();
+		});
+	});
+});
 
 function commentVote(path, commentId, vote, upId, downId) {
 	var up = document.getElementById(upId);	
@@ -154,3 +232,12 @@ function doVote(up, down, direction, inc) {
 	var value = parseInt(element.textContent) + inc;
 	element.textContent = "" + value;
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+	let links = document.querySelectorAll('.prevent-default');
+	links.forEach(function (link) {
+		link.addEventListener('click', function (event) {
+			event.preventDefault();
+		});
+	});
+});

--- a/phoneblock/src/main/webapp/setup-android/07-people-sync-add.jsp
+++ b/phoneblock/src/main/webapp/setup-android/07-people-sync-add.jsp
@@ -26,15 +26,15 @@
 		
 		<ol>
 		<li>
-			Wähle die Option "Mit URL und Benutzername anmelden" und gib als "Basis-URL" die Adresse des PhoneBlock-Adressbuchs an: <code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('url');"><i class="fa-solid fa-copy"></i></a>. 
+			Wähle die Option "Mit URL und Benutzername anmelden" und gib als "Basis-URL" die Adresse des PhoneBlock-Adressbuchs an: <code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a id="url_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>.
 		</li>
 			
 		<li>
-			Bei "Benutzername" trägst Du den Benutzernamen ein, den Du bei der <a href="<%=request.getContextPath() %>/signup.jsp">PhoneBlock-Anmeldung</a> erhalten hast<%if (login != null) {%> (<code id="login"><%= login %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('login');"><i class="fa-solid fa-copy"></i></a>)<%}%>. 
+			Bei "Benutzername" trägst Du den Benutzernamen ein, den Du bei der <a href="<%=request.getContextPath() %>/signup.jsp">PhoneBlock-Anmeldung</a> erhalten hast<%if (login != null) {%> (<code id="login"><%= login %></code> <a id="login_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>)<%}%>.
 		</li>
 			
 		<li>
-			Das Passwort wurde dir nach erfolgreicher Registrierung angezeigt<% if (token != null) {%> (<code id="passwd"><%= token %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('passwd');"><i class="fa-solid fa-copy"></i></a>)<%}%>. 
+			Das Passwort wurde dir nach erfolgreicher Registrierung angezeigt<% if (token != null) {%> (<code id="passwd"><%= token %></code> <a id="passwd_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>)<%}%>.
 		</li>
 		</ol>
 		

--- a/phoneblock/src/main/webapp/setup-iphone/index.jsp
+++ b/phoneblock/src/main/webapp/setup-iphone/index.jsp
@@ -42,12 +42,12 @@
    		<li>Gib deine Zugangsdaten ein und tippe auf "Weiter".
    			<dl>
 				<dt><b>Server</b></dt>
-				<dd><code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('url');"><i class="fa-solid fa-copy"></i></a></dd>
+				<dd><code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a id="url_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></dd>
 
 				<dt><b>Benutzername</b></dt>
 				<dd>
 				<%if (login != null) {%>					
-				<code id="login"><%= login %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('login');"><i class="fa-solid fa-copy"></i></a>
+				<code id="login"><%= login %></code> <a id="login_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>
 				<%} else {%>	
 				Wurde Dir direkt nach der Anmeldung angezeigt.
 				<%}%>
@@ -56,7 +56,7 @@
 				<dt><b>Passwort</b></dt>
 				<dd>
 				<% if (token != null) {%>
-				<code id="passwd"><%= token %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('passwd');"><i class="fa-solid fa-copy"></i></a>
+				<code id="passwd"><%= token %></code> <a id="passwd_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>
 				<%} else {%>
 				Wurde Dir direkt nach der Anmeldung angezeigt.
 				<%}%>

--- a/phoneblock/src/main/webapp/setup.jsp
+++ b/phoneblock/src/main/webapp/setup.jsp
@@ -65,17 +65,17 @@
 		
 				<div class="field">
 				  <label class="label">Internetadresse des CardDAV-Servers</label>
-				  <div class="control"><code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('url');"><i class="fa-solid fa-copy"></i></a></div>
+				  <div class="control"><code id="url">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a id="url_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></div>
 				</div>
 				
 				<div class="field">
 				  <label class="label">Benutzername</label>
-				  <div class="control"><code id="login"><%= JspUtil.quote(login) %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('login');"><i class="fa-solid fa-copy"></i></a></div>
+				  <div class="control"><code id="login"><%= JspUtil.quote(login) %></code> <a id="login_" title="In die Zwischenablage kopieren." class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></div>
 				</div>
 				
 				<div class="field">
 				  <label class="label">Passwort</label>
-				  <div class="control"><code id="passwd"><%= JspUtil.quote(token) %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('passwd');"><i class="fa-solid fa-copy"></i></a></div>
+				  <div class="control"><code id="passwd"><%= JspUtil.quote(token) %></code> <a title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></div>
 				</div>
 			</div>
 		</article>
@@ -145,12 +145,12 @@
 		
 		<div class="columns">
 		  <div class="column is-8 is-offset-2">
-			<code id="url2">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('url2');"><i class="fa-solid fa-copy"></i></a>
+			<code id="url2">https://phoneblock.net<%=request.getContextPath() %>/contacts/</code> <a id="url2_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>
 		  </div>
 		</div>
 		
 		<p>
-			Trage den Benutzernamen <%if (login != null) {%> <code id="login2"><%= JspUtil.quote(login) %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('login2');"><i class="fa-solid fa-copy"></i></a><%} %>, den Du bei der  
+			Trage den Benutzernamen <%if (login != null) {%> <code id="login2"><%= JspUtil.quote(login) %></code> <a id="login2" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a><%} %>, den Du bei der
 			<a href="<%=request.getContextPath() %>/signup.jsp">Registrierung</a> erhalten hast, in das Feld 
 			<i>Benutzername</i> ein. Am besten überträgst Du ihn mit Cut&amp;Paste.
 		</p>
@@ -158,7 +158,7 @@
 		<p>
 			Das Passwort<%if (token == null) {%>, 
 			das Du bei der <a href="<%=request.getContextPath() %>/signup.jsp">Registrierung</a> erhalten 
-			hast, <%} else  {%> <code id="passwd2"><%= JspUtil.quote(token) %></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('passwd2');"><i class="fa-solid fa-copy"></i></a>,<%}%> muss Du jetzt noch in das Feld 
+			hast, <%} else  {%> <code id="passwd2"><%= JspUtil.quote(token) %></code> <a id="passwd2_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a>,<%}%> muss Du jetzt noch in das Feld
 			<i>Passwort</i> in dem Formular in der Fritz!Box eintragen.
 		</p>
 		

--- a/phoneblock/src/main/webapp/setup.jsp
+++ b/phoneblock/src/main/webapp/setup.jsp
@@ -75,7 +75,7 @@
 				
 				<div class="field">
 				  <label class="label">Passwort</label>
-				  <div class="control"><code id="passwd"><%= JspUtil.quote(token) %></code> <a title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></div>
+				  <div class="control"><code id="passwd"><%= JspUtil.quote(token) %></code> <a id="passwd_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></div>
 				</div>
 			</div>
 		</article>
@@ -150,7 +150,7 @@
 		</div>
 		
 		<p>
-			Trage den Benutzernamen <%if (login != null) {%> <code id="login2"><%= JspUtil.quote(login) %></code> <a id="login2" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a><%} %>, den Du bei der
+			Trage den Benutzernamen <%if (login != null) {%> <code id="login2"><%= JspUtil.quote(login) %></code> <a id="login2_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a><%} %>, den Du bei der
 			<a href="<%=request.getContextPath() %>/signup.jsp">Registrierung</a> erhalten hast, in das Feld 
 			<i>Benutzername</i> ein. Am besten überträgst Du ihn mit Cut&amp;Paste.
 		</p>

--- a/phoneblock/src/main/webapp/status.jsp
+++ b/phoneblock/src/main/webapp/status.jsp
@@ -109,7 +109,7 @@ request.setAttribute("title", "Telefonnummern aktueller Werbeanrufer - PhoneBloc
 %>
 					<tr>
 						<td>
-							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" onclick="return showNumber('<%= report.getPhone()%>');">☎ <%= JspUtil.quote(report.getPhone()) %></a>
+							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" class="showNumber">☎ <%= JspUtil.quote(report.getPhone()) %></a>
 						</td>
 						
 						<td>
@@ -154,7 +154,7 @@ request.setAttribute("title", "Telefonnummern aktueller Werbeanrufer - PhoneBloc
 %>
 					<tr>
 						<td>
-							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" onclick="return showNumber('<%= report.getPhone()%>');">☎ <%= JspUtil.quote(report.getPhone()) %></a>
+							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" class="showNumber">☎ <%= JspUtil.quote(report.getPhone()) %></a>
 						</td>
 						
 						<td>
@@ -199,7 +199,7 @@ request.setAttribute("title", "Telefonnummern aktueller Werbeanrufer - PhoneBloc
 %>
 					<tr>
 						<td>
-							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" onclick="return showNumber('<%= report.getPhone()%>');">☎ <%= JspUtil.quote(report.getPhone()) %></a>
+							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" class="showNumber">☎ <%= JspUtil.quote(report.getPhone()) %></a>
 						</td>
 						
 						<td>
@@ -244,7 +244,7 @@ request.setAttribute("title", "Telefonnummern aktueller Werbeanrufer - PhoneBloc
 %>
 					<tr>
 						<td>
-							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" onclick="return showNumber('<%= report.getPhone()%>');">☎ <%= JspUtil.quote(report.getPhone()) %></a>
+							<a href="<%= request.getContextPath()%>/nums/<%= report.getPhone()%>" class="showNumber">☎ <%= JspUtil.quote(report.getPhone()) %></a>
 						</td>
 						
 						<td>

--- a/phoneblock/src/main/webapp/support-banktransfer.jsp
+++ b/phoneblock/src/main/webapp/support-banktransfer.jsp
@@ -28,10 +28,10 @@
 		</p>
 
 		<ul>
-			<li>Empfänger: <code id="receiver">${bank.receiver}</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('receiver');"><i class="fa-solid fa-copy"></i></a></li>
-			<li>Kontonummer: <code id="account">${bank.account}</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('account');"><i class="fa-solid fa-copy"></i></a></li>
-			<li>BIC: <code id="bic">${bank.bic}</code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('bic');"><i class="fa-solid fa-copy"></i></a></li>
-			<li>Verwendungszweck: <code id="purpose">PhoneBlock-<%= LoginFilter.getAuthenticatedUser(request.getSession())%></code> <a title="In die Zwischenablage kopieren." href="#" onclick="return copyToClipboard('purpose');"><i class="fa-solid fa-copy"></i></a></li>
+			<li>Empfänger: <code id="receiver">${bank.receiver}</code> <a id="receiver_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></li>
+			<li>Kontonummer: <code id="account">${bank.account}</code> <a id="account_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></li>
+			<li>BIC: <code id="bic">${bank.bic}</code> <a id="bic_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></li>
+			<li>Verwendungszweck: <code id="purpose">PhoneBlock-<%= LoginFilter.getAuthenticatedUser(request.getSession())%></code> <a id="purpose_" title="In die Zwischenablage kopieren." href="#" class="copyToClipboard"><i class="fa-solid fa-copy"></i></a></li>
 		</ul>
 		
 		<p>


### PR DESCRIPTION
I added the `X-Content-Type-Options` header to stops a browser from trying to MIME-sniff the content type and forces it to stick with the declared content-type.

I am not sure how a FritzBox react to this header, so I excluded URIs containing `/contacts`.

If you agree, we could also add some more HTTP Security headers, as described in [https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html)   