### PR TITLE
Hotfix: No welcome mails

### DIFF
--- a/phoneblock-ab/.classpath
+++ b/phoneblock-ab/.classpath
@@ -25,5 +25,12 @@
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/phoneblock-ab/.gitignore
+++ b/phoneblock-ab/.gitignore
@@ -1,1 +1,2 @@
 /target/
+/.phoneblock

--- a/phoneblock-ab/pom.xml
+++ b/phoneblock-ab/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.haumacher</groupId>
 		<artifactId>phoneblock-parent</artifactId>
-		<version>1.7.8</version>
+		<version>1.7.9-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>phoneblock-ab</artifactId>
@@ -33,7 +33,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.7.8</tag>
+		<tag>1.6.14</tag>
   	</scm>
 
 	<properties>

--- a/phoneblock-ab/pom.xml
+++ b/phoneblock-ab/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.haumacher</groupId>
 		<artifactId>phoneblock-parent</artifactId>
-		<version>1.7.8-SNAPSHOT</version>
+		<version>1.7.8</version>
 	</parent>
 	
 	<artifactId>phoneblock-ab</artifactId>
@@ -33,7 +33,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.6.14</tag>
+		<tag>1.7.8</tag>
   	</scm>
 
 	<properties>

--- a/phoneblock-shared/.classpath
+++ b/phoneblock-shared/.classpath
@@ -24,5 +24,12 @@
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/phoneblock-shared/pom.xml
+++ b/phoneblock-shared/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.haumacher</groupId>
 		<artifactId>phoneblock-parent</artifactId>
-		<version>1.7.8-SNAPSHOT</version>
+		<version>1.7.8</version>
 	</parent>
 	
 	<artifactId>phoneblock-shared</artifactId>
@@ -31,7 +31,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.6.14</tag>
+		<tag>1.7.8</tag>
   	</scm>
 
 	<dependencies>

--- a/phoneblock-shared/pom.xml
+++ b/phoneblock-shared/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.haumacher</groupId>
 		<artifactId>phoneblock-parent</artifactId>
-		<version>1.7.8</version>
+		<version>1.7.9-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>phoneblock-shared</artifactId>
@@ -31,7 +31,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.7.8</tag>
+		<tag>1.6.14</tag>
   	</scm>
 
 	<dependencies>

--- a/phoneblock/.classpath
+++ b/phoneblock/.classpath
@@ -21,7 +21,6 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
@@ -34,11 +33,13 @@
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources-filtered">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -505,35 +505,41 @@
 			    </execution>
 			  </executions>
 			</plugin>
