### PR TITLE
fix compose.yaml

### DIFF
--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -13,13 +13,12 @@ services:
       - REALM=fritz.box
       - SIP_USER=phoneblock
       - SIP_PASSWD=your-password
-      - HOST_PORT=50060
       - PHONEBLOCK_USERNAME=<fill-out-here>
       - PHONEBLOCK_PASSWORD=<fill-out-here>
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
-      - MIN_SILENCE_TIME = 1500
-      - PADDING_TIME = 500
-      - SILENCE_DB = -35
+      - MIN_SILENCE_TIME=1500
+      - PADDING_TIME=500
+      - SILENCE_DB=-35
       - MEDIA_PORT=50100
       - PORT_COUNT=10
       - RECODINGS=none


### PR DESCRIPTION
Wie in #97 beschrieben führen die Leerzeichen dazu, dass die CMD und Environment-Variablen nicht mehr gelesen werden.

Leider ist mjsp hier aktuell nicht besonders aussagekräftig und fällt bei Fehlern auf die Default Config zurück ohne einen Hinweis zu geben, dass etwas nicht gelesen werden konnte.