### PR TITLE
feat: add minimal GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Create .phoneblock config
+        run: cp phoneblock/.phoneblock.template phoneblock/.phoneblock
+
+      - name: Test
+        run: mvn test --no-transfer-progress
+        # Run all modules even if one fails so test-reporter sees every result
+        continue-on-error: true
+        id: mvn-test
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Maven Tests
+          path: '**/target/surefire-reports/TEST-*.xml'
+          reporter: java-junit
+
+      - name: Fail if tests failed
+        if: steps.mvn-test.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Closes #205

## Summary

- Adds `.github/workflows/test.yml`: runs `mvn test` across all modules on every push and pull request
- Uses `actions/setup-java@v4` with Temurin 17 (matches `maven.compiler.source/target = 17` in `pom.xml`) and Maven dependency caching
- Creates a minimal `.phoneblock` from the existing template so the enforcer check passes (tests use an in-memory H2 database and need no real credentials)
- Uses `dorny/test-reporter@v3` to surface Surefire JUnit XML results as inline GitHub Check annotations on PRs

## Note

This PR assumes the DeepL plugin fix #295 (moving `auto-translate-maven-plugin` and `tl-maven-plugin` to the `with-deepl` profile) is merged first — otherwise the workflow will fail on the `phoneblock` module for the same reason `mvn test` fails locally today.