-            <plugin>
-             <artifactId>maven-antrun-plugin</artifactId>
-             <executions>
-               <execution>
-			     <id>unzip-ip4-database</id>
-			     <phase>process-resources</phase>
-				 <goals>
-				   <goal>run</goal>
-				 </goals>
-				 <configuration>
-				   <target>
-				     <unzip src="${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.BIN.ZIP" dest="${project.build.directory}/IP2LOCATION" />
-				   </target>
-				 </configuration>
-               </execution>
-               <execution>
-			     <id>unzip-ip6-database</id>
-			     <phase>process-resources</phase>
-                 <configuration>
-                   <target>
-                     <unzip src="${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP" dest="${project.build.directory}/IP2LOCATION" />
-                   </target>
-                 </configuration>
-                 <goals>
-                   <goal>run</goal>
-                 </goals>
-               </execution>
-             </executions>
-           </plugin>			
+			
+			<plugin>
+			  <groupId>org.codehaus.mojo</groupId>
+			  <artifactId>truezip-maven-plugin</artifactId>
+			  <version>1.2</version>
+			  <executions>
+			    <execution>
+			      <id>unzip-ip4-database</id>
+			      <goals>
+			        <goal>copy</goal>
+			      </goals>
+			      <phase>process-resources</phase>
+			      <configuration>
+			        <fileset>
+			          <directory>${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.BIN.ZIP</directory>
+			          <outputDirectory>${project.build.directory}/IP2LOCATION</outputDirectory>
+			        </fileset>
+			      </configuration>
+			    </execution>
+
+			    <execution>
+			      <id>unzip-ip6-database</id>
+			      <goals>
+			        <goal>copy</goal>
+			      </goals>
+			      <phase>process-resources</phase>
+			      <configuration>
+			        <fileset>
+			          <directory>${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP</directory>
+			          <outputDirectory>${project.build.directory}/IP2LOCATION</outputDirectory>
+			        </fileset>
+			      </configuration>
+			    </execution>
+			  </executions>
+			</plugin>
 			
 			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -515,18 +515,18 @@
 				   <goal>run</goal>
 				 </goals>
 				 <configuration>
-				   <tasks>
+				   <target>
 				     <unzip src="${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.BIN.ZIP" dest="${project.build.directory}/IP2LOCATION" />
-				   </tasks>
+				   </target>
 				 </configuration>
                </execution>
                <execution>
 			     <id>unzip-ip6-database</id>
 			     <phase>process-resources</phase>
                  <configuration>
-                   <tasks>
+                   <target>
                      <unzip src="${project.build.directory}/IP2LOCATION/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP" dest="${project.build.directory}/IP2LOCATION" />
-                   </tasks>
+                   </target>
                  </configuration>
                  <goals>
                    <goal>run</goal>

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>de.haumacher</groupId>
 	<artifactId>phoneblock</artifactId>
-	<version>1.7.8</version>
+	<version>1.7.9-SNAPSHOT</version>
 	
 	<name>PhoneBlock</name>
 	<description>Ad blocker for your Fritz!Box</description>
@@ -29,7 +29,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-	  <tag>1.7.8</tag>
+	  <tag>1.6.14</tag>
   	</scm>
   	
   	<packaging>war</packaging>

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>de.haumacher</groupId>
 	<artifactId>phoneblock</artifactId>
-	<version>1.7.8-SNAPSHOT</version>
+	<version>1.7.8</version>
 	
 	<name>PhoneBlock</name>
 	<description>Ad blocker for your Fritz!Box</description>
@@ -29,7 +29,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-	  <tag>1.6.14</tag>
+	  <tag>1.7.8</tag>
   	</scm>
   	
   	<packaging>war</packaging>

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -1736,7 +1736,7 @@ public class DB {
 		calendar.set(Calendar.MINUTE, 0);
 		calendar.set(Calendar.HOUR, 0);
 		calendar.add(Calendar.HOUR, -1);
-		calendar.add(Calendar.DAY_OF_MONTH, -2);
+		calendar.add(Calendar.DAY_OF_MONTH, -3);
 		
 		long twoDaysBefore = calendar.getTimeInMillis();
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -1533,7 +1533,7 @@ public class DB {
 					DBUserSettings userSettings = getUserSettings(users, login);
 					users.markWelcome(userSettings.getId());
 					session.commit();
-					
+
 					_scheduler.executor().submit(() -> mailService.sendWelcomeMail(userSettings));
 				} else {
 					LOG.info("Not sending welcome mail to '{}': {}", login, 
@@ -1748,6 +1748,10 @@ public class DB {
 			
 			// Users that did not update the address book for three days.
 			List<DBUserSettings> inactiveUsers = users.getNewInactiveUsers(twoDaysBefore, oneMonthBefore, twoDaysBefore);
+			if (inactiveUsers.size() > 50) {
+				LOG.warn("Excessive amount of inactive users found ({}), not sending help mails.", inactiveUsers.size());
+				return;
+			}
 			for (DBUserSettings user : inactiveUsers) {
 				// Mark mail as send to prevent mail-bombing a user under all circumstances. Sending
 				// a support mail is not tried again, if the first attempt fails.

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBService.java
@@ -122,7 +122,7 @@ public class DBService implements IDBService, ServletContextListener {
 		}
 		
 		_pool = JdbcConnectionPool.create(dataSource);
-		INSTANCE = new DB(_rnd.getRnd(), config.isSendHelpMails(), _pool, _indexer, _scheduler, _mail == null ? null : _mail.getMailService());
+		INSTANCE = new DB(_rnd.getRnd(), config, _pool, _indexer, _scheduler, _mail == null ? null : _mail.getMailService());
 	}
 
 	protected int defaultDbPort() {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/config/DBConfig.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/config/DBConfig.java
@@ -30,6 +30,9 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 	/** @see #isSendHelpMails() */
 	public static final String SEND_HELP_MAILS__PROP = "sendHelpMails";
 
+	/** @see #isSendWelcomeMails() */
+	public static final String SEND_WELCOME_MAILS__PROP = "sendWelcomeMails";
+
 	/** Identifier for the property {@link #getUrl()} in binary format. */
 	static final int URL__ID = 1;
 
@@ -45,6 +48,9 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 	/** Identifier for the property {@link #isSendHelpMails()} in binary format. */
 	static final int SEND_HELP_MAILS__ID = 5;
 
+	/** Identifier for the property {@link #isSendWelcomeMails()} in binary format. */
+	static final int SEND_WELCOME_MAILS__ID = 6;
+
 	private String _url = "";
 
 	private String _user = "";
@@ -54,6 +60,8 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 	private int _port = 0;
 
 	private boolean _sendHelpMails = false;
+
+	private boolean _sendWelcomeMails = false;
 
 	/**
 	 * Creates a {@link DBConfig} instance.
@@ -169,6 +177,27 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 		_sendHelpMails = value;
 	}
 
+	/**
+	 * Whether to send welcome mails after the blocklist has been synchronized the first time.
+	 */
+	public final boolean isSendWelcomeMails() {
+		return _sendWelcomeMails;
+	}
+
+	/**
+	 * @see #isSendWelcomeMails()
+	 */
+	public de.haumacher.phoneblock.db.config.DBConfig setSendWelcomeMails(boolean value) {
+		internalSetSendWelcomeMails(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #isSendWelcomeMails()} without chain call utility. */
+	protected final void internalSetSendWelcomeMails(boolean value) {
+		_listener.beforeSet(this, SEND_WELCOME_MAILS__PROP, value);
+		_sendWelcomeMails = value;
+	}
+
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;
 
 	@Override
@@ -202,7 +231,8 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 			USER__PROP, 
 			PASSWORD__PROP, 
 			PORT__PROP, 
-			SEND_HELP_MAILS__PROP));
+			SEND_HELP_MAILS__PROP, 
+			SEND_WELCOME_MAILS__PROP));
 
 	@Override
 	public java.util.List<String> properties() {
@@ -217,6 +247,7 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 			case PASSWORD__PROP: return getPassword();
 			case PORT__PROP: return getPort();
 			case SEND_HELP_MAILS__PROP: return isSendHelpMails();
+			case SEND_WELCOME_MAILS__PROP: return isSendWelcomeMails();
 			default: return null;
 		}
 	}
@@ -229,6 +260,7 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 			case PASSWORD__PROP: internalSetPassword((String) value); break;
 			case PORT__PROP: internalSetPort((int) value); break;
 			case SEND_HELP_MAILS__PROP: internalSetSendHelpMails((boolean) value); break;
+			case SEND_WELCOME_MAILS__PROP: internalSetSendWelcomeMails((boolean) value); break;
 		}
 	}
 
@@ -257,6 +289,8 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 		out.value(getPort());
 		out.name(SEND_HELP_MAILS__PROP);
 		out.value(isSendHelpMails());
+		out.name(SEND_WELCOME_MAILS__PROP);
+		out.value(isSendWelcomeMails());
 	}
 
 	@Override
@@ -267,6 +301,7 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 			case PASSWORD__PROP: setPassword(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case PORT__PROP: setPort(in.nextInt()); break;
 			case SEND_HELP_MAILS__PROP: setSendHelpMails(in.nextBoolean()); break;
+			case SEND_WELCOME_MAILS__PROP: setSendWelcomeMails(in.nextBoolean()); break;
 			default: super.readField(in, field);
 		}
 	}
