### PR TITLE
Initialize LASTPING on insert to prevent immediate archiving

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
@@ -24,8 +24,8 @@ public interface SpamReports {
 	Long getLastUpdate();
 	
 	@Insert("""
-			insert into NUMBERS (PHONE, SHA1, VOTES, DOWN_VOTES, UP_VOTES, UPDATED, ADDED)
-			values (#{phone}, #{hash}, #{votes}, CASEWHEN (#{votes} > 0, #{votes}, 0), CASEWHEN (#{votes} < 0, 0 - #{votes}, 0), #{now}, #{now})
+			insert into NUMBERS (PHONE, SHA1, VOTES, DOWN_VOTES, UP_VOTES, UPDATED, ADDED, LASTPING)
+			values (#{phone}, #{hash}, #{votes}, CASEWHEN (#{votes} > 0, #{votes}, 0), CASEWHEN (#{votes} < 0, 0 - #{votes}, 0), #{now}, #{now}, #{now})
 			""")
 	void addReport(String phone, byte[] hash, int votes, long now);
 	


### PR DESCRIPTION
## Summary
- `addReport` left `LASTPING` at its schema default `0`, so newly inserted numbers (especially FTC imports and search stubs without rating/aggregation follow-ups) were immediately archived by `archiveReportsWithLowVotes`, which sets `PENDING_UPDATE=true`.
- The next `assignVersionToPendingUpdates` then assigned a `VERSION` to these entries, causing them to appear in the incremental blocklist diff as spurious deletions even though they never crossed the visibility threshold.
- Fix: initialize `LASTPING = #{now}` in the `addReport` insert, consistent with `addVote`/`updateRating`.

## Test plan
- [ ] Run existing DB / blocklist tests (`mvn test`)
- [ ] Verify FTC import no longer produces large incremental diffs of below-threshold numbers
- [ ] Check that archival behavior for genuinely stale numbers still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)