### PR TITLE
Fix blocklist background sync failing in WorkManager isolate

### DIFF
--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:device_region/device_region.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:phoneblock_mobile/blocklist_sync_service.dart';
 import 'package:phoneblock_mobile/logging/app_logger.dart';
@@ -500,6 +501,8 @@ void callbackDispatcher() {
     AppLogger.instance.info('app', 'workmanager task=$task started');
     try {
       if (task == 'blocklistSync') {
+        final packageInfo = await PackageInfo.fromPlatform();
+        appVersion = packageInfo.version;
         return await BlocklistSyncService.instance.sync();
       }
       return Future.value(true);
@@ -2742,12 +2745,36 @@ class LoginFailed extends StatelessWidget {
   }
 }
 
-void setAuthToken(String token) {
+/// Stores the auth token in both Flutter SharedPreferences (accessible from
+/// background isolates for WorkManager sync) and native SharedPreferences
+/// (used by CallChecker for call screening).
+Future<void> setAuthToken(String token) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('auth_token', token);
   platform.invokeMethod("setAuthToken", token);
 }
 
+/// Reads the auth token from Flutter SharedPreferences.
+///
+/// On first call after migration from native-only storage, falls back to
+/// reading via MethodChannel (foreground only) and copies the value to
+/// Flutter SharedPreferences for future background access.
 Future<String?> getAuthToken() async {
-  return platform.invokeMethod("getAuthToken");
+  final prefs = await SharedPreferences.getInstance();
+  var token = prefs.getString('auth_token');
+  if (token == null) {
+    // Migration: try reading from native SharedPreferences via MethodChannel.
+    // This only works when the Flutter engine has an Activity (foreground).
+    try {
+      token = await platform.invokeMethod<String>("getAuthToken");
+      if (token != null) {
+        await prefs.setString('auth_token', token);
+      }
+    } catch (e) {
+      // MethodChannel unavailable in background isolate — token stays null.
+    }
+  }
+  return token;
 }
 
 /// Registers the daily blocklist sync task with WorkManager.


### PR DESCRIPTION
Closes #276

## Summary

- Switch `getAuthToken`/`setAuthToken` to Flutter `shared_preferences` plugin, which WorkManager properly initializes in background isolates
- `setAuthToken` writes to both Flutter and native SharedPreferences so `CallChecker.java` continues working unchanged
- `getAuthToken` includes a one-time migration from native prefs on first foreground read
- Initialize `appVersion` in `callbackDispatcher` via `PackageInfo.fromPlatform()`

## Test plan

- [ ] Verify blocklist sync runs successfully in background (check logcat for WorkManager task completion)
- [ ] Verify call screening still works after login (native SharedPreferences still written)
- [ ] Verify existing users get their token migrated on first foreground `getAuthToken` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)