### PR TITLE
Issue #101: Use unlimited parallelism for critical tasks.

### DIFF
--- a/phoneblock-ab/pom.xml
+++ b/phoneblock-ab/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>	
 		    <groupId>org.mjsip</groupId>
 			<artifactId>mjsip-ua</artifactId>
-		    <version>2.0.1</version>
+		    <version>2.0.2</version>
 		</dependency>
 	</dependencies>
 	

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
@@ -178,7 +178,7 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 		
 		resolveViaAddress(sipConfig);
 		
-		Scheduler scheduler = Scheduler.of(_scheduler.executor());
+		Scheduler scheduler = _scheduler;
 		
 		_sipProvider = new SipProvider(sipConfig, scheduler);
 		_portPool = portConfig.createPool();
@@ -250,7 +250,7 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 		
 		_instance = this;
 		
-		_scheduler.executor().schedule(this::registerBots, 10, TimeUnit.SECONDS);
+		_scheduler.scheduler().schedule(this::registerBots, 10, TimeUnit.SECONDS);
 	}
 
 	private void resolveViaAddress(SipConfig sipConfig) {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/RegisterServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/RegisterServlet.java
@@ -44,7 +44,7 @@ public class RegisterServlet extends HttpServlet {
 		Captcha captcha = new Captcha(SecureRandomService.getInstance().getRnd());
 		String captchaImage = "data:image/png;base64," + Base64.getEncoder().encodeToString(captcha.getPng());
 		_sessions.put(session, SessionInfo.create().setCreated(System.currentTimeMillis()).setSession(session).setAnswer(captcha.getText()));
-		SchedulerService.getInstance().executor().schedule(() -> _sessions.remove(session), 15, TimeUnit.MINUTES);
+		SchedulerService.getInstance().scheduler().schedule(() -> _sessions.remove(session), 15, TimeUnit.MINUTES);
 		
 		ServletUtil.sendResult(req, resp, RegistrationChallenge.create().setSession(session).setCaptcha(captchaImage));
 	}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/chatgpt/ChatGPTService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/chatgpt/ChatGPTService.java
@@ -92,7 +92,7 @@ public class ChatGPTService implements ServletContextListener {
 		
 		LOG.info("Starting ChatGPTService.");
 		
-		_heartBeat = _scheduler.executor().scheduleWithFixedDelay(this::heardBeat, 15, 3600, TimeUnit.SECONDS);
+		_heartBeat = _scheduler.scheduler().scheduleWithFixedDelay(this::heardBeat, 15, 3600, TimeUnit.SECONDS);
 		reschedule();
 	}
 
@@ -271,7 +271,7 @@ public class ChatGPTService implements ServletContextListener {
 		// Reset exponential back-off.
 		_delaySeconds = INITIAL_DELAY_SECONDS;
 		
-		_process = _scheduler.executor().schedule(this::process, _delaySeconds, TimeUnit.SECONDS);
+		_process = _scheduler.scheduler().schedule(this::process, _delaySeconds, TimeUnit.SECONDS);
 	}
 
 	/** 
@@ -284,7 +284,7 @@ public class ChatGPTService implements ServletContextListener {
 		}
 		
 		LOG.info("Rescheduling with " + _delaySeconds + " seconds delay.");
-		_process = _scheduler.executor().schedule(this::process, _delaySeconds, TimeUnit.SECONDS);
+		_process = _scheduler.scheduler().schedule(this::process, _delaySeconds, TimeUnit.SECONDS);
 	}
 
 }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -419,7 +419,7 @@ public class DB {
 		 long millisFirst = cal.getTimeInMillis();
 		 long initialDelay = millisFirst - millisNow;
 		 
-		_tasks.add(_scheduler.executor().scheduleAtFixedRate(command, initialDelay, 24 * 60 * 60 * 1000L, TimeUnit.MILLISECONDS));
+		_tasks.add(_scheduler.scheduler().scheduleAtFixedRate(command, initialDelay, 24 * 60 * 60 * 1000L, TimeUnit.MILLISECONDS));
 		return cal.getTime();
 	}
 	

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/dns/DnsServer.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/dns/DnsServer.java
@@ -15,7 +15,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Collections;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -62,7 +62,7 @@ public class DnsServer implements Runnable {
 
 	private static Logger LOG = LoggerFactory.getLogger(DnsServer.class);
 
-	private final ScheduledExecutorService _executor;
+	private final ExecutorService _executor;
 	private final ServerSocket _serverSocket;
 	
 	private Zone _onlyZone;
@@ -73,8 +73,8 @@ public class DnsServer implements Runnable {
 	private long _ttlMaster = 600;
 	private long _ttlClient = 60;
 
-	public DnsServer(ScheduledExecutorService executor, int port) throws IOException {
-		_executor = executor;
+	public DnsServer(ExecutorService executorService, int port) throws IOException {
+		_executor = executorService;
 
 		try (ServerSocket test = new ServerSocket()) {
 			LOG.info("Supported socket options: " + test.supportedOptions().stream().map(o -> o.name()).collect(Collectors.joining(", ")));

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/meta/MetaSearchService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/meta/MetaSearchService.java
@@ -66,7 +66,7 @@ public class MetaSearchService implements ServletContextListener {
 		
 		_instance = this;
 		
-		_heartBeat = _scheduler.executor().scheduleWithFixedDelay(this::heartBeat, 1, 10, TimeUnit.MINUTES);
+		_heartBeat = _scheduler.scheduler().scheduleWithFixedDelay(this::heartBeat, 1, 10, TimeUnit.MINUTES);
 	}
 	
 	private void heartBeat() {
@@ -173,7 +173,7 @@ public class MetaSearchService implements ServletContextListener {
 		
 		LOG.info("Scheduling next meta search in " + Duration.of(delay, ChronoUnit.MILLIS) + ", queue size is: " + _jobs.size());
 		
-		_task = _scheduler.executor().schedule(this::performSearch, delay, TimeUnit.MILLISECONDS);
+		_task = _scheduler.scheduler().schedule(this::performSearch, delay, TimeUnit.MILLISECONDS);
 	}
 
 	private void performSearch() {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/scheduler/SchedulerService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/scheduler/SchedulerService.java
@@ -3,31 +3,41 @@
  */
 package de.haumacher.phoneblock.scheduler;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import org.mjsip.time.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Service providing a {@link ScheduledExecutorService}.
  */
-public class SchedulerService implements ServletContextListener {
+public class SchedulerService implements ServletContextListener, Scheduler {
+
+	/**
+	 * The default core pool size of the scheduler.
+	 */
+	public static final int CORE_POOL_SIZE = 10;
 
 	private static final Logger LOG = LoggerFactory.getLogger(SchedulerService.class);
 
-	private ScheduledExecutorService _executor;
+	private ExecutorService _executor;
+
+	private ScheduledExecutorService _scheduler;
 
 	private static SchedulerService _instance;
 
 	@Override
 	public void contextInitialized(ServletContextEvent sce) {
 		LOG.info("Starting scheduler.");
-		_executor = new ScheduledThreadPoolExecutor(10);
+		_executor = Executors.newCachedThreadPool();
+		_scheduler = Executors.newScheduledThreadPool(CORE_POOL_SIZE);
 		
 		_instance = this;
 	}
@@ -65,8 +75,15 @@ public class SchedulerService implements ServletContextListener {
 	/** 
 	 * The executor.
 	 */
-	public ScheduledExecutorService executor() {
+	public ExecutorService executor() {
 		return _executor;
+	}
+	
+	/** 
+	 * The scheduler.
+	 */
+	public ScheduledExecutorService scheduler() {
+		return _scheduler;
 	}
 
 }

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/scheduler/TestSchedulerService.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/scheduler/TestSchedulerService.java
@@ -1,0 +1,66 @@
+package de.haumacher.phoneblock.scheduler;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link SchedulerService}.
+ */
+public class TestSchedulerService {
+
+	/**
+	 * Test that the {@link SchedulerService} can execute more parallel tasks than specified in its core pool size.
+	 */
+	@Test
+	public void testExecute() {
+		SchedulerService service = new SchedulerService();
+		service.contextInitialized(null);
+		
+		AtomicInteger done = new AtomicInteger();
+		AtomicBoolean fence = new AtomicBoolean();
+		int cnt = SchedulerService.CORE_POOL_SIZE + 5;
+		for (int n = 0; n < cnt; n++) {
+			service.executor().execute(() -> {
+				System.out.println("Waiting.");
+				while (!fence.get()) {
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException e) {
+						Assertions.fail("Interrupted");
+					}
+				}
+				int id = done.incrementAndGet();
+				System.out.println("Completed " + id +".");
+			});
+		}
+		
+		AtomicBoolean check = new AtomicBoolean();
+		service.executor().execute(() -> {
+			System.out.println("Releasing.");
+			check.set(true);
+		});
+		
+		while (!check.get()) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				Assertions.fail("Interrupted");
+			}
+		}
+		
+		fence.set(true);
+		
+		while (done.get() < cnt) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				Assertions.fail("Interrupted");
+			}
+		}
+		
+		service.contextDestroyed(null);
+	}
+}


### PR DESCRIPTION
Some tasks cannot be scheduled through a work list but must immediately be started, even if the core pool size of the scheduled thread pool executor is exhausted. Introduce two separate thread pools, one with unlimited capacity for urgent tasks and one for scheduled tasks.