### PR TITLE
fix: Handle null Uri in CallChecker.onScreenCall

### DIFF
--- a/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
+++ b/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
@@ -75,6 +75,12 @@ public class CallChecker extends CallScreeningService {
         Uri handle = callDetails.getHandle();
         Log.d(CallChecker.class.getName(), "onScreenCall: " + handle);
 
+        if (handle == null) {
+            Log.d(CallChecker.class.getName(), "onScreenCall: No handle (e.g. withheld number), accepting.");
+            acceptCall(callDetails);
+            return;
+        }
+
         SharedPreferences prefs = MainActivity.getPreferences(this);
         String authToken = prefs.getString("auth_token", null);
         int minVotes = prefs.getInt("min_votes", 4);


### PR DESCRIPTION
## Summary
- Fix NullPointerException in `CallChecker.onScreenCall` when `Call.Details.getHandle()` returns `null` (withheld numbers, emergency calls, some VoIP scenarios)
- Accept the call when no handle is available, since screening is not possible

## Crash report
```
java.lang.NullPointerException: Attempt to invoke virtual method
  'java.lang.String android.net.Uri.getSchemeSpecificPart()' on a null object reference
  at de.haumacher.phoneblock_mobile.CallChecker.onScreenCall (CallChecker.java:82)
```

## Test plan
- [ ] Verify app still builds (`flutter build apk`)
- [ ] Manual test: incoming call with withheld number is accepted without crash
- [ ] Manual test: normal calls still get screened

🤖 Generated with [Claude Code](https://claude.com/claude-code)