### PR TITLE
Build vollständig in Docker verschoben – reproduzierbarer & unabhängiger Build-Prozess

### DIFF
--- a/phoneblock-ab/Dockerfile
+++ b/phoneblock-ab/Dockerfile
@@ -1,12 +1,55 @@
-FROM eclipse-temurin:17
-LABEL org.opencontainers.image.authors=play@haumacher.de
+# ===== Stage 1: Build the JAR using Maven =====
+FROM maven:3.9.9-eclipse-temurin-17 AS builder
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+
+# Set the working directory
+WORKDIR /build
+
+# Configure Maven settings for GitHub Packages
+RUN mkdir -p /root/.m2
+RUN echo "<settings>\
+  <servers>\
+    <server>\
+      <id>github</id>\
+      <username>${GITHUB_USER}</username>\
+      <password>${GITHUB_TOKEN}</password>\
+    </server>\
+  </servers>\
+</settings>" > /root/.m2/settings.xml
+
+# Clone and install the missing dependency, see https://github.com/haumacher/phoneblock/issues/202 ---
+RUN git clone https://github.com/haumacher/java-utils-mail-dkim.git /tmp/java-utils-mail-dkim && \
+    cd /tmp/java-utils-mail-dkim && \
+    sed -i 's/<version>3.2.0<\/version>/<version>3.2.1-haumacher<\/version>/' pom.xml && \
+    mvn clean install -DskipTests -Dspotbugs.skip=true && \
+    rm -rf /tmp/java-utils-mail-dkim
+
+# Copy the whole project
+COPY . .
+
+# Pre-fetch dependencies (speeds up rebuilds)
+RUN mvn dependency:go-offline -B
+
+# Build the project and package the jar with dependencies
+RUN mvn -am --projects de.haumacher:phoneblock-ab package -DskipTests
+
+# ===== Stage 2: Runtime image =====
+FROM eclipse-temurin:17-jre
+LABEL org.opencontainers.image.authors="play@haumacher.de"
+
 USER root
 RUN adduser --system  --uid 999 --group --home /opt/phoneblock phoneblock
 
 USER phoneblock
-RUN mkdir  /opt/phoneblock/bin /opt/phoneblock/conversation /opt/phoneblock/recordings
-COPY --chown=phoneblock:phoneblock .phoneblock.docker /opt/phoneblock/.phoneblock
-COPY --chown=phoneblock:phoneblock target/phoneblock-ab-*-jar-with-dependencies.jar /opt/phoneblock/bin/phoneblock-ab.jar
+RUN mkdir -p /opt/phoneblock/bin /opt/phoneblock/conversation /opt/phoneblock/recordings
+COPY --from=builder --chown=phoneblock:phoneblock /build/phoneblock-ab/target/*-jar-with-dependencies.jar /opt/phoneblock/bin/
+COPY --chown=phoneblock:phoneblock phoneblock-ab/.phoneblock.docker /opt/phoneblock/.phoneblock
+
+RUN for f in /opt/phoneblock/bin/*-jar-with-dependencies.jar; do \
+        mv "$f" /opt/phoneblock/bin/phoneblock-ab.jar; \
+    done
 
 WORKDIR /opt/phoneblock/
 ENTRYPOINT ["java", "-jar", "/opt/phoneblock/bin/phoneblock-ab.jar"]


### PR DESCRIPTION
Das Dockerfile wurde so angepasst, dass der gesamte Build-Prozess innerhalb von Docker abläuft. Das bedeutet, dass auf dem Hostsystem keine Installation von Java, Maven oder anderen Build-Tools erforderlich ist. 

Vorteile:
- Reproduzierbare Builds mit definierter Maven- und JDK-Version
- Keine Abhängigkeiten vom lokalen System, keine Installation von Java, Maven, etc. nötig, kein unnötiges Installieren von dependencies in das lokale Repository
- Saubere Trennung zwischen Build- und Runtime-Image

Herausforderungen und Lösungen
- Für Download der Artefakte bei github sind credentials erforderlich, diese müssen beim Build übergeben werden, aus Sicherheitsgründen am besten via env-var
`docker build -f phoneblock-ab/Dockerfile --build-arg GITHUB_USER="$GITHUB_USER" --build-arg GITHUB_TOKEN="$GITHUB_TOKEN" -t phoneblock-ab .`
- pom erwartet `org.simplejavamail:utils-mail-dkim:3.2.1-haumacher`, https://github.com/haumacher/java-utils-mail-dkim.git stellt aber `org.simplejavamail:utils-mail-dkim:3.2.0` bereit --> patchen der POM während des Builds
- Build-Fehler durch SpotBugs (Java 17-Kompatibilität) bei `org.simplejavamail:utils-mail-dkim:3.2.1-haumacher`, SpotBugs-Plugin konnte Class Files mit „major version 61“ (Java 17) nicht lesen -->  SpotBugs wird beim DKIM-Build übersprungen (`-Dspotbugs.skip=true`).
- Der Aufruf von docker muss im Projekt-Root erfolgen (s.o.) damit der Zugriff auf alle Projekt-Dateien möglich ist (docker verbietet path-traversal)

