### PR TITLE
Refresh cached user settings after email change (#279)

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/EmailChangeServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/EmailChangeServlet.java
@@ -271,6 +271,12 @@ public class EmailChangeServlet extends HttpServlet {
 			}
 			LOG.info("Email changed successfully for user '{}' to '{}'.", userName, newEmail);
 
+			UserSettings settings = LoginFilter.getUserSettings(req);
+			if (settings != null) {
+				settings.setEmail(newEmail);
+				LoginFilter.refreshUserSettings(req, settings);
+			}
+
 			// Clear session attributes
 			clearSessionAttributes(session);
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/SettingsServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/SettingsServlet.java
@@ -187,12 +187,20 @@ public class SettingsServlet extends HttpServlet {
 			return;
 		}
 
+		String trimmed = newDisplayName.trim();
 		DB db = DBService.getInstance();
 		try (SqlSession session = db.openSession()) {
 			Users users = session.getMapper(Users.class);
-			users.setDisplayName(userName, newDisplayName.trim());
+			users.setDisplayName(userName, trimmed);
 			session.commit();
 		}
+
+		UserSettings settings = LoginFilter.getUserSettings(req);
+		if (settings != null) {
+			settings.setDisplayName(trimmed);
+			LoginFilter.refreshUserSettings(req, settings);
+		}
+
 		forwardToSettings(req, resp, null);
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #279: new email was only visible after next login
- Refresh cached `UserSettings` in session after successful email change, same pattern as `SettingsServlet`

## Test plan
- [ ] Change email via settings, verify new address appears immediately without re-login