### PR TITLE
Ignore whitespaces for basic auth

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -820,6 +820,7 @@ public class DB {
 	
 	/**
 	 * Checks credentials in the given authorization header.
+	 * Ignores whitespaces surrounding username or password.
 	 * 
 	 * @return The authorized user name, if authorization was successful, <code>null</code> otherwise.
 	 */
@@ -830,8 +831,8 @@ public class DB {
 			String decoded = new String(decodedBytes, StandardCharsets.UTF_8);
 			int sepIndex = decoded.indexOf(':');
 			if (sepIndex >= 0) {
-				String login = decoded.substring(0, sepIndex);
-				String passwd = decoded.substring(sepIndex + 1);
+				String login = decoded.substring(0, sepIndex).trim();
+				String passwd = decoded.substring(sepIndex + 1).trim();
 				return login(login, passwd);
 			}
 		}


### PR DESCRIPTION
In #95 wurde beschrieben,  dass ein häufiger Fehler bei der Einrichtung des Telefonbuches Leerzeichen sind. Jetzt wird in `basicAuth`  `trim()` verwendet um alle Leerzeichen vor/nach dem Nutzernamen und dem Passwort zu entfernen. Ich habe es lokal mit curl ausprobiert und funktioniert wie erwartet. Da ich die Implementierung direkt in `DB` geändert habe, wird dies auch in allen Seiten die `LoginFilter` benutzen und in `BlocklistServlet`, sowie in `RateServlet` angewandt.