### PR TITLE
improve Dockerfile

### DIFF
--- a/phoneblock-ab/Docker-Multi-Plattform.md
+++ b/phoneblock-ab/Docker-Multi-Plattform.md
@@ -3,9 +3,9 @@ Docker unterstützt das Bereitstellen von Multi-Plattform Images.
 Die Dokumentation hierfür ist unter https://docs.docker.com/build/building/multi-platform/ zu finden.
 
 ## Setup
-Zunächst muss auf dem PC `docker` und `docker-buildx` installiert sein. Nach der installation von `docker-buildx` muss Docker neu gestartet werden.
+Zunächst muss auf dem PC `docker`, `docker-buildx` und `binfmt-support `installiert sein. Nach der installation von `docker-buildx` muss Docker neu gestartet werden.
 ### Ubuntu
-`sudo apt install docker-buildx`
+`sudo apt install docker binfmt-support docker-buildx`
 
 ## Einrichten QEMU
 QEMU wird benötigt um die verschiedenen CPU-Architekturen zu emulieren.

--- a/phoneblock-ab/Docker-Multi-Plattform.md
+++ b/phoneblock-ab/Docker-Multi-Plattform.md
@@ -3,12 +3,13 @@ Docker unterstützt das Bereitstellen von Multi-Plattform Images.
 Die Dokumentation hierfür ist unter https://docs.docker.com/build/building/multi-platform/ zu finden.
 
 ## Setup
-Zunächst muss auf dem PC `docker`, `docker-buildx` und `binfmt-support `installiert sein. Nach der installation von `docker-buildx` muss Docker neu gestartet werden.
+Zunächst muss auf dem PC `docker`, `docker-buildx` und `binfmt-support `installiert sein. Nach der Installation von `docker-buildx` muss Docker neu gestartet werden.
+
 ### Ubuntu
 `sudo apt install docker binfmt-support docker-buildx`
 
 ## Einrichten QEMU
-QEMU wird benötigt um die verschiedenen CPU-Architekturen zu emulieren.
+QEMU wird benötigt, um die verschiedenen CPU-Architekturen zu emulieren.
 Zum Installieren wird folgender Befehl ausgeführt:
 
 `docker run --privileged --rm tonistiigi/binfmt --install all`
@@ -16,21 +17,20 @@ Zum Installieren wird folgender Befehl ausgeführt:
 ## Einrichten des Builders
 Um mit `buildx` plattformunabhängig zu bauen, muss ein eigener Builder erzeugt werden.
 
-`docker buildx create --name my_builder --driver docker-container`
+`docker buildx create --name build_multi --driver docker-container`
 
-## Bauen von Multi-Plattform Images
-ZU beachten ist, dass die verwendeten Images ebenfalls die für die Plattformen gebaut sein müssen. `eclipse-temurin' unterstützt mehrere Plattformen:
-- windows/amd64
-- windows/amd64
-- linux/amd64
-- linux/arm/v7
-- linux/arm64/v8
-- linux/ppc64le
-- linux/riscv64
-- linux/s390x
+## Bauen von multi-plattform Images
+Zu beachten ist, dass auch die verwendeten Images für alle Ziel-Plattformen gebaut sein müssen. `eclipse-temurin' unterstützt mehrere Plattformen:
+- `windows/amd64`
+- `linux/amd64`
+- `linux/arm/v7`
+- `linux/arm64/v8`
+- `linux/ppc64le`
+- `linux/riscv64`
+- `linux/s390x`
 
-Um jetzt für mehrere Plattformen zu Bauen muss `buildx` mit dem zuvor definierten Builder ausgeführt werden. Die plattformen werden kommasepariert angegeben. Mit `-t ` werden die Tags definiert.
+Um jetzt für mehrere Plattformen zu Bauen muss `buildx` mit dem zuvor definierten Builder ausgeführt werden. Die Plattformen werden kommasepariert angegeben. Mit `-t ` werden die Tags definiert.
 
-`docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64/v8 --builder my_builder -t pb_test .`
+`docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64/v8 --builder build_multi -t pb_test .`
 
-Hiernach sollten images für linux/amd64, linux/arm/v7 und linux/arm64/v8 gebaut worden sein. Wird zusätzlich nach `--push` hinzugefügt, so werden die Images direkt auf Dockerhub veröffentlicht.
+Hiernach sollten Images für `linux/amd64`, `linux/arm/v7` und `linux/arm64/v8` gebaut worden sein. Wird zusätzlich noch `--push` hinzugefügt, so werden die Images direkt auf Dockerhub veröffentlicht.

