### PR TITLE
Build PhoneBlock immediately after checkout

### DIFF
--- a/phoneblock-ab/pom.xml
+++ b/phoneblock-ab/pom.xml
@@ -46,18 +46,17 @@
 		    <version>${project.version}</version>
 		</dependency>
 		
-		<dependency>	
-		    <groupId>org.mjsip</groupId>
+		<dependency>
+		    <groupId>com.github.haumacher.mjSIP</groupId>
 			<artifactId>mjsip-ua</artifactId>
 		    <version>2.0.5</version>
 		</dependency>
 	</dependencies>
-	
+
 	<repositories>
 		<repository>
-			<id>github</id>
-			<name>GitHub haumacher/mjSIP Apache Maven Packages</name>
-			<url>https://maven.pkg.github.com/haumacher/mjSIP</url>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -300,10 +300,6 @@
 	</dependencies>
 
 	<build>
-		<filters>
-			<filter>.phoneblock</filter>
-		</filters>
-	
 		<resources>
 			<resource>
 				<directory>${project.build.sourceDirectory}</directory>
@@ -313,7 +309,6 @@
 			</resource>
 			<resource>
 				<directory>${project.basedir}/src/main/resources-filtered</directory>
-				<filtering>true</filtering>
 			</resource>
 		</resources>
 

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -300,6 +300,10 @@
 	</dependencies>
 
 	<build>
+		<filters>
+			<filter>.phoneblock</filter>
+		</filters>
+
 		<resources>
 			<resource>
 				<directory>${project.build.sourceDirectory}</directory>
@@ -309,10 +313,39 @@
 			</resource>
 			<resource>
 				<directory>${project.basedir}/src/main/resources-filtered</directory>
+				<filtering>true</filtering>
 			</resource>
 		</resources>
 
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>check-phoneblock-config</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireFilesExist>
+									<files>
+										<file>${project.basedir}/.phoneblock</file>
+									</files>
+									<message>
+Configuration file '.phoneblock' is missing.
+Copy '.phoneblock.template' to '.phoneblock' and fill in your local values
+(database URL, OAuth credentials, SMTP settings). See CLAUDE.md for details.
+									</message>
+								</requireFilesExist>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>de.haumacher.msgbuf</groupId>
 				<version>${msgbuf.version}</version>


### PR DESCRIPTION
This PR contains minor changes to the project build so that the build can be successfully executed locally immediately after a checkout.

1. Use of [Jitpack ](https://jitpack.io/) to directly use your fix https://github.com/haumacher/java-utils-mail-dkim/tree/fix-automatic-module-name without needed extra building it locally.
2. Adjustment of the filtering of the .phoneblock file.
    ```
    - Remove global <filters> configuration that was applied during process-resources phase
    - Keep filtering in maven-war-plugin for deployment-time configuration injection
    - Allow developers to compile and test without needing environment-specific .phoneblock file
    ```

Fixes #202 