### PR TITLE
Respect personal blacklist in AnswerBot and /api/num/ (issue #297)

### DIFF
--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -274,7 +274,12 @@ public class AnswerBot extends MultipleUAS {
 				LOG.info("Ignoring call from {}, failed to retrieve rating.", from);
 				return rejectHandler();
 			}
-			
+
+			if (info.isBlackListed()) {
+				LOG.info("Accepting call from {} (number on personal blacklist).", from);
+				return spamHandler(userName, from);
+			}
+
 			int votes = user.getWildcard() ? info.getVotesWildcard() : info.getVotes();
 			if (votes < user.getMinVotes()) {
 				// Not considered SPAM.

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerBot.java
@@ -280,6 +280,10 @@ public class AnswerBot extends MultipleUAS {
 				return spamHandler(userName, from);
 			}
 
+			// Note: The corresponding personal whitelist case needs no explicit handling here.
+			// The server already reports whitelisted numbers with rating A_LEGITIMATE and
+			// zero votes, so the vote-restriction check below rejects the call (i.e. the
+			// answerbot does not pick up and the phone rings normally).
 			int votes = user.getWildcard() ? info.getVotesWildcard() : info.getVotes();
 			if (votes < user.getMinVotes()) {
 				// Not considered SPAM.

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/BasicLoginFilter.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/BasicLoginFilter.java
@@ -15,6 +15,7 @@ import de.haumacher.phoneblock.ab.CreateABServlet;
 import de.haumacher.phoneblock.ab.ListABServlet;
 import de.haumacher.phoneblock.app.api.AccountManagementServlet;
 import de.haumacher.phoneblock.app.api.BlocklistServlet;
+import de.haumacher.phoneblock.app.api.NumServlet;
 import de.haumacher.phoneblock.app.api.PersonalizationServlet;
 import de.haumacher.phoneblock.app.api.RateServlet;
 import de.haumacher.phoneblock.app.api.SearchApiServlet;
@@ -25,6 +26,7 @@ import de.haumacher.phoneblock.carddav.CardDavServlet;
 import de.haumacher.phoneblock.db.settings.AuthToken;
 import de.haumacher.phoneblock.util.ServletUtil;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -47,6 +49,7 @@ import jakarta.servlet.http.HttpServletResponse;
 	CallReportServlet.URL_PATTERN,
 	SearchApiServlet.PATTERN,
 	CardDavServlet.URL_PATTERN,
+	NumServlet.PREFIX + "/*",
 })
 public class BasicLoginFilter extends LoginFilter {
 
@@ -60,7 +63,13 @@ public class BasicLoginFilter extends LoginFilter {
 	}
 	
 	@Override
-	protected void requestLogin(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException {
+	protected void requestLogin(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+		if (NumServlet.PREFIX.equals(request.getServletPath())) {
+			// /api/num/* accepts anonymous access; authentication is only used to
+			// apply personal blacklist/whitelist when a valid token is presented.
+			chain.doFilter(request, response);
+			return;
+		}
 		LOG.debug("Requesting authentication for: {}", request.getServletPath());
 		ServletUtil.sendAuthenticationRequest(response);
 	}
@@ -111,6 +120,7 @@ public class BasicLoginFilter extends LoginFilter {
 		case SearchApiServlet.PREFIX:
 		case SpamCheckServlet.PATH:
 		case TestConnectServlet.PATH:
+		case NumServlet.PREFIX:
 			return authorization.isAccessQuery();
 		case CardDavServlet.DIR_NAME:
 			return authorization.isAccessCarddav();

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/NumServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/NumServlet.java
@@ -13,10 +13,12 @@ import de.haumacher.phoneblock.app.SearchServlet;
 import de.haumacher.phoneblock.app.api.model.PhoneInfo;
 import de.haumacher.phoneblock.app.api.model.PhoneNumer;
 import de.haumacher.phoneblock.app.api.model.Rating;
+import de.haumacher.phoneblock.db.BlockList;
 import de.haumacher.phoneblock.db.DB;
 import de.haumacher.phoneblock.db.DBService;
 import de.haumacher.phoneblock.db.SpamReports;
 import de.haumacher.phoneblock.db.Users;
+import de.haumacher.phoneblock.db.settings.AuthToken;
 import de.haumacher.phoneblock.location.LocationService;
 import de.haumacher.phoneblock.meta.MetaSearchService;
 import de.haumacher.phoneblock.util.ServletUtil;
@@ -32,7 +34,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(urlPatterns = NumServlet.PREFIX + "/*")
 public class NumServlet extends HttpServlet {
 
-	static final String PREFIX = "/api/num";
+	public static final String PREFIX = "/api/num";
 
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -53,6 +55,39 @@ public class NumServlet extends HttpServlet {
 		if (number == null) {
 			ServletUtil.sendError(resp, "Invalid phone number.");
 			return;
+		}
+
+		// For authenticated requests, honor the user's personal blacklist/whitelist
+		// (same semantics as SpamCheckServlet, but by plain phone number instead of
+		// SHA1 hash). Anonymous requests fall through to the public lookup.
+		AuthToken auth = LoginFilter.getAuthorization(req);
+		if (auth != null) {
+			String phoneId = NumberAnalyzer.getPhoneId(number);
+			DB db = DBService.getInstance();
+			try (SqlSession session = db.openSession()) {
+				BlockList blocklist = session.getMapper(BlockList.class);
+				Boolean state = blocklist.getPersonalizationState(auth.getUserId(), phoneId);
+				if (state != null) {
+					PhoneInfo info;
+					if (state.booleanValue()) {
+						// User has personally blocked this number — return real community data
+						// with blackListed flag so the client can force-block.
+						SpamReports reports = session.getMapper(SpamReports.class);
+						info = db.getPhoneApiInfo(reports, phoneId);
+						info.setBlackListed(true);
+					} else {
+						// User has personally whitelisted this number.
+						info = NumberAnalyzer.phoneInfoFromId(phoneId)
+							.setRating(Rating.A_LEGITIMATE);
+					}
+					info.setLabel(number.getShortcut());
+					if (number.hasCity()) {
+						info.setLocation(number.getCity());
+					}
+					ServletUtil.sendResult(req, resp, info);
+					return;
+				}
+			}
 		}
 
 		ServletUtil.sendResult(req, resp, lookup(req, number));


### PR DESCRIPTION
## Summary

- **AnswerBot** (`phoneblock-ab/`, Docker image) now honors the `blackListed` flag on the `/api/check` response and accepts calls from numbers on the authenticated user's personal blacklist regardless of the community vote threshold. Previously those calls were dropped with `Ignoring potential SPAM call … due to vote restriction`.
- **`/api/num/<phone>`** is now symmetric to `/api/check`: when a request carries a valid bearer/cookie/session auth, the endpoint resolves the user's personal blacklist/whitelist and returns a `PhoneInfo` with `blackListed=true` (or rating `A_LEGITIMATE` for a personal whitelist entry). Anonymous access stays untouched — `BasicLoginFilter` was extended to pass `/api/num/*` through when no valid auth is presented instead of sending 401.
- Added a clarifying comment in the AnswerBot call filter explaining why the personal whitelist needs no explicit client handling (server already returns zero votes + `A_LEGITIMATE`).

Fixes #297.

## Out of scope

The PhoneBlock dongle (branch `phoneblock-dongle`) still queries `/api/num/{phone}` in clear text and ignores `blackListed`. It will pick up the server-side personalization automatically once the client is upgraded to evaluate the flag; the privacy improvement (switch to hashed `/api/check`) is tracked in `phoneblock-dongle/PROGRESS.md`.

## Test plan

- [x] `mvn compile -pl phoneblock,phoneblock-ab -am` builds clean
- [x] `mvn test -pl phoneblock -Dtest=TestBasicLoginFilter` passes
- [x] Manual: anonymous `GET /api/num/<phone>` returns the same response as before (no 401, no personalization)
- [x] Manual: authenticated `GET /api/num/<phone>` for a number on the caller's personal blacklist returns `"blackListed": true`
- [ ] Manual: Docker AnswerBot picks up a call from a personally-blacklisted number with < `min-votes` community votes

🤖 Generated with [Claude Code](https://claude.com/claude-code)