--- a/phoneblock-ab/Docker-Multi-Plattform.md
+++ b/phoneblock-ab/Docker-Multi-Plattform.md
@@ -1,0 +1,36 @@
+# Bereitstellen von Multi-Plattform Images
+Docker unterstützt das Bereitstellen von Multi-Plattform Images.
+Die Dokumentation hierfür ist unter https://docs.docker.com/build/building/multi-platform/ zu finden.
+
+## Setup
+Zunächst muss auf dem PC `docker` und `docker-buildx` installiert sein. Nach der installation von `docker-buildx` muss Docker neu gestartet werden.
+### Ubuntu
+`sudo apt install docker-buildx`
+
+## Einrichten QEMU
+QEMU wird benötigt um die verschiedenen CPU-Architekturen zu emulieren.
+Zum Installieren wird folgender Befehl ausgeführt:
+
+`docker run --privileged --rm tonistiigi/binfmt --install all`
+
+## Einrichten des Builders
+Um mit `buildx` plattformunabhängig zu bauen, muss ein eigener Builder erzeugt werden.
+
+`docker buildx create --name my_builder --driver docker-container`
+
+## Bauen von Multi-Plattform Images
+ZU beachten ist, dass die verwendeten Images ebenfalls die für die Plattformen gebaut sein müssen. `eclipse-temurin' unterstützt mehrere Plattformen:
+- windows/amd64
+- windows/amd64
+- linux/amd64
+- linux/arm/v7
+- linux/arm64/v8
+- linux/ppc64le
+- linux/riscv64
+- linux/s390x
+
+Um jetzt für mehrere Plattformen zu Bauen muss `buildx` mit dem zuvor definierten Builder ausgeführt werden. Die plattformen werden kommasepariert angegeben. Mit `-t ` werden die Tags definiert.
+
+`docker buildx build --platform linux/amd64,linux/arm/v7,linux/arm64/v8 --builder my_builder -t pb_test .`
+
+Hiernach sollten images für linux/amd64, linux/arm/v7 und linux/arm64/v8 gebaut worden sein. Wird zusätzlich nach `--push` hinzugefügt, so werden die Images direkt auf Dockerhub veröffentlicht.

--- a/phoneblock-ab/Dockerfile
+++ b/phoneblock-ab/Dockerfile
@@ -1,22 +1,16 @@
 FROM eclipse-temurin:17
-MAINTAINER play@haumacher.de
+LABEL org.opencontainers.image.authors=play@haumacher.de
 USER root
-RUN mkdir /opt/phoneblock
-RUN mkdir /opt/phoneblock/bin
-RUN mkdir /opt/phoneblock/conversation
-RUN mkdir /opt/phoneblock/recordings
-COPY .phoneblock.docker /opt/phoneblock/.phoneblock
-COPY target/phoneblock-ab-1.5.0-SNAPSHOT-jar-with-dependencies.jar /opt/phoneblock/bin/phoneblock-ab.jar
-CMD ["java", "-jar", "/opt/phoneblock/bin/phoneblock-ab.jar", "-f", "/opt/phoneblock/.phoneblock"]
+RUN adduser --system  --uid 999 --group --home /opt/phoneblock phoneblock
+
+USER phoneblock
+RUN mkdir  /opt/phoneblock/bin /opt/phoneblock/conversation /opt/phoneblock/recordings
+COPY --chown=phoneblock:phoneblock .phoneblock.docker /opt/phoneblock/.phoneblock
+COPY --chown=phoneblock:phoneblock target/phoneblock-ab-1.5.0-SNAPSHOT-jar-with-dependencies.jar /opt/phoneblock/bin/phoneblock-ab.jar
+
+WORKDIR /opt/phoneblock/
+ENTRYPOINT ["java", "-jar", "/opt/phoneblock/bin/phoneblock-ab.jar"]
+CMD ["-f", "/opt/phoneblock/.phoneblock"]
 EXPOSE 50060/tcp
 EXPOSE 50060/udp
-EXPOSE 50100/udp
-EXPOSE 50101/udp
-EXPOSE 50102/udp
-EXPOSE 50103/udp
-EXPOSE 50104/udp
-EXPOSE 50105/udp
-EXPOSE 50106/udp
-EXPOSE 50107/udp
-EXPOSE 50108/udp
-EXPOSE 50109/udp
+EXPOSE 50100-50109/udp


### PR DESCRIPTION
Ich habe die neue Dockerfile verbessert. Jeder `RUN` Befehl erzeugt ein neues Layer. Daher habe ich die `mkdir` in einen Befehl zusammengeführt. Außerdem habe ich einen neuen System-Benutzer `phoneblock` mit der uid 999 erstellt. Hierdurch wird der Answerbot nicht mehr als Root ausgeführt. Die kopierten Files gehören jetzt dem neuen User.

Die `CMD` ist jetzt in `ENTRYPOINT` und  `CMD`  unterteilt. `ENTRYPOINT` wird immer als Startbefehl genutzt und `CMD` kann beim Ausführen des Containers überschrieben werden. Hierdurch ist es möglich eine andere Config-File zu werdenden und andere Parameter zu übergeben. Die Reihenfolge, in der die Befehle aneinander gesetzt werden ist  `ENTRYPOINT`  +  `CMD`.

`MAINTAINER` ist deprecated. Stattdessen soll  `LABEL org.opencontainers.image.authors` verwendet werden.

Für das Exponieren der Ports habe ich auf die Kurzschreibweise für Port-Ranges gewechselt.


Aktuell wird ja in Dockerhub nur der Tag `latest` verwendet. Da dieser recht inconsistent auf Dockerhub verwendet wird, sollte neben dem Tag auch ein Tag um die letzte stabile Version zu kennzeichnen verwendet werden, zum Beispiel `stable`. Außerdem sollte jedes Release noch ein eindeutiges Tag mit der Versionsnummer bekommen, ansonsten ist die einzige Möglichkeit eine fixe Version des Images zu bekommen, das Nutzen des Hashes.