### PR TITLE
fix: move DeepL translation plugins to with-deepl Maven profile

### DIFF
--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -368,63 +368,6 @@ Copy '.phoneblock.template' to '.phoneblock' and fill in your local values
 				</executions>
 			</plugin>
 
-			<!-- To trigger manually: mvn auto-translate:translate@translate-web-templates -->
-			<plugin>
-				<groupId>de.haumacher</groupId>
-				<artifactId>auto-translate-maven-plugin</artifactId>
-				<version>1.1.1</version>
-				
-				<executions>
-					<execution>
-						<id>translate-web-templates</id>
-						<goals>
-							<goal>translate</goal>
-						</goals>
-						
-						<configuration>
-							<sourceLang>de</sourceLang>
-							<targetLangs>ar,da,el,en-US,es,fr,it,nb,nl,pl,sv,uk,zh-Hans</targetLangs>
-							<templateDirectory>${project.basedir}/src/main/webapp/WEB-INF/templates</templateDirectory>
-						</configuration>
-					</execution>
-					<execution>
-						<id>translate-mail-templates</id>
-						<goals>
-							<goal>translate</goal>
-						</goals>
-
-						<configuration>
-							<sourceLang>de</sourceLang>
-							<targetLangs>ar,da,el,en-US,es,fr,it,nb,nl,pl,sv,uk,zh-Hans</targetLangs>
-							<templateDirectory>${project.basedir}/src/main/java/de/haumacher/phoneblock/mail/templates</templateDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<!-- Translates Messages_de.properties into all other Messages_*.properties bundles.
-				 To trigger manually:
-				   mvn -Pwith-deepl com.top-logic:tl-maven-plugin:7.10.0:translate -e \
-				     -DsourcePath=src/main/java/Messages_de.properties -N -->
-			<plugin>
-				<groupId>com.top-logic</groupId>
-				<artifactId>tl-maven-plugin</artifactId>
-				<version>7.10.0</version>
-
-				<executions>
-					<execution>
-						<id>translate-messages</id>
-						<goals>
-							<goal>translate</goal>
-						</goals>
-
-						<configuration>
-							<sourcePath>${project.basedir}/src/main/java/Messages_de.properties</sourcePath>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
@@ -751,4 +694,74 @@ Copy '.phoneblock.template' to '.phoneblock' and fill in your local values
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<profiles>
+		<!-- Both translation plugins require a DeepL API key and are not needed for normal
+			 builds or tests. Activate this profile only when re-generating translations.
+			 Note: tl-maven-plugin is not published on Maven Central, so keeping it here
+			 prevents plugin-resolution failures on every regular build.
+			 Trigger web/mail templates:  mvn -Pwith-deepl auto-translate:translate@translate-web-templates
+			 Trigger message bundles:     mvn -Pwith-deepl com.top-logic:tl-maven-plugin:7.10.0:translate -e \
+			                                -DsourcePath=src/main/java/Messages_de.properties -N -->
+		<profile>
+			<id>with-deepl</id>
+			<build>
+				<plugins>
+					<!-- Translates WEB-INF/templates and mail templates from de/ to all other locales -->
+					<plugin>
+						<groupId>de.haumacher</groupId>
+						<artifactId>auto-translate-maven-plugin</artifactId>
+						<version>1.1.1</version>
+
+						<executions>
+							<execution>
+								<id>translate-web-templates</id>
+								<goals>
+									<goal>translate</goal>
+								</goals>
+
+								<configuration>
+									<sourceLang>de</sourceLang>
+									<targetLangs>ar,da,el,en-US,es,fr,it,nb,nl,pl,sv,uk,zh-Hans</targetLangs>
+									<templateDirectory>${project.basedir}/src/main/webapp/WEB-INF/templates</templateDirectory>
+								</configuration>
+							</execution>
+							<execution>
+								<id>translate-mail-templates</id>
+								<goals>
+									<goal>translate</goal>
+								</goals>
+
+								<configuration>
+									<sourceLang>de</sourceLang>
+									<targetLangs>ar,da,el,en-US,es,fr,it,nb,nl,pl,sv,uk,zh-Hans</targetLangs>
+									<templateDirectory>${project.basedir}/src/main/java/de/haumacher/phoneblock/mail/templates</templateDirectory>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<!-- Translates Messages_de.properties into all other Messages_*.properties bundles -->
+					<plugin>
+						<groupId>com.top-logic</groupId>
+						<artifactId>tl-maven-plugin</artifactId>
+						<version>7.10.0</version>
+
+						<executions>
+							<execution>
+								<id>translate-messages</id>
+								<goals>
+									<goal>translate</goal>
+								</goals>
+
+								<configuration>
+									<sourcePath>${project.basedir}/src/main/java/Messages_de.properties</sourcePath>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
## Problem

`mvn test` fails on every fresh checkout because two translation plugins are declared unconditionally in `phoneblock/pom.xml`'s `<build>` section:

- **`com.top-logic:tl-maven-plugin`** — not published on Maven Central. Maven fails with `PluginResolutionException` before any phase runs.
- **`de.haumacher:auto-translate-maven-plugin`** — available on Maven Central but requires a DeepL API key at runtime; errors out without one.

Both plugins are only needed when regenerating translations, yet they block every normal build and any CI setup.

## Fix

Move both plugins into a `with-deepl` Maven profile. Regular `mvn test` and CI runs no longer need them. Translation runs continue to work exactly as before via `-Pwith-deepl` (already documented in the existing comments).

## Test

```
mvn test   # passes without any -P flag or API key
mvn -Pwith-deepl ...   # translation still works as documented
```