### PR TITLE
Issue #129: Must set votes and votesWildcard consistently.

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
@@ -208,7 +208,7 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 						if (state.booleanValue()) {
 							// Locally blocked.
 							LOG.info("Caller is on blacklist of {}: {}", botName, phoneId);
-							info = PhoneInfo.create().setPhone(phoneId).setRating(Rating.B_MISSED).setVotes(1000);
+							info = PhoneInfo.create().setPhone(phoneId).setRating(Rating.B_MISSED).setVotes(1000).setVotesWildcard(1000);
 						} else {
 							// On the exclude list.
 							LOG.info("Call form white-listed number of {}.", botName);


### PR DESCRIPTION
Otherwise, calls will be ignored, if the personal settings enable blocking calls by wildcards.