### PR TITLE
Update default value for `block_ranges` preference

### DIFF
--- a/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
+++ b/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
@@ -67,7 +67,7 @@ public class CallChecker extends CallScreeningService {
         SharedPreferences prefs = MainActivity.getPreferences(this);
         String authToken = prefs.getString("auth_token", null);
         int minVotes = prefs.getInt("min_votes", 4);
-        boolean blockRanges = prefs.getBoolean("block_ranges", false);
+        boolean blockRanges = prefs.getBoolean("block_ranges", true);
         int minRangeVotes = prefs.getInt("min_range_votes", 10);
 
         if (authToken == null) {


### PR DESCRIPTION
This aligns the default value used for the `block_ranges` preference in the `CallChecker` with the rest of the app.

Usage of `true` as default/fallback value in settings related code paths:
- [`MainActivity` line 357](https://github.com/haumacher/phoneblock/blob/6435eb072e1723610f8f63e6017c9ece47c1f22f/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/MainActivity.java#L357)
- [`_SettingsScreenState` line 2185](https://github.com/haumacher/phoneblock/blob/6435eb072e1723610f8f63e6017c9ece47c1f22f/phoneblock_mobile/lib/main.dart#L2185)
- [`_SettingsScreenState` line 2217](https://github.com/haumacher/phoneblock/blob/6435eb072e1723610f8f63e6017c9ece47c1f22f/phoneblock_mobile/lib/main.dart#L2217)

The `CallChecker` was using `false` as its fallback, causing range-based blocking to be disabled on fresh installs despite appearing enabled in the settings screen.

Resolves #238.