### PR TITLE
fix Answerbot not listening and typo

### DIFF
--- a/phoneblock-ab/.phoneblock.docker
+++ b/phoneblock-ab/.phoneblock.docker
@@ -8,5 +8,5 @@ padding-time = 500
 silence-db = -35
 media_port=50100
 port-count=10
-recodings=none
+recordings=none
 conversation=/opt/phoneblock/conversation

--- a/phoneblock-ab/.phoneblock.template
+++ b/phoneblock-ab/.phoneblock.template
@@ -73,7 +73,7 @@ port-count=10
 
 # The directory where to store recordings. If no directory is specified, no audio
 # is recorded.
-recodings=none
+recordings=none
 
 # The directory where the anwerbot expects audio files for playback. In this directory,
 # the following subdirectories are expected with audio files (*.wav) in the encoding 

--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -22,7 +22,7 @@ services:
       - SILENCE_DB = -35
       - MEDIA_PORT=50100
       - PORT_COUNT=10
-      - RECODINGS=none
+      - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
     volumes:
       - ./conversation:/opt/phoneblock/conversation

--- a/phoneblock-ab/configs/phoneblock-answerbot.template
+++ b/phoneblock-ab/configs/phoneblock-answerbot.template
@@ -42,7 +42,7 @@ viaAddr4=
 via-addr-v6=
 
 # Directory where to store recordings to, 'none' to disable recording.
-recodings = .
+recordings = .
 
 # The directory where the WAV files for the bot conversation are located.
 conversation=./conversation

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
@@ -25,7 +25,7 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	@Option(name = "--conversation", usage = "Directory with WAV files used for streaming during automatic conversation.")
 	private File _conversationDir = new File("./conversation");
 	
-	@Option(name = "--recodings", usage = "Directory where to store recordings to, 'none' to disable recording.")
+	@Option(name = "--recordings", aliases = "--recodings", usage = "Directory where to store recordings to, 'none' to disable recording.")
 	private String _recordingDir = "none";
 	
 	@Option(name = "--test-prefix", usage = "Phone number prefix that triggers the answer bot to respond (for testing). " + 
@@ -196,7 +196,7 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	
 	@Override
 	public Direction getDirection() {
-		return recordingDir() != null ? Direction.FULL_DUPLEX : Direction.SEND_ONLY;
+		return Direction.FULL_DUPLEX;
 	}
 
 	/**


### PR DESCRIPTION
In #97 ist aufgefallen, dass anstelle von `recordings` `recodings` als config verwendet wird. Dies habe ich behoben. Damit bestehende Config nicht kaputt geht habe ich `recodings` als Alias eingefügt. 
Außerdem ist aufgefallen, dass ohne `recordings` aktuell nicht auf den Anrufenden gehört wird. Dies ist ein Fehler aus eeb3adb7. Als korrekte Lösung für dieses Problem habe ich, den `nullOutputStream()` verwendet, wenn kein `recordings` gibt. Dieser verwirft einfach alle Bytes.