### PR TITLE
Allow single-digit country codes in mobile wildcard blocking (#286)

### DIFF
--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -4161,7 +4161,7 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
   Future<void> _addWildcardNumber(BuildContext context, String phoneInput) async {
     final prefix = await _normalizeWildcardPrefix(phoneInput);
 
-    if (prefix == null || prefix.length < 3) {
+    if (prefix == null || prefix.length < 2) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(


### PR DESCRIPTION
## Summary
- Fixes #286: Wildcard-Sperre in der Mobile-App akzeptiert jetzt einstellige Landesvorwahlen wie `+7` oder `+1`.
- Mindestlänge in `_addWildcardNumber` von 3 auf 2 Zeichen gesenkt (`+` + mindestens eine Ziffer).

Der zweite im Issue genannte Aspekt (Server-Sync bzw. Export/Import von Wildcard-Regeln) ist bewusst nicht Teil dieses PRs — das wäre ein größeres Feature und sollte separat getrackt werden.

## Test plan
- [ ] Wildcard mit `+7` hinzufügen → wird akzeptiert
- [ ] Wildcard mit `+` (leer) → weiterhin abgelehnt
- [ ] Nationale Eingaben (z. B. `030`) → weiterhin korrekt normalisiert