@@ -296,6 +331,8 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 		out.value(getPort());
 		out.name(SEND_HELP_MAILS__ID);
 		out.value(isSendHelpMails());
+		out.name(SEND_WELCOME_MAILS__ID);
+		out.value(isSendWelcomeMails());
 	}
 
 	/** Reads a new instance from the given reader. */
@@ -329,6 +366,7 @@ public class DBConfig extends de.haumacher.msgbuf.data.AbstractDataObject implem
 			case PASSWORD__ID: setPassword(in.nextString()); break;
 			case PORT__ID: setPort(in.nextInt()); break;
 			case SEND_HELP_MAILS__ID: setSendHelpMails(in.nextBoolean()); break;
+			case SEND_WELCOME_MAILS__ID: setSendWelcomeMails(in.nextBoolean()); break;
 			default: in.skipValue(); 
 		}
 	}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/config/dbConfig.proto
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/config/dbConfig.proto
@@ -19,4 +19,7 @@ message DBConfig {
 	
 	/** Whether to automatically send help mails when a period of inactivity is detected. */
 	boolean sendHelpMails;
+	
+	/** Whether to send welcome mails after the blocklist has been synchronized the first time. */
+	boolean sendWelcomeMails;
 }

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/location/TestCountry4IP.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/location/TestCountry4IP.java
@@ -2,12 +2,11 @@ package de.haumacher.phoneblock.location;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 
 import org.junit.jupiter.api.Test;
-
-import de.haumacher.phoneblock.location.Country4IP;
 
 /**
  * Test case for {@link Country4IP}.
@@ -16,7 +15,9 @@ public class TestCountry4IP {
 	
 	@Test
 	public void testLookup() throws IOException {
-		Country4IP country = new Country4IP("./target/IP2LOCATION/IP2LOCATION-LITE-DB1.BIN", "./target/IP2LOCATION/IP2LOCATION-LITE-DB1.IPV6.BIN");
+		Country4IP country = new Country4IP(
+			resolve("./target/IP2LOCATION/IP2LOCATION-LITE-DB1.BIN"), 
+			resolve("./target/IP2LOCATION/IP2LOCATION-LITE-DB1.IPV6.BIN"));
 		
         assertEquals("DE", country.lookup("phoneblock.net"));
         assertEquals("DE", country.lookup("128.140.84.131"));
@@ -24,6 +25,10 @@ public class TestCountry4IP {
         
         assertEquals("DE", country.lookup(InetAddress.getByName("128.140.84.131")));
         assertEquals("DE", country.lookup(InetAddress.getByName("2a01:4f8:c17:6624::1")));
+	}
+
+	private String resolve(String fileName) {
+		return new File(fileName).getAbsolutePath();
 	}
 	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>de.haumacher</groupId>
 	<artifactId>phoneblock-parent</artifactId>
-	<version>1.7.8-SNAPSHOT</version>
+	<version>1.7.8</version>
 	
 	<name>PhoneBlock Aggregator</name>
 	<description>Maven aggregator building all parts of PhoneBlock</description>
@@ -31,7 +31,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.6.14</tag>
+		<tag>1.7.8</tag>
 	</scm>
 	
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>de.haumacher</groupId>
 	<artifactId>phoneblock-parent</artifactId>
-	<version>1.7.8</version>
+	<version>1.7.9-SNAPSHOT</version>
 	
 	<name>PhoneBlock Aggregator</name>
 	<description>Maven aggregator building all parts of PhoneBlock</description>
@@ -31,7 +31,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/haumacher/phoneblock.git</developerConnection>
-		<tag>1.7.8</tag>
+		<tag>1.6.14</tag>
 	</scm>
 	
 	<modules>


### PR DESCRIPTION
Instabilitäten haben dazu geführt, dass eine Mail-Flut von "Hilfe-Mails" an Nutzer erzeugt wurde, die auf Probleme beim Blocklist-Abruf hinweisen. Das hat zu einer Sperre des Mail-Accounts bei Hetzner geführt. Beim Wiederanlauf muss jetzt verhindert werden, dass bei einer neuerlichen erfolgreichen Synchronisation genausoviele Willkommens-E-Mails generiert werden.

Über das Flag `sendWelcomeMails` läst sich der Versandt dieser Mails abschalten, bis sich die Situation wieder beruhigt hat.

Wenn das System erkennt, dass mehr als 50 Hilfe-E-Mails generiert würden, dann werden keine solche E-Mails geschickt und stattdessen eine Warnung geloggt.