### PR TITLE
feat(carddav): StAX render pipeline + lightweight Depth-0 (Hebel B + E)

### DIFF
--- a/docs/plans/2026-05-02-carddav-performance.md
+++ b/docs/plans/2026-05-02-carddav-performance.md
@@ -20,50 +20,58 @@ einen geänderten URL-Schemastand und machen Vollsync).
 
 Strukturelle Beobachtungen aus dem Live-Log:
 
-- Cache-Miss-Logs (`Address book computed for: …`) feuern pro User-Sync: bei
-  iOS-Polling alle 18 min und Cache-TTL 5 / 15 min ist der `_userCache` immer
-  stale, wenn der Client wiederkommt. Funktional OK (`_numberCache` warm,
-  ETag stabil → nächster Sync mit `If-None-Match` wird 304), aber jeder Poll
-  läuft durch den Compute-Pfad und allokiert eine eigene
-  `AddressBookResource` mit ~700 `AddressResource`-Wrappern. Drei
-  common-only-User mit je 715 Blocks innerhalb einer Sekunde sind nichts
-  Ungewöhnliches im Log — genau die Verschwendung, die Hebel C / Stufe 2
-  adressieren würde.
-- Verbleibende Last sitzt vermutlich überwiegend auf dem FritzBox-Pfad: 72 %
-  der Requests, davon 50 % Auth-401-Roundtrips ohne Nutzdaten und 50 %
-  gerenderte 207-Antworten ohne `If-None-Match`-Support. Hebel A wirkt dort
-  per Design nicht.
+- iOS pollt alle ~18 min mit PROPFIND Depth: 0 und fragt nur
+  Collection-Metadaten (`getctag`/`getetag`/`displayname`/`resourcetype`).
+  Diese Requests setzen **kein** `If-None-Match` — A3 greift dort also nicht,
+  alle Antworten bleiben 207 (~3.5 KB Body). iOS vergleicht den ctag
+  clientseitig und zieht den großen Depth: 1-Sync nur, wenn der ctag sich
+  geändert hat (im 4-h-Slice einmal beobachtet beim Übergang
+  1086 → 1087 Blocks). Trotzdem materialisiert der Server pro Mini-PROPFIND
+  eine volle `AddressBookResource` mit ~1086 `AddressResource`-Wrappern, nur
+  um den ETag aus den Wrappern zu hashen. Genau die Verschwendung, auf die
+  Hebel E zielt.
+- FritzBox macht **keinen** ctag-basierten Sync — jeder ihrer Polls (täglich)
+  ist ein Full-Sync mit Depth: 1. Damit ist die volle Block-Materialisierung
+  + 207-Render der dominante Pfad: 72 % des Volumens, davon 50 %
+  Auth-401-Roundtrips ohne Nutzdaten und 50 % gerenderte 207-Antworten ohne
+  `If-None-Match`-Support. Hebel A wirkt dort per Design nicht; das ist die
+  Domäne von Hebel B (StAX-Render) und Hebel C (geteilte Resource pro
+  `ListType`).
 
 ## Nächste Schritte
 
 In dieser Reihenfolge, jeweils mit klarer Wirkungs-Hypothese:
 
-1. **Cache-TTL hochziehen.** Quick-Win, ein paar Konstanten in
-   `AddressBookCache.Cache`. Heute 5 min unused / 15 min max — das stammt aus
-   der Zeit, als `getReports` live aus NUMBERS las. Mit dem published-Snapshot
-   und dem Release-Hook (`flushAllCaches` um 22:00) ist Staleness nur noch via
-   Release möglich; alle anderen Invalidate-Pfade sind explizit
-   (`flushUserCache` bei Settings-Change und PUT). Vorschlag 6 h / 24 h.
-   Memory-Schätzung: pro User-Cache-Eintrag ~50 KB, bei realistisch 7000
-   aktiven Usern in einem 6-h-Fenster ~350 MB. Wirkung: weniger Compute, weniger
-   Allokation, leiseres Log; auf den 304-Anteil hat das keinen Einfluss.
-2. **Hebel B (StAX-Streaming-Render).** Wirkt auf jede 207-Antwort, also auch
-   auf die FritzBox. Ersetzt DOM-Aufbau + `LSSerializer` durch direkten
-   `XMLStreamWriter` in den Output-Stream. Erwarteter Effekt: Faktor 2-3
-   schnellerer Render und drastisch weniger Heap-Druck.
+1. **Hebel E — Depth-0-PROPFIND ohne Block-Materialisierung.** Wirkt auf
+   ctag-basierte Clients, primär iOS (~21 % Volumen, alle 18 min ein
+   PROPFIND Depth: 0 pro aktivem Gerät). Die Mini-PROPFIND-Antwort hängt nur
+   an Collection-Metadaten + ETag, nicht an den Block-Children. ETag
+   inputbasiert berechnen aus Common-ETag (auf `CommonList` mitgehalten) +
+   Personal-Hash + `ListType.hashCode()`. Statt 1086
+   `AddressResource`-Wrappern pro Poll: ein paar Set-Probes und ein
+   SHA-1-Update. `_userCache` bleibt eine kurze Sync-Session-Brücke und
+   bekommt explizit *keine* längere TTL — ~50 KB pro Eintrag × Userzahl ×
+   TTL-Fenster skaliert nicht im Heap. Details in Hebel E unten.
+2. **Hebel B (StAX-Streaming-Render).** Wirkt auf jeden 207-Render mit Body —
+   das ist vor allem der FritzBox-Pfad, der jeden Sync als Depth: 1-Full-Sync
+   fährt (72 % Volumen, kein ctag-Skip). Ersetzt DOM-Aufbau + `LSSerializer`
+   durch direkten `XMLStreamWriter` in den Output-Stream. Erwarteter Effekt:
+   Faktor 2-3 schnellerer Render und drastisch weniger Heap-Druck.
 3. **Hebel C (geteilte `AddressBookResource` pro `ListType`).** Setzt die in
    Hebel A bereits angedeutete Stufe 2 um: `AddressBookResource` ist heute
    user-spezifisch, obwohl der Inhalt für alle no-personalization-User
-   identisch ist. Eine geteilte Instanz pro `ListType` eliminiert
-   ~21k redundante Wrapper-Allokationen. Erfordert HREF-Schema-Entscheidung
-   (relativ vs. absolut mit Render-Time-Substitution).
+   identisch ist. Eine geteilte Instanz pro `ListType` eliminiert ~21k
+   redundante Wrapper-Allokationen pro FritzBox-Welle. Erfordert
+   HREF-Schema-Entscheidung (relativ vs. absolut mit
+   Render-Time-Substitution).
 4. **Hebel D (FritzBox-Auth-Loop).** Heute 3 RPS reine 401-Antworten. Lohnt
    sich erst wenn Hebel B/C ausgeschöpft sind, denn Hebel D braucht
    Reverse-Proxy-Konfiguration oder Auth-Filter-Tuning und ist nicht trivial
    für tokenbasierte Auth.
 
-Schritt 1 ist klein und in eigenständig deploybar. Schritt 2 ist der nächste
-große Hebel; Schritt 3 ist der Folgeschritt, der Hebel B in seiner Wirkung
+Schritt 1 ist klein und eigenständig deploybar (reine Server-interne
+Refaktorierung, keine URL-/ID-Änderung). Schritt 2 ist der nächste große
+Hebel; Schritt 3 ist der Folgeschritt, der Hebel B in seiner Wirkung
 verstärkt (weniger gerenderte 207, plus pro Render weniger Wrapper-Bauen).
 
 ## Was nach Hebel A schon korrekt ist (gegen den ursprünglichen Plan)
@@ -251,18 +259,23 @@ Bei jedem PROPFIND/REPORT:
 Jeder FritzBox-CardDAV-Request kommt zweimal an: erst 401-Challenge, dann mit
 `Authorization`-Header. Verdoppelt die FritzBox-Last.
 
-### Damals verworfen — Common-Number-Cache-TTL hochziehen
+### Verworfen — Cache-TTL hochziehen
 
 Beim Original-Design der Optimierung argumentiert: bei 8.6 RPS Gesamtlast wird
 der `_numberCache` ohnehin permanent warm gehalten, Misses sind nicht der
 dominante Cost.
 
-**Nach Rollout neu bewertet:** Das Argument galt für `_numberCache` und stimmt
-weiterhin. Aber für den **`_userCache`** ist es falsch — pro User-Sync ein
-eigener Eintrag, und mit TTL 15 min < 18 min iOS-Polling ist quasi jeder Poll
-ein Cache-Miss. Mit dem neuen Release-Hook wird der Cache ohnehin nur einmal
-am Tag (22:00) und ad-hoc bei Settings/PUT-Änderungen invalidiert. TTLs auf
-6 h / 24 h zu setzen (siehe "Nächste Schritte") ist jetzt der Standard-Move.
+**Nach Rollout zwischenzeitlich revisited** — Beobachtung war: für den
+`_userCache` ist 15 min TTL < 18 min iOS-Polling, jeder Poll ein Miss. Idee
+TTL auf 6 h / 24 h zu setzen.
+
+**Wieder verworfen:** ~50 KB pro User-Cache-Eintrag × Userzahl × Fensterdauer
+skaliert nicht im Heap (~350 MB allein für ein 6-h-Fenster bei 7000 aktiven
+Usern, und faktisch wären es alle Sync-aktiven User der letzten 24 h). Der
+`_userCache` ist konzeptionell eine Sync-Session-Brücke, kein Long-Term-Cache.
+Stattdessen Hebel E: ETag und Mini-PROPFIND-Antwort aus den Inputs erzeugen,
+ohne pro Poll eine Materialisierung zu provozieren. Damit wird der `_userCache`
+für den iOS-Pfad ohnehin nicht mehr getroffen.
 
 ### Verworfen — sync-collection (RFC 6578)
 
@@ -541,11 +554,22 @@ extrahieren, dort testen — keine Servlet-Container-Infrastruktur nötig:
 
 #### Erwartete Wirkung
 
-- 304-Anteil bei iOS/macOS/DAVx5/PeopleSync sollte hoch werden — wie hoch
-  hängt davon ab, wie häufig die effektive Block-ID-Menge wirklich kippt
-  (= Top-K-Mitgliedschaftswechsel + lokale Bucket-Splits an der 9er-Grenze).
-- Realistisches Ziel: ~70–90% der Apple/Android-PROPFINDs werden 304.
-- Reduktion der CardDAV-CPU-Last: geschätzt 20–25%.
+Original-Annahme: ~70-90 % der Apple/Android-PROPFINDs werden 304;
+CardDAV-CPU-Last −20 bis −25 %.
+
+**Stand 2026-05-02 (Live-Log nach Rollout):** Die 304-Quote auf iOS ist 0 % —
+nicht weil der ETag instabil ist, sondern weil iOS bei Mini-PROPFINDs (Depth:
+0) **kein** `If-None-Match` setzt. iOS verwendet stattdessen den
+`getctag`-Wert clientseitig zur Sync-Entscheidung und springt nur dann in den
+großen Depth: 1-Sync, wenn der ctag sich geändert hat. PeopleSync-Pfad
+funktional korrekt (ist vor Rollout verifiziert worden); macOS und DAVx5
+verhalten sich vermutlich wie iOS, das bestätigt sich live mit der gleichen
+0 %-Quote. CPU-Last hat sich nach Rollout etwa halbiert — Beitrag aus Hebel A
+ist der stabile ctag (kein Vollsync mehr bei jedem Vote), nicht der
+304-Pfad.
+
+Konsequenz: die Wirkung auf den iOS-Pfad muss aus Hebel E kommen
+(Materialisierung pro Poll vermeiden), nicht aus 304.
 
 ### Hebel B — Render-Pfad: DOM → StAX
 
@@ -616,28 +640,106 @@ Speicher: ~30 aktive Listen-Varianten (siehe Listen-Varianten-Abschnitt) à
 PhoneBlock-Auth ist tokenbasiert, nicht trivial. Erst angehen, wenn A + B
 ausgeschöpft sind.
 
+### Hebel E — Depth-0-PROPFIND ohne Block-Materialisierung
+
+**Wirkt auf:** Clients, die per ctag synchronisieren und Mini-PROPFINDs ohne
+`If-None-Match` schicken — primär iOS / `dataaccessd` (~21 % Volumen, p50
+18 min Polling, ein PROPFIND Depth: 0 pro Poll). macOS und DAVx5 zeigen
+denselben Pfad in deutlich kleinerem Volumen. **Nicht** auf FritzBox: deren
+PROPFINDs sind Depth: 1 und ziehen jedes Mal die volle Block-Liste.
+
+#### Beobachtung
+
+iOS-Mini-PROPFIND (~3.5 KB Antwort) fragt nur Collection-Properties
+(`getctag`/`getetag`/`displayname`/`resourcetype`, optional
+`current-user-principal`). Der Server materialisiert dafür heute eine volle
+`AddressBookResource` mit ~1086 `AddressResource`-Wrappern, weil
+`AddressBookResource.getEtag()` über die schon konstruierten Wrapper hasht.
+Ein 304 ist nicht möglich, weil iOS kein `If-None-Match` setzt.
+
+#### Idee
+
+1. **Collection-ETag inputbasiert berechnen.** Inputs sind alle in der
+   Cache-Hierarchie schon vorhanden:
+   - **Common-ETag** pro `ListType`: in `CommonList` mitgehalten und einmal
+     pro Release berechnet — Hash über die sortierten Block-IDs +
+     Block-ETags der `_numberCache`-Liste.
+   - **Personal-Hash**: Hash über die deduplizierte Personal-Singleton-Menge
+     (Personalisations nach `common.covers(...)`-Filter) und
+     `personalSettingsHash(personalizations, exclusions)`.
+   - **Settings-Hash**: `ListType.hashCode()`.
+
+   Kosten pro Aufruf: 1 × `getUserId`, 1 × `getPersonalizations`, 1 ×
+   `getExcluded`, ein paar Set-Probes gegen `commonNumbers` /
+   `commonWildcards`, ein SHA-1-Update.
+2. **`AddressBookCache.lookupCollectionMeta(principal, settings)`** liefert
+   ein kleines Wertobjekt `(etag, displayname, path)` ohne
+   `AddressBookResource`-Konstruktion. Verzweigt intern wie heute zwischen
+   common-only / common+personal / full-pipeline; nur die ~98 effektive
+   Exclusion-User landen weiterhin auf dem materialisierenden Pfad.
+3. **`CardDavServlet.doPropfind`** zweigt für Depth: 0 auf den
+   Address-Book-Pfad in einen Lightweight-Renderer ab, der direkt in den
+   Response-Stream schreibt:
+   - `<href>` der Collection
+   - `<displayname>BLOCKLIST</displayname>`
+   - `<resourcetype><collection/><cs:addressbook/></resourcetype>`
+   - `<getctag>{etag}</getctag>`, `<getetag>"{etag}"</getetag>`
+   - `<current-user-principal>` aus dem Login-Context
+
+   Keine Block-Information, keine Wrapper, keine vCards.
+4. **Depth: 1-PROPFIND und REPORT mit Body** laufen unverändert durch
+   `lookupAddressBook` — dort bleibt die Materialisierung notwendig, weil
+   tatsächlich Children gerendert werden. Hebel C kann diesen Pfad weiter
+   reduzieren.
+
+#### Effekt
+
+- iOS-Polling-Pfad (1 PROPFIND alle 18 min × ~5k aktive Geräte ≈ 4–5 RPS)
+  kostet künftig nur noch DB-Reads + ein paar Bytes Stream-Output. Keine
+  Wrapper-Allokation, kein Top-K-Bauen pro Poll.
+- `_userCache` darf auf der heutigen kurzen TTL bleiben — sein Job ist nur
+  noch die Sync-Session-Brücke für Depth: 1-Renders. TTL hochziehen wäre
+  weiterhin falsch (Heap-Skalierung).
+- Kein 304-Effekt — die Mini-PROPFINDs bleiben 207, weil iOS so synct. Aber
+  sie kosten nichts mehr.
+
+#### Migration / Risiko
+
+- Reine Server-interne Refaktorierung. Keine ID-/URL-Änderungen, kein
+  Cache-Invalidate beim Deploy, keine Client-Welle.
+- Test: Property-für-Property-Vergleich der Lightweight-Antwort gegen die
+  heutige Materialisierungsantwort auf einem konstruierten Fixture
+  (verschiedene `ListType`s, common-only / common+personal /
+  full-pipeline-User). Plus: ETag aus dem Lightweight-Pfad muss byteweise
+  identisch zum ETag aus dem Full-Pfad sein, damit Clients-Caches kohärent
+  bleiben.
+
 ## Reihenfolge / Entscheidungspunkte
 
-1. **Hebel A umsetzen** (A1–A4) als zusammenhängender Wechsel — A1 allein bringt
-   nichts, A2/A3 ohne A1 kippt der ETag zu oft, A4 ist die Erweiterung auf
-   personalisierte User.
-2. **Wirkung messen** — 304-Quote pro User-Agent aus Access-Logs, CPU-Last
-   vor/nach.
-3. **Entscheidung:** Reicht Hebel A?
-   - Wenn ja: B/C zurückstellen.
-   - Wenn nein: Hebel B (StAX) als nächster Schritt — wirkt auf alle
-     verbleibenden 207-Renders inkl. FritzBox.
-4. **Hebel C** nur, wenn auch nach A + B noch CPU-Last auf der CardDAV-Strecke
-   dominant ist.
-5. **Hebel D** unabhängig, falls FritzBox-Auth-Roundtrips ein nennenswerter
+1. **Hebel A** (A1–A4) ist umgesetzt und live. Beobachtung siehe "Status nach
+   Hebel A": stabiler ctag wirkt, 304-Pfad bleibt ungenutzt weil iOS kein
+   `If-None-Match` schickt.
+2. **Hebel E (Lightweight Depth-0)** — der Move für den iOS-Pfad. Klein,
+   eigenständig deploybar, keine Client-Migration.
+3. **Wirkung messen** — Anzahl `Address book computed for: …`-Logs pro
+   Stunde (sollte für common-only und common+personal-User auf ~0 fallen),
+   CPU-Last vor/nach.
+4. **Hebel B (StAX)** — der Move für den FritzBox-Pfad. FritzBox macht
+   Depth: 1-Full-Sync, das ist der teure Render und bleibt nach Hebel E die
+   dominante Last.
+5. **Hebel C** verstärkt Hebel B für common-only-User (geteilte Resource pro
+   `ListType`); Reihenfolge B-dann-C, weil C ohne den schlanken Render von B
+   weniger trägt.
+6. **Hebel D** unabhängig, falls FritzBox-Auth-Roundtrips ein nennenswerter
    Anteil der verbleibenden Last sind.
 
 ## Nicht zum Plan gehörig
 
 - `sync-collection`-Implementierung (RFC 6578) — separates Thema.
 - Antwort-Komprimierung via `gzip` — kostet zusätzliche CPU, spart Bandbreite.
-- Cache-TTL-Tuning — wurde initial als unwirksam ausgeschlossen, ist nach
-  Rollout für `_userCache` aber wieder auf der Liste (siehe "Nächste
-  Schritte").
+- Cache-TTL-Tuning — initial als unwirksam ausgeschlossen, nach
+  Rollout-Beobachtung kurz wieder erwogen, dann als nicht-skalierend
+  verworfen (Heap pro User × Userzahl × TTL-Fenster). Siehe "Verworfen —
+  Cache-TTL hochziehen".
 - Modifikation der Top-K- oder Wildcard-Schwellen — verstößt gegen den
   Semantik-Constraint.

--- a/docs/plans/2026-05-02-carddav-performance.md
+++ b/docs/plans/2026-05-02-carddav-performance.md
@@ -38,41 +38,67 @@ Strukturelle Beobachtungen aus dem Live-Log:
   Domäne von Hebel B (StAX-Render) und Hebel C (geteilte Resource pro
   `ListType`).
 
+## Status nach Hebel B + E (umgesetzt)
+
+Hebel B (StAX-Render) und Hebel E (Lightweight Depth-0) sind in einem
+gemeinsamen Branch gebaut, weil sie beide den Render-Pfad anfassen — siehe
+Implementierungsplan
+[2026-05-02-carddav-render-pipeline.md](2026-05-02-carddav-render-pipeline.md).
+Vier Phasen, ein PR:
+
+1. Pipeline auf StAX umgestellt — `Resource`-Hierarchie schreibt direkt per
+   `XMLStreamWriter` in den Output-Stream. DOM und `LSSerializer` raus.
+   Schmaler `RenderContext` statt `HttpServletRequest`,
+   `MultiStatusWriter`-Helper für die Envelope, `CardDavRequestParser` für
+   die Body-Parser.
+2. Collection-ETag inputbasiert komponiert via `CollectionEtag` — Common-
+   Blocks-Hash auf der `CommonList` einmal pro Refresh berechnet,
+   Personal-Singletons-Hash und Settings-Hash pro Aufruf in
+   konstanter Zeit.
+3. `AddressBookCollectionResource` als schlanke `Resource`-Subklasse für
+   Depth: 0 PROPFIND. `AddressBookCache.lookupCollectionEtag` umgeht die
+   Materialisierung der ~1086 `AddressResource`-Wrapper pro iOS-Poll.
+4. DOM-Output-Helper aus `DomUtil` entfernt.
+
+Erwartete Effekte (zu verifizieren nach Deploy):
+
+- iOS-Polling-Pfad kostet praktisch nichts mehr —
+  `Address book computed for: …`-Logs fallen für common-only und
+  common+personal-User auf null, weil der `_userCache` für Depth-0-
+  PROPFINDs nicht mehr getroffen wird.
+- FritzBox-Full-Syncs (72 % Volumen, alle Depth: 1) renderen jetzt per
+  StAX direkt in den Output-Stream — Faktor 2-3 schneller, weniger
+  Heap-Druck.
+- ETag-Migrationswelle einmalig beim Deploy: alle Clients sehen einen
+  neuen ETag-Wert (Komposition geändert), machen einen Vollsync, danach
+  stationärer Zustand.
+
 ## Nächste Schritte
 
 In dieser Reihenfolge, jeweils mit klarer Wirkungs-Hypothese:
 
-1. **Hebel E — Depth-0-PROPFIND ohne Block-Materialisierung.** Wirkt auf
-   ctag-basierte Clients, primär iOS (~21 % Volumen, alle 18 min ein
-   PROPFIND Depth: 0 pro aktivem Gerät). Die Mini-PROPFIND-Antwort hängt nur
-   an Collection-Metadaten + ETag, nicht an den Block-Children. ETag
-   inputbasiert berechnen aus Common-ETag (auf `CommonList` mitgehalten) +
-   Personal-Hash + `ListType.hashCode()`. Statt 1086
-   `AddressResource`-Wrappern pro Poll: ein paar Set-Probes und ein
-   SHA-1-Update. `_userCache` bleibt eine kurze Sync-Session-Brücke und
-   bekommt explizit *keine* längere TTL — ~50 KB pro Eintrag × Userzahl ×
-   TTL-Fenster skaliert nicht im Heap. Details in Hebel E unten.
-2. **Hebel B (StAX-Streaming-Render).** Wirkt auf jeden 207-Render mit Body —
-   das ist vor allem der FritzBox-Pfad, der jeden Sync als Depth: 1-Full-Sync
-   fährt (72 % Volumen, kein ctag-Skip). Ersetzt DOM-Aufbau + `LSSerializer`
-   durch direkten `XMLStreamWriter` in den Output-Stream. Erwarteter Effekt:
-   Faktor 2-3 schnellerer Render und drastisch weniger Heap-Druck.
-3. **Hebel C (geteilte `AddressBookResource` pro `ListType`).** Setzt die in
-   Hebel A bereits angedeutete Stufe 2 um: `AddressBookResource` ist heute
-   user-spezifisch, obwohl der Inhalt für alle no-personalization-User
-   identisch ist. Eine geteilte Instanz pro `ListType` eliminiert ~21k
-   redundante Wrapper-Allokationen pro FritzBox-Welle. Erfordert
-   HREF-Schema-Entscheidung (relativ vs. absolut mit
-   Render-Time-Substitution).
-4. **Hebel D (FritzBox-Auth-Loop).** Heute 3 RPS reine 401-Antworten. Lohnt
-   sich erst wenn Hebel B/C ausgeschöpft sind, denn Hebel D braucht
-   Reverse-Proxy-Konfiguration oder Auth-Filter-Tuning und ist nicht trivial
-   für tokenbasierte Auth.
+1. **Wirkung messen.** Live-Logs nach Deploy: `Address book computed for: …`
+   pro Stunde (sollte für common-only/common+personal-User auf null
+   fallen), CPU-Last vor/nach, FritzBox-Render-Zeit. Bestimmt, ob
+   Hebel C noch nötig ist.
+2. **Hebel C (geteilte `AddressBookResource` pro `ListType`).** Setzt die
+   in Hebel A bereits angedeutete Stufe 2 um. `AddressBookResource` ist
+   heute user-spezifisch, obwohl der Inhalt für alle no-personalization-
+   User identisch ist. Eine geteilte Instanz (oder ein vorgerenderter
+   `byte[]`-Cache) pro `ListType` eliminiert ~21k redundante Wrapper-
+   Allokationen pro FritzBox-Welle. Erfordert HREF-Schema-Entscheidung
+   (relativ vs. absolut mit Render-Time-Substitution). Macht nach
+   Hebel B in der Render-Geschwindigkeit den größten verbleibenden
+   Sprung.
+3. **Hebel D (FritzBox-Auth-Loop).** Heute 3 RPS reine 401-Antworten.
+   Lohnt sich erst wenn Hebel B/C ausgeschöpft sind, denn Hebel D braucht
+   Reverse-Proxy-Konfiguration oder Auth-Filter-Tuning und ist nicht
+   trivial für tokenbasierte Auth.
 
-Schritt 1 ist klein und eigenständig deploybar (reine Server-interne
-Refaktorierung, keine URL-/ID-Änderung). Schritt 2 ist der nächste große
-Hebel; Schritt 3 ist der Folgeschritt, der Hebel B in seiner Wirkung
-verstärkt (weniger gerenderte 207, plus pro Render weniger Wrapper-Bauen).
+Schritt 1 (Messung) ist nur eine Beobachtung post-Deploy — keine
+Code-Änderung. Schritt 2 ist der größte verbleibende Render-Hebel;
+Schritt 3 ist orthogonal zur Render-Optimierung und kann unabhängig
+angegangen werden.
 
 ## Was nach Hebel A schon korrekt ist (gegen den ursprünglichen Plan)
 
@@ -571,7 +597,7 @@ ist der stabile ctag (kein Vollsync mehr bei jedem Vote), nicht der
 Konsequenz: die Wirkung auf den iOS-Pfad muss aus Hebel E kommen
 (Materialisierung pro Poll vermeiden), nicht aus 304.
 
-### Hebel B — Render-Pfad: DOM → StAX
+### Hebel B — Render-Pfad: DOM → StAX (umgesetzt)
 
 **Wirkt auf:** Alle verbleibenden 207-Antworten, vor allem die großen
 iOS- (68 KB) und macOS-Antworten (169 KB), sowie alle FritzBox-Renders
@@ -640,7 +666,7 @@ Speicher: ~30 aktive Listen-Varianten (siehe Listen-Varianten-Abschnitt) à
 PhoneBlock-Auth ist tokenbasiert, nicht trivial. Erst angehen, wenn A + B
 ausgeschöpft sind.
 
-### Hebel E — Depth-0-PROPFIND ohne Block-Materialisierung
+### Hebel E — Depth-0-PROPFIND ohne Block-Materialisierung (umgesetzt)
 
 **Wirkt auf:** Clients, die per ctag synchronisieren und Mini-PROPFINDs ohne
 `If-None-Match` schicken — primär iOS / `dataaccessd` (~21 % Volumen, p50

--- a/docs/plans/2026-05-02-carddav-render-pipeline.md
+++ b/docs/plans/2026-05-02-carddav-render-pipeline.md
@@ -1,0 +1,221 @@
+# CardDAV-Render-Pipeline — Implementierungsplan (Hebel E + B)
+
+## Zweck
+
+Konkreter Implementierungsplan für die Hebel E (Lightweight Depth-0) und B
+(StAX-Render) aus
+[2026-05-02-carddav-performance.md](2026-05-02-carddav-performance.md).
+Beide Hebel berühren denselben Render-Code; einzeln nacheinander gebaut
+ergäbe das doppelte Umstellung. Plan beschreibt einen kohärenten Umbau der
+Render-Pipeline, in dem E und B gemeinsam landen.
+
+## Constraints
+
+- **vCard-Inhalt unverändert** — Block-Titel, TEL-Einträge, CATEGORIES wie
+  heute. Hebel A hat das schon eingestellt.
+- **HREFs bleiben absolut** — der Kommentar in `Resource.java:264–271`
+  beschreibt, dass relative HREFs einen FritzBox-DELETE-Bug auslösen.
+  Reverse-Evaluierung gehört nicht in diesen Plan, sondern zu Hebel C.
+- **ETag im stationären Zustand stabil**, einmalige Migrationswelle beim
+  Deploy ist akzeptiert (wie bei Hebel A): die ETag-Komposition ändert sich
+  bei der Umstellung von Wrapper-Hash auf Input-Hash, alle Clients machen
+  einmal Vollsync. Danach ETag stabil über `CommonList.commonEtag` +
+  Personal-Hash + `ListType.hashCode()`.
+- **XML-Output äquivalent** — kanonisch identisch zum heutigen Output (das
+  ist die testbare Bedingung); kosmetische Whitespace-Unterschiede sind
+  tolerabel, sofern alle relevanten Clients den Output akzeptieren (Live-
+  Smoke gegen iOS und FritzBox auf Staging).
+
+## Code-Berührung
+
+- `de.haumacher.phoneblock.carddav.CardDavServlet` — `doPropfind`,
+  `doReport`, `marshalMultiStatus` (entfällt).
+- `de.haumacher.phoneblock.carddav.resource.Resource` — `propfind`,
+  `fillProperty`, `quote` (umbenannt nach `EtagUtil` schon erledigt).
+- `RootResource`, `PrincipalResource`, `AddressBookResource`,
+  `AddressResource` — Override-Methoden auf neue Write-API.
+- `AddressBookCache` — `lookupCollectionMeta` neu, `CommonList` bekommt
+  `commonEtag`.
+- `de.haumacher.phoneblock.util.DomUtil` — Output-Helper (`appendElement`,
+  `appendText`, `appendTextElement`) entfallen für Resource-Hierarchie;
+  Eingangs-Parsing (Request-Body) bleibt.
+
+## Render-API
+
+Neue Signatur auf `Resource`:
+
+```java
+public abstract void propfind(HttpServletRequest req, Resource parent,
+    XMLStreamWriter writer, List<QName> properties) throws XMLStreamException;
+
+public int fillProperty(HttpServletRequest req, XMLStreamWriter writer,
+    QName property) throws XMLStreamException;
+```
+
+Multistatus-Envelope öffnet/schließt `CardDavServlet`:
+
+```java
+XMLOutputFactory factory = XMLOutputFactory.newInstance();
+XMLStreamWriter writer = factory.createXMLStreamWriter(
+    resp.getOutputStream(), "UTF-8");
+writer.writeStartDocument("UTF-8", "1.0");
+writer.setPrefix("d", DavSchema.DAV_NS);
+writer.setPrefix(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
+writer.writeStartElement(DavSchema.DAV_NS, "multistatus");
+writer.writeNamespace("d", DavSchema.DAV_NS);
+writer.writeNamespace(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
+// resource.propfind(req, null, writer, properties);
+// for child : resource.list() child.propfind(req, resource, writer, properties);
+writer.writeEndElement();
+writer.writeEndDocument();
+writer.flush();
+```
+
+Achtung beim Namespace-Handling: `setPrefix` muss **vor**
+`writeStartElement` für jedes verwendete Namespace passieren, sonst
+generiert der Writer ungewollt `xmlns:ns0`-artige Bindings. Ein
+gemeinsamer Helper `openMultiStatus(writer)` / `closeMultiStatus(writer)`
+fasst das zusammen.
+
+## Phasen
+
+### Phase 1 — Pipeline auf StAX umstellen
+
+Eine kohärente Änderung über den ganzen Resource-Baum. Doppel-API mit DOM
+parallel ist unnötig — der Code ist überschaubar (Resource + 4
+Subklassen), und ein sauberer Diff hilft mehr als eine Übergangsphase.
+
+1. `Resource.propfind` und `fillProperty` auf `XMLStreamWriter`-Signatur
+   umstellen. `quote(...)` ist schon in `EtagUtil` ausgelagert.
+2. `RootResource`, `PrincipalResource`, `AddressBookResource`,
+   `AddressResource`: alle `appendElement`-/`appendText`-Aufrufe durch
+   `writer.writeStartElement` / `writer.writeCharacters` /
+   `writer.writeEndElement` ersetzen.
+3. `CardDavServlet.doPropfind` und `doReport`: DOM-Document-Aufbau durch
+   Stream-Envelope ersetzen, `marshalMultiStatus` entfällt. Conditional-
+   GET-Pfad (`If-None-Match` → 304) bleibt unverändert.
+4. `AddressResource.fillProperty` für die `address-data`-Property
+   schreibt `vCardContent()` direkt per `writer.writeCharacters` in den
+   Stream — keine Zwischen-Stringifizierung in eine `Element`-Textnode.
+
+**Test**: ein neuer Equivalence-Test rendert das Multistatus-Output für
+einen Fixture-`AddressBook` einmal über den (kurz noch parallel
+mitgehaltenen) DOM-Pfad und einmal über den neuen Stream-Pfad und
+vergleicht XML-kanonisch (z. B. `Canonicalizer` aus `xmlsec`, oder
+einfacher: beide Outputs durch denselben DOM-Parser jagen und per
+`isEqualNode()` vergleichen). Sobald grün, DOM-Pfad löschen.
+
+### Phase 2 — ETag inputbasiert
+
+1. `AddressBookCache.CommonList` bekommt ein berechnetes Feld
+   `commonEtag`: SHA-1 über die sortierten Block-IDs und Block-ETags der
+   `_blocks`-Liste, einmal beim Konstruktor mitberechnet (gleiche Kosten
+   wie heute beim ersten `getEtag`-Aufruf einer common-only-Resource,
+   aber zentral und gecacht).
+2. `AddressBookResource.getEtag()` wird zu:
+   ```
+   Hash(commonEtag, personalHash, listType.hashCode())
+   ```
+   wobei `personalHash` über die deduplizierten Personal-Singletons +
+   `personalSettingsHash(personalizations, exclusions)` läuft. Keine
+   Iteration mehr über `_addressById`.
+3. Für den full-pipeline-Pfad (effektive Exclusions, ~98 User) bleibt der
+   alte Hash-Pfad oder bekommt eine eigene Komposition mit demselben
+   Endergebnis-Format (12-Hex-SHA-1-Prefix).
+
+**Migrations-Effekt**: ETag-Komposition ändert sich beim Deploy einmal —
+alle Clients sehen einen neuen Wert, machen Vollsync. Akzeptiert.
+
+**Test**: für drei Beispiel-User (common-only, common+personal,
+full-pipeline) Stabilität über mehrere `getEtag`-Aufrufe (= byteidentisch
+bei identischen Inputs) und Sensitivität gegenüber: einer einzelnen
+Personal-Nummer mehr/weniger, einer einzelnen Common-Block-Änderung,
+geändertem `ListType`.
+
+### Phase 3 — Lightweight Depth-0-Pfad
+
+1. `AddressBookCache.lookupCollectionMeta(principal, settings)` liefert
+   `record CollectionMeta(String etag, String displayName, String path)`
+   ohne `AddressBookResource`-Konstruktion. Verzweigt intern wie der
+   heutige `computeBlocks`-Pfad zwischen common-only / common+personal /
+   full-pipeline; nutzt für die ersten beiden Pfade nur den
+   `_numberCache` und die `getPersonalizations` / `getExcluded`-Reads.
+   Für full-pipeline materialisiert sie wie heute (selten genug, ~98
+   User).
+2. `CardDavServlet.doPropfind` erkennt **Depth: 0** + Pfad-Match auf
+   `/addresses/{user}/`, ruft `lookupCollectionMeta`, ruft Helper
+   `writeAddressBookCollectionProps(writer, req, meta, properties)`. Kein
+   `getResource(req)`, kein `lookupAddressBook`.
+3. `writeAddressBookCollectionProps` wird **auch** vom Heavy-Pfad
+   (`AddressBookResource.propfind` für Depth: 1) für die Collection-
+   Eigen-Response verwendet. Eine Implementierung, beide Pfade.
+4. Die Address-Book-Children im Heavy-Pfad bleiben über
+   `resource.list()` + `child.propfind(...)` wie heute.
+
+**Test**: Goldfile-Vergleich der Depth-0-Antwort gegen den heutigen
+Output für common-only, common+personal, full-pipeline. ETag aus
+`CollectionMeta` byteidentisch zu `AddressBookResource.getEtag()` für
+denselben User+Settings.
+
+### Phase 4 — Cleanup
+
+1. `marshalMultiStatus`, alle DOM-`appendXxx`-Aufrufe und ggf.
+   ungenutzte `DomUtil`-Helper löschen.
+2. `_userCache`-TTL und Konstanten in `AddressBookCache.Cache`
+   inspizieren — nach Phase 3 trifft der iOS-Pfad den `_userCache` nicht
+   mehr; TTL bleibt aber für Depth: 1 / REPORT relevant. Heutige Werte
+   (5 / 15 min) wahrscheinlich ok, kurz prüfen.
+3. Dokumentation in `2026-05-02-carddav-performance.md` aktualisieren
+   (Hebel B und Hebel E von "geplant" auf "umgesetzt" verschieben,
+   "Nächste Schritte" auf C und D verkürzen).
+
+## Tests im Detail
+
+- **XML-Equivalenz pro Resource × Property-Set** (Phase 1): konstruierter
+  Fixture-User, Liste der relevanten Properties, kanonischer XML-
+  Vergleich gegen einen Snapshot des heutigen Outputs.
+- **ETag-Stabilität** (Phase 2): selber Input → byteidentischer ETag bei
+  wiederholten Aufrufen; Mutation an Common, Personal oder Settings
+  ändert ETag.
+- **ETag-Identität Lightweight vs. Heavy** (Phase 3): für denselben User
+  liefert `lookupCollectionMeta(...).etag` denselben Wert wie
+  `lookupAddressBook(...).getEtag()`.
+- **Goldfile Depth-0** (Phase 3): heutiger Depth-0-Output vs. neuer
+  Lightweight-Output, kanonisch gleich.
+- **Live-Smoke auf Staging** (vor Merge): iOS-Sync läuft (ctag wird
+  akzeptiert, kein leeres Adressbuch); FritzBox-Sync läuft (Full-Sync
+  gibt korrekte Liste, DELETE-Verhalten unverändert);
+  Conditional-GET-Pfad (PeopleSync) liefert weiterhin 304 bei
+  unverändertem ETag.
+
+## Risiken
+
+- **StAX-Namespace-Handling**: `setPrefix`-Reihenfolge,
+  `writeNamespace`-Aufrufe nur einmal pro Element. Ein einziger
+  zentraler Helper für die Multistatus-Envelope reduziert die
+  Fehlerquellen auf eine Stelle.
+- **XML-Declaration / Whitespace**: heutiger `LSSerializer` produziert
+  ein bestimmtes Layout, StAX ein anderes. Spec-konform sind beide; in
+  der Praxis ist FritzBox-CardDAV historisch pingelig. Goldfile-Test
+  fängt das, Live-Smoke verifiziert.
+- **Migrations-ETag-Welle**: einmaliger Vollsync aller Clients beim
+  Deploy. Deployment-Fenster wählen wie bei Hebel A
+  (Wochenende / Abend), nicht parallel zur 22:00-Release-Welle.
+
+## Out of Scope
+
+- **Hebel C** (pre-rendered `byte[]`-Cache pro `ListType`) — eigener
+  Plan; setzt auf der hier eingezogenen Stream-API auf, also keine
+  Doppelarbeit, aber HREF-Strategie und Cache-Layout sind eigene
+  Entscheidungen.
+- **Hebel D** (FritzBox-Auth-Loop) — unabhängiger Pfad,
+  Reverse-Proxy-Thema.
+- **`sync-collection`-Implementierung** — separates Thema, würde DB-
+  Versionierung benötigen.
+
+## Reihenfolge der Commits
+
+Ein Feature-Branch (dieser), ein PR, Commits in der Reihenfolge der
+Phasen. Phase 1 ist groß genug, dass sie ggf. in zwei Commits
+zerlegbar ist (Resource-Hierarchie umstellen / Servlet umstellen +
+DOM-Pfad löschen). Phasen 2, 3, 4 jeweils eigener Commit.

--- a/docs/plans/2026-05-02-carddav-render-pipeline.md
+++ b/docs/plans/2026-05-02-carddav-render-pipeline.md
@@ -26,14 +26,75 @@ Render-Pipeline, in dem E und B gemeinsam landen.
   tolerabel, sofern alle relevanten Clients den Output akzeptieren (Live-
   Smoke gegen iOS und FritzBox auf Staging).
 
+## Schichtenschnitt
+
+Damit die Render-Logik unit-testbar ohne Servlet-Container wird, müssen
+die `Resource`-Methoden frei von `HttpServletRequest` sein. Heute lesen
+sie genau eine Information aus dem Request — den authentifizierten User
+für `current-user-principal`. Den Rest verarbeitet das Servlet vor dem
+Aufruf.
+
+**Lösung**: schmaler Render-Context als Wertobjekt, kein Servlet-Bezug.
+
+```java
+public record RenderContext(String authenticatedUser, String rootUrl) {}
+```
+
+Die Render-Schicht ist anschließend die `Resource`-Hierarchie selbst —
+**kein separater `Renderer`-Typ**. Polymorphie auf `Resource` ist die
+natürliche Modellierung des Konzepts „jede Resource-Sorte hat ihr
+eigenes Property-Set".
+
+Die einzige geteilte Hilfsfunktion ist die Multistatus-Envelope. Die
+liegt als Mini-Helper in einem neuen `MultiStatusWriter` (statische
+Methoden):
+
+```java
+public final class MultiStatusWriter {
+    public static XMLStreamWriter open(OutputStream out) throws XMLStreamException;
+    public static void close(XMLStreamWriter writer) throws XMLStreamException;
+}
+```
+
+`open(...)` öffnet `<d:multistatus>` mit den nötigen Namespace-Bindings
+(`DAV:`, `CARDDAV`, ggf. `calendarserver.org/ns/`); `close(...)` schließt
+das Element und das Dokument. Ein einziger zentraler Punkt für
+Namespace-Handling — dort wo sonst die meisten StAX-Stolpersteine
+liegen.
+
+Die Servlet-Schicht wird zum dünnen I/O-Adapter:
+
+1. Auth + Resource-Resolution (`getResource(req)`).
+2. Request-Body parsen → `List<QName> properties` bzw.
+   `List<String> hrefs + List<QName> properties`. Beide Parser sind reine
+   Funktionen über `InputStream` und liegen in einem neuen
+   `CardDavRequestParser` (auch unit-testbar).
+3. ETag bestimmen, `If-None-Match` über `EtagUtil` matchen → ggf. 304.
+4. `RenderContext` aus `req` konstruieren (User + rootUrl), Envelope per
+   `MultiStatusWriter.open(...)` öffnen, `resource.propfind(...)` /
+   `resource.renderMultiGet(...)` aufrufen, schließen.
+5. ETag-Header und Status setzen.
+
+Das Servlet hat damit keine XML-Logik mehr, nur Routing + I/O.
+
 ## Code-Berührung
 
 - `de.haumacher.phoneblock.carddav.CardDavServlet` — `doPropfind`,
   `doReport`, `marshalMultiStatus` (entfällt).
+- `de.haumacher.phoneblock.carddav.resource.RenderContext` — neu, kleines
+  Wertobjekt.
+- `de.haumacher.phoneblock.carddav.resource.MultiStatusWriter` — neu,
+  statischer Envelope-Helper.
+- `de.haumacher.phoneblock.carddav.CardDavRequestParser` — neu, reines
+  Input-Parsing (PROPFIND-Body, REPORT-Multiget-Body) ohne
+  Servlet-Bezug.
 - `de.haumacher.phoneblock.carddav.resource.Resource` — `propfind`,
-  `fillProperty`, `quote` (umbenannt nach `EtagUtil` schon erledigt).
+  `fillProperty` auf `XMLStreamWriter`-Signatur und `RenderContext`
+  umstellen.
 - `RootResource`, `PrincipalResource`, `AddressBookResource`,
   `AddressResource` — Override-Methoden auf neue Write-API.
+- `de.haumacher.phoneblock.carddav.resource.AddressBookCollectionResource`
+  — neu, Lightweight-Variante für Depth-0 (siehe Phase 3).
 - `AddressBookCache` — `lookupCollectionMeta` neu, `CommonList` bekommt
   `commonEtag`.
 - `de.haumacher.phoneblock.util.DomUtil` — Output-Helper (`appendElement`,
@@ -42,68 +103,70 @@ Render-Pipeline, in dem E und B gemeinsam landen.
 
 ## Render-API
 
-Neue Signatur auf `Resource`:
+Resource-Methoden ohne Servlet-Abhängigkeit:
 
 ```java
-public abstract void propfind(HttpServletRequest req, Resource parent,
+public abstract void propfind(RenderContext ctx, Resource parent,
     XMLStreamWriter writer, List<QName> properties) throws XMLStreamException;
 
-public int fillProperty(HttpServletRequest req, XMLStreamWriter writer,
+public int fillProperty(RenderContext ctx, XMLStreamWriter writer,
     QName property) throws XMLStreamException;
 ```
 
-Multistatus-Envelope öffnet/schließt `CardDavServlet`:
+Multi-get ist ein Address-Book-Konzept und bekommt eine eigene Methode
+auf `AddressBookResource` (statt im Servlet zu leben):
 
 ```java
-XMLOutputFactory factory = XMLOutputFactory.newInstance();
-XMLStreamWriter writer = factory.createXMLStreamWriter(
-    resp.getOutputStream(), "UTF-8");
-writer.writeStartDocument("UTF-8", "1.0");
-writer.setPrefix("d", DavSchema.DAV_NS);
-writer.setPrefix(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
-writer.writeStartElement(DavSchema.DAV_NS, "multistatus");
-writer.writeNamespace("d", DavSchema.DAV_NS);
-writer.writeNamespace(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
-// resource.propfind(req, null, writer, properties);
-// for child : resource.list() child.propfind(req, resource, writer, properties);
-writer.writeEndElement();
-writer.writeEndDocument();
-writer.flush();
+public void renderMultiGet(RenderContext ctx, XMLStreamWriter writer,
+    List<String> hrefs, List<QName> properties) throws XMLStreamException;
 ```
 
-Achtung beim Namespace-Handling: `setPrefix` muss **vor**
+Sie iteriert intern, schlägt jeden href über `lookupAddress(...)` nach
+und ruft pro Treffer `child.propfind(...)` mit denselben Bausteinen wie
+der Depth-1-Pfad.
+
+Achtung beim Namespace-Handling: `setPrefix` muss **vor** dem ersten
 `writeStartElement` für jedes verwendete Namespace passieren, sonst
-generiert der Writer ungewollt `xmlns:ns0`-artige Bindings. Ein
-gemeinsamer Helper `openMultiStatus(writer)` / `closeMultiStatus(writer)`
-fasst das zusammen.
+generiert der Writer ungewollt `xmlns:ns0`-artige Bindings.
+`MultiStatusWriter.open(...)` ist die einzige Stelle, an der das
+festgelegt wird.
 
 ## Phasen
 
-### Phase 1 — Pipeline auf StAX umstellen
+### Phase 1 — Pipeline auf StAX umstellen, RenderContext einführen
 
 Eine kohärente Änderung über den ganzen Resource-Baum. Doppel-API mit DOM
 parallel ist unnötig — der Code ist überschaubar (Resource + 4
 Subklassen), und ein sauberer Diff hilft mehr als eine Übergangsphase.
 
-1. `Resource.propfind` und `fillProperty` auf `XMLStreamWriter`-Signatur
-   umstellen. `quote(...)` ist schon in `EtagUtil` ausgelagert.
-2. `RootResource`, `PrincipalResource`, `AddressBookResource`,
+1. `RenderContext`-Record und `MultiStatusWriter`-Helper einführen.
+2. `Resource.propfind` und `fillProperty` auf neue Signatur umstellen
+   (`RenderContext` + `XMLStreamWriter`).
+3. `RootResource`, `PrincipalResource`, `AddressBookResource`,
    `AddressResource`: alle `appendElement`-/`appendText`-Aufrufe durch
    `writer.writeStartElement` / `writer.writeCharacters` /
-   `writer.writeEndElement` ersetzen.
-3. `CardDavServlet.doPropfind` und `doReport`: DOM-Document-Aufbau durch
-   Stream-Envelope ersetzen, `marshalMultiStatus` entfällt. Conditional-
-   GET-Pfad (`If-None-Match` → 304) bleibt unverändert.
-4. `AddressResource.fillProperty` für die `address-data`-Property
+   `writer.writeEndElement` ersetzen. `LoginFilter.getAuthenticatedUser(req)`
+   wird zu `ctx.authenticatedUser()`.
+4. `AddressBookResource.renderMultiGet(...)` neu — verschiebt die Schleife
+   aus `CardDavServlet.doReport` in die Resource.
+5. `CardDavRequestParser` einziehen mit zwei Methoden:
+   `parsePropfindBody(InputStream)` → `List<QName>` und
+   `parseMultiGetBody(InputStream)` → `(List<String> hrefs, List<QName>)`.
+6. `CardDavServlet.doPropfind` und `doReport`: DOM-Document-Aufbau durch
+   `MultiStatusWriter.open(...)` + Resource-Aufruf + `close(...)` ersetzen,
+   Body-Parsing auf den neuen Parser umstellen, `marshalMultiStatus`
+   entfällt. Conditional-GET-Pfad (`If-None-Match` → 304) bleibt
+   unverändert.
+7. `AddressResource.fillProperty` für die `address-data`-Property
    schreibt `vCardContent()` direkt per `writer.writeCharacters` in den
    Stream — keine Zwischen-Stringifizierung in eine `Element`-Textnode.
 
 **Test**: ein neuer Equivalence-Test rendert das Multistatus-Output für
 einen Fixture-`AddressBook` einmal über den (kurz noch parallel
 mitgehaltenen) DOM-Pfad und einmal über den neuen Stream-Pfad und
-vergleicht XML-kanonisch (z. B. `Canonicalizer` aus `xmlsec`, oder
-einfacher: beide Outputs durch denselben DOM-Parser jagen und per
-`isEqualNode()` vergleichen). Sobald grün, DOM-Pfad löschen.
+vergleicht XML-kanonisch — beide Outputs durch denselben DOM-Parser
+jagen und per `isEqualNode()` vergleichen. Sobald grün, DOM-Pfad
+löschen.
 
 ### Phase 2 — ETag inputbasiert
 
@@ -132,24 +195,38 @@ bei identischen Inputs) und Sensitivität gegenüber: einer einzelnen
 Personal-Nummer mehr/weniger, einer einzelnen Common-Block-Änderung,
 geändertem `ListType`.
 
-### Phase 3 — Lightweight Depth-0-Pfad
+### Phase 3 — Lightweight Depth-0-Pfad als eigene Resource-Subklasse
 
-1. `AddressBookCache.lookupCollectionMeta(principal, settings)` liefert
-   `record CollectionMeta(String etag, String displayName, String path)`
-   ohne `AddressBookResource`-Konstruktion. Verzweigt intern wie der
-   heutige `computeBlocks`-Pfad zwischen common-only / common+personal /
-   full-pipeline; nutzt für die ersten beiden Pfade nur den
-   `_numberCache` und die `getPersonalizations` / `getExcluded`-Reads.
-   Für full-pipeline materialisiert sie wie heute (selten genug, ~98
-   User).
-2. `CardDavServlet.doPropfind` erkennt **Depth: 0** + Pfad-Match auf
-   `/addresses/{user}/`, ruft `lookupCollectionMeta`, ruft Helper
-   `writeAddressBookCollectionProps(writer, req, meta, properties)`. Kein
-   `getResource(req)`, kein `lookupAddressBook`.
-3. `writeAddressBookCollectionProps` wird **auch** vom Heavy-Pfad
-   (`AddressBookResource.propfind` für Depth: 1) für die Collection-
-   Eigen-Response verwendet. Eine Implementierung, beide Pfade.
-4. Die Address-Book-Children im Heavy-Pfad bleiben über
+Polymorphie statt Sonderfall: der Lightweight-Pfad bekommt eine eigene
+Resource-Subklasse mit denselben Render-Methoden, aber ohne Children.
+
+1. `CollectionMeta` als `record CollectionMeta(String etag, String
+   displayName, String path)` einführen.
+2. `AddressBookCollectionResource extends Resource` neu — hält eine
+   `CollectionMeta`, `list()` ist leer, `getEtag()` liefert `meta.etag()`,
+   `propfind(...)` und `fillProperty(...)` bedienen dieselben Properties
+   wie `AddressBookResource` für die Collection-Eigen-Response
+   (`getctag`, `getetag`, `displayname`, `resourcetype`,
+   `current-user-principal`).
+3. **Property-Logik geteilt**: das gemeinsame Property-Set für die
+   Address-Book-Collection wird aus beiden Subklassen über einen
+   protected Helper bedient (z. B. `fillCollectionProperty(...)` auf
+   einer gemeinsamen Basis oder als statische Methode in
+   `AddressBookProps`). Eine Implementierung, beide Pfade.
+4. `AddressBookCache.lookupCollectionMeta(principal, settings)` liefert
+   `CollectionMeta` ohne `AddressBookResource`-Konstruktion. Verzweigt
+   intern wie der heutige `computeBlocks`-Pfad zwischen common-only /
+   common+personal / full-pipeline; nutzt für die ersten beiden Pfade
+   nur den `_numberCache` und die `getPersonalizations` /
+   `getExcluded`-Reads. Für full-pipeline materialisiert sie wie heute
+   (selten genug, ~98 User).
+5. `CardDavServlet.doPropfind` interpretiert den `Depth`-Header **vor**
+   der Resource-Resolution: bei Depth: 0 auf `/addresses/{user}/` ruft
+   sie `lookupCollectionMeta` und konstruiert eine
+   `AddressBookCollectionResource`; bei Depth: 1 (oder REPORT) wie
+   heute `lookupAddressBook`. Ab da identischer Code-Pfad — beide
+   Resources implementieren dasselbe Interface.
+6. Die Address-Book-Children im Heavy-Pfad bleiben über
    `resource.list()` + `child.propfind(...)` wie heute.
 
 **Test**: Goldfile-Vergleich der Depth-0-Antwort gegen den heutigen
@@ -169,24 +246,124 @@ denselben User+Settings.
    (Hebel B und Hebel E von "geplant" auf "umgesetzt" verschieben,
    "Nächste Schritte" auf C und D verkürzen).
 
-## Tests im Detail
+## Test-Plan
 
-- **XML-Equivalenz pro Resource × Property-Set** (Phase 1): konstruierter
-  Fixture-User, Liste der relevanten Properties, kanonischer XML-
-  Vergleich gegen einen Snapshot des heutigen Outputs.
-- **ETag-Stabilität** (Phase 2): selber Input → byteidentischer ETag bei
-  wiederholten Aufrufen; Mutation an Common, Personal oder Settings
-  ändert ETag.
-- **ETag-Identität Lightweight vs. Heavy** (Phase 3): für denselben User
-  liefert `lookupCollectionMeta(...).etag` denselben Wert wie
-  `lookupAddressBook(...).getEtag()`.
-- **Goldfile Depth-0** (Phase 3): heutiger Depth-0-Output vs. neuer
-  Lightweight-Output, kanonisch gleich.
-- **Live-Smoke auf Staging** (vor Merge): iOS-Sync läuft (ctag wird
-  akzeptiert, kein leeres Adressbuch); FritzBox-Sync läuft (Full-Sync
-  gibt korrekte Liste, DELETE-Verhalten unverändert);
-  Conditional-GET-Pfad (PeopleSync) liefert weiterhin 304 bei
-  unverändertem ETag.
+Die Schichten-Trennung ist die Voraussetzung für sinnvoll fokussierte
+Tests. Drei Test-Ebenen, jede mit klarer Zuständigkeit:
+
+### Ebene 1 — Unit-Tests auf der Resource-Hierarchie
+
+Setzen direkt auf den Resource-Subklassen auf. Konstruieren eine Resource
+mit Test-Daten, rufen `propfind(...)` mit einem `RenderContext` und
+einem `XMLStreamWriter` auf einen `ByteArrayOutputStream`, vergleichen
+das Ergebnis kanonisch (`isEqualNode()` nach DOM-Re-Parse) gegen ein
+Goldfile.
+
+Keine Servlet-Infrastruktur, kein `HttpServletRequest`-Stub, keine DB.
+Was die Resource an externen Daten braucht (Block-Liste, Principal-
+Name, rootUrl), wird im Test-Setup geliefert.
+
+**`TestRootResourceRender`**:
+- Property-Set `{resourcetype, displayname, current-user-principal}` →
+  Goldfile.
+- Einzeln pro Property: nur `resourcetype` angefragt → nur
+  `<d:resourcetype>`-Block; nur `current-user-principal` mit
+  authenticatedUser=null → `404 Not Found`-Status im Propstat.
+
+**`TestPrincipalResourceRender`**:
+- Standard-Property-Set für CardDAV-Discovery → Goldfile.
+- Unbekannte Property → `404`-Status.
+
+**`TestAddressBookResourceRender`** (Heavy-Pfad):
+- Depth: 0 (Eigen-Response) mit `{getctag, getetag, displayname,
+  resourcetype}` → Goldfile.
+- Depth: 1 (Eigen + Children) mit drei NumberBlock-Fixtures → Goldfile;
+  drei `<d:response>`-Elemente für Children.
+- `renderMultiGet` mit gemischten hrefs (existent + nicht existent) →
+  Goldfile mit 200 / 404-Statuszeilen.
+
+**`TestAddressResourceRender`**:
+- vCard-Inhalt für Single-Number-Block, Multi-Number-Block,
+  Wildcard-Block — Goldfiles.
+- ETag stabil über wiederholte Aufrufe.
+
+**`TestAddressBookCollectionResourceRender`** (Lightweight-Pfad):
+- Depth: 0 mit identischem Property-Set wie `AddressBookResource`,
+  identische `CollectionMeta` → kanonisch gleiches XML wie
+  `TestAddressBookResourceRender` Depth: 0.
+- `list()` ist leer (Smoke).
+
+**Gemeinsamer Goldfile-Helper**: `resources/de/.../carddav/golden/*.xml`,
+Lese-Vergleich-Utility in einer `RenderTestSupport`-Klasse.
+
+### Ebene 2 — Unit-Tests auf den reinen Funktionen
+
+**`TestCardDavRequestParser`**:
+- `parsePropfindBody`: Real-World-Beispiele aus iOS, FritzBox, DAVx5,
+  PeopleSync → erwartete `List<QName>`. Beispiel-Bodies als
+  Test-Resources einchecken.
+- `parsePropfindBody` mit kaputtem XML → klare Exception.
+- `parseMultiGetBody`: hrefs + property-Liste extrahiert, Reihenfolge
+  erhalten.
+
+**`TestEtagUtil`** (existiert schon nach Hebel A — beibehalten).
+
+**`TestCommonListEtag`** (Phase 2):
+- Stabilität: gleiche Block-Liste → byteidentischer `commonEtag` über
+  N Aufrufe.
+- Sensitivität: ein Block hinzu/weg → anderer `commonEtag`; eine Nummer
+  in einem Block geändert → anderer `commonEtag`; `ListType` geändert
+  → anderer Wert.
+- Reihenfolge-Robustheit: Block-Liste vorher permutieren → identischer
+  `commonEtag`.
+
+**`TestAddressBookEtag`** (existiert nach Hebel A — erweitern für
+Phase 3):
+- ETag-Identität Lightweight vs. Heavy: für denselben User+Settings
+  liefert `lookupCollectionMeta(...).etag()` denselben Wert wie
+  `lookupAddressBook(...).getEtag()` — über alle drei Pfade
+  (common-only, common+personal, full-pipeline).
+- ETag-Sensitivität: Personal-Add/Remove ändert ETag; Common-Mutation
+  ändert ETag; Settings-Change ändert ETag.
+
+### Ebene 3 — Servlet-Integration (schmal)
+
+Hand-gestrickte Stubs für `HttpServletRequest` / `HttpServletResponse`
+(getHeader / getInputStream / getOutputStream / setStatus / setHeader),
+keine Mockito, kein Servlet-Container. Decken nur Glue-Logik ab —
+**nicht** den XML-Inhalt (das machen Ebene 1).
+
+**`TestCardDavServlet`**:
+- Auth fehlt → 401-Challenge.
+- Auth passt + PROPFIND Depth: 0 → 207, ETag-Header gesetzt,
+  `MultiStatusWriter`-Pfad aufgerufen (Smoke: irgendein gültiges
+  Multistatus-XML im Body).
+- `If-None-Match` matcht aktuellen ETag → 304, kein Body.
+- `If-None-Match` mit `*` und vorhandenem ETag → 304.
+- PROPFIND Depth: 0 auf Address-Book → `AddressBookCollectionResource`
+  wird konstruiert (über Cache-Stub verifizierbar); Depth: 1 →
+  `AddressBookResource`.
+- METHOD-Routing: OPTIONS, PROPFIND, REPORT, GET, PUT, DELETE.
+
+### Ebene 4 — Live-Smoke auf Staging (vor Merge)
+
+Manuell, nicht automatisiert:
+
+- **iOS-Sync** läuft: ctag wird akzeptiert, kein leeres Adressbuch,
+  Übergang von altem zu neuem ETag löst genau einen Vollsync aus.
+- **FritzBox-Sync** läuft: Full-Sync gibt korrekte Liste, DELETE-
+  Verhalten unverändert (ein Test-Block per Web-UI entfernen, FritzBox
+  übernimmt das).
+- **PeopleSync** liefert weiterhin 304 bei unverändertem ETag (das ist
+  der einzige Client mit echtem `If-None-Match`-Pfad).
+
+### Was Tests nicht abdecken
+
+- Performance der `lookupCollectionMeta`-Pfads — die wird über die
+  Live-Beobachtung nach Deploy gemessen (`Address book computed for: …`
+  -Logs sollten für den iOS-Pfad auf null fallen).
+- StAX-Whitespace-Layout — kanonischer Vergleich toleriert das per
+  Design; Live-Smoke fängt, falls ein Client doch pingelig ist.
 
 ## Risiken
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavRequestParser.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavRequestParser.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav;
+
+import static de.haumacher.phoneblock.util.DomUtil.createDocumentBuilder;
+import static de.haumacher.phoneblock.util.DomUtil.elements;
+import static de.haumacher.phoneblock.util.DomUtil.filter;
+import static de.haumacher.phoneblock.util.DomUtil.qname;
+import static de.haumacher.phoneblock.util.DomUtil.qnames;
+import static de.haumacher.phoneblock.util.DomUtil.toList;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
+import de.haumacher.phoneblock.carddav.schema.DavSchema;
+
+/**
+ * Parses CardDAV request bodies (PROPFIND, REPORT addressbook-multiget) into
+ * plain Java values. Pure functions over an {@link InputStream}, no servlet
+ * dependency.
+ */
+public final class CardDavRequestParser {
+
+	private CardDavRequestParser() {
+		// no instances
+	}
+
+	/**
+	 * Parses a {@code <d:propfind>} body into the list of requested property
+	 * names.
+	 */
+	public static List<QName> parsePropfindBody(InputStream body) throws IOException, SAXException {
+		DocumentBuilder builder = createDocumentBuilder();
+		Document doc = builder.parse(body);
+		return qnames(toList(elements(doc, DavSchema.DAV_PROPFIND, DavSchema.DAV_PROP)));
+	}
+
+	/**
+	 * Parses a {@code <c:addressbook-multiget>} body into the list of addressed
+	 * resource URLs and the list of requested property names.
+	 *
+	 * @return {@code null} if the body is not an
+	 *         {@code addressbook-multiget} report.
+	 */
+	public static MultiGetRequest parseMultiGetBody(InputStream body) throws IOException, SAXException {
+		DocumentBuilder builder = createDocumentBuilder();
+		Document doc = builder.parse(body);
+		if (!CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET.equals(qname(doc.getDocumentElement()))) {
+			return null;
+		}
+
+		List<QName> properties = qnames(toList(
+			elements(doc, CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET, DavSchema.DAV_PROP)));
+
+		List<String> hrefs = new ArrayList<>();
+		for (Element href : filter(
+				elements(filter(elements(doc), CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET)),
+				DavSchema.DAV_HREF)) {
+			hrefs.add(href.getTextContent());
+		}
+
+		return new MultiGetRequest(Collections.unmodifiableList(hrefs),
+			Collections.unmodifiableList(properties));
+	}
+
+	/**
+	 * Parsed result of a {@code <c:addressbook-multiget>} body.
+	 */
+	public record MultiGetRequest(List<String> hrefs, List<QName> properties) {
+	}
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavServlet.java
@@ -3,44 +3,30 @@
  */
 package de.haumacher.phoneblock.carddav;
 
-import static de.haumacher.phoneblock.util.DomUtil.appendElement;
-import static de.haumacher.phoneblock.util.DomUtil.appendText;
-import static de.haumacher.phoneblock.util.DomUtil.appendTextElement;
-import static de.haumacher.phoneblock.util.DomUtil.createDocumentBuilder;
-import static de.haumacher.phoneblock.util.DomUtil.elements;
-import static de.haumacher.phoneblock.util.DomUtil.filter;
-import static de.haumacher.phoneblock.util.DomUtil.qname;
-import static de.haumacher.phoneblock.util.DomUtil.qnames;
-import static de.haumacher.phoneblock.util.DomUtil.toList;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilder;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
-import org.apache.http.impl.EnglishReasonPhraseCatalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.ls.DOMImplementationLS;
-import org.w3c.dom.ls.LSOutput;
-import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.SAXException;
 
 import de.haumacher.phoneblock.app.LoginFilter;
+import de.haumacher.phoneblock.carddav.CardDavRequestParser.MultiGetRequest;
 import de.haumacher.phoneblock.carddav.resource.AddressBookCache;
 import de.haumacher.phoneblock.carddav.resource.AddressBookResource;
+import de.haumacher.phoneblock.carddav.resource.MultiStatusWriter;
 import de.haumacher.phoneblock.carddav.resource.PrincipalResource;
+import de.haumacher.phoneblock.carddav.resource.RenderContext;
 import de.haumacher.phoneblock.carddav.resource.Resource;
 import de.haumacher.phoneblock.carddav.resource.RootResource;
-import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
-import de.haumacher.phoneblock.carddav.schema.DavSchema;
+import de.haumacher.phoneblock.db.DBService;
 import de.haumacher.phoneblock.db.settings.UserSettings;
 import de.haumacher.phoneblock.util.DebugUtil;
 import de.haumacher.phoneblock.util.EtagUtil;
@@ -57,7 +43,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class CardDavServlet extends HttpServlet {
 
 	private static final Logger LOG = LoggerFactory.getLogger(CardDavServlet.class);
-	
+
 	public static final String DIR_NAME = "/contacts";
 
 	private static final String BASE_PATH = DIR_NAME + "/";
@@ -72,7 +58,7 @@ public class CardDavServlet extends HttpServlet {
 	public static final String URL_PATTERN = BASE_PATH + "*";
 
 	private static final int SC_MULTI_STATUS = 207;
-	
+
 	/**
 	 * The request path where user-specific information is served.
 	 */
@@ -84,7 +70,7 @@ public class CardDavServlet extends HttpServlet {
 	public static final String ADDRESSES_PATH = "/addresses/";
 
 	public static final String SERVER_LOC = "https://phoneblock.net";
-	
+
 	private static final Pattern WHITE_SPACE_PREFIX = Pattern.compile("/\\s*/");
 
 	@Override
@@ -93,7 +79,7 @@ public class CardDavServlet extends HttpServlet {
 			resp.sendRedirect(req.getContextPath() + BASE_PATH);
 			return;
 		}
-		
+
 		try {
 			if (METHOD_PROPFIND.equals(req.getMethod())) {
 				doPropfind(req, resp);
@@ -106,18 +92,18 @@ public class CardDavServlet extends HttpServlet {
 			}
 		} catch (Exception ex) {
 			LOG.error("Failed to process CardDAV request.", ex);
-			
+
 			resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
 		}
 	}
 
 	@Override
 	protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-		resp.setHeader("Allow", 
+		resp.setHeader("Allow",
 			"GET" + ", " + "HEAD" + ", " + METHOD_PROPFIND + ", " + METHOD_REPORT + ", " + "TRACE" + ", " + "OPTIONS");
 		resp.setHeader("DAV", "addressbook");
 	}
-	
+
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		Resource resource = getResource(req);
@@ -125,7 +111,7 @@ public class CardDavServlet extends HttpServlet {
 			handleNotFound(req, resp);
 			return;
 		}
-		
+
 		if (LOG.isDebugEnabled()) {
 			StringWriter out = new StringWriter();
 			out.write(req.getMethod() + " " + req.getPathInfo() + ": " + resource);
@@ -136,7 +122,7 @@ public class CardDavServlet extends HttpServlet {
 
 		resource.get(req, resp);
 	}
-	
+
 	@Override
 	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		Resource resource = getResource(req);
@@ -152,10 +138,10 @@ public class CardDavServlet extends HttpServlet {
 			DebugUtil.dumpHeaders(out, req);
 			LOG.debug(out.toString());
 		}
-		
+
 		resource.put(req, resp);
 	}
-	
+
 	@Override
 	protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		Resource resource = getResource(req);
@@ -175,7 +161,7 @@ public class CardDavServlet extends HttpServlet {
 		resource.delete(resp);
 	}
 
-	private void doPropfind(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException {
+	private void doPropfind(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException, XMLStreamException {
 		Resource resource = getResource(req);
 		if (resource == null) {
 			handleNotFound(req, resp);
@@ -189,10 +175,8 @@ public class CardDavServlet extends HttpServlet {
 			return;
 		}
 
-		DocumentBuilder builder = createDocumentBuilder();
-		Document requestDoc = builder.parse(req.getInputStream());
+		List<QName> properties = CardDavRequestParser.parsePropfindBody(req.getInputStream());
 		Depth depth = Depth.fromHeader(req.getHeader("depth"));
-		List<QName> properties = qnames(toList(elements(requestDoc, DavSchema.DAV_PROPFIND, DavSchema.DAV_PROP)));
 
 		if (LOG.isDebugEnabled()) {
 			StringWriter out = new StringWriter();
@@ -202,45 +186,22 @@ public class CardDavServlet extends HttpServlet {
 			LOG.debug(out.toString());
 		}
 
-		Document responseDoc = builder.newDocument();
-		Element multistatus = appendElement(responseDoc, DavSchema.DAV_MULTISTATUS);
-		multistatus.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE, DavSchema.DAV_NS);
-		multistatus.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE + ':' + CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
-
-		resource.propfind(req, null, multistatus, properties);
-		if (depth != Depth.EMPTY) {
-			for (Resource content : resource.list()) {
-				content.propfind(req, resource, multistatus, properties);
+		RenderContext ctx = renderContextOf(req);
+		beginMultiStatus(resp, etag);
+		XMLStreamWriter writer = MultiStatusWriter.open(resp.getOutputStream());
+		try {
+			resource.propfind(ctx, null, writer, properties);
+			if (depth != Depth.EMPTY) {
+				for (Resource content : resource.list()) {
+					content.propfind(ctx, resource, writer, properties);
+				}
 			}
-		}
-
-		marshalMultiStatus(resp, responseDoc, etag);
-	}
-
-	private void marshalMultiStatus(HttpServletResponse resp,
-			Document responseDoc, String etag) throws IOException {
-		if (etag != null) {
-			resp.setHeader("ETag", EtagUtil.quote(etag));
-		}
-		resp.setStatus(SC_MULTI_STATUS);
-		resp.setCharacterEncoding("utf-8");
-		resp.setContentType("application/xml");
-		
-		DOMImplementationLS ls = (DOMImplementationLS) responseDoc.getImplementation().getFeature("LS", "3.0");
-		LSOutput output = ls.createLSOutput();
-		output.setEncoding("utf-8");
-		output.setByteStream(resp.getOutputStream());
-		LSSerializer serializer = ls.createLSSerializer();
-		serializer.write(responseDoc, output);
-		
-		if (LOG.isDebugEnabled()) {
-			StringWriter out = new StringWriter();
-			DebugUtil.dumpDoc(out, responseDoc);
-			LOG.debug("Response: " + out.toString());
+		} finally {
+			MultiStatusWriter.close(writer);
 		}
 	}
 
-	private void doReport(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException {
+	private void doReport(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException, XMLStreamException {
 		Resource resource = getResource(req);
 		if (resource == null) {
 			handleNotFound(req, resp);
@@ -254,79 +215,59 @@ public class CardDavServlet extends HttpServlet {
 			return;
 		}
 
-		DocumentBuilder builder = createDocumentBuilder();
-		Document requestDoc = builder.parse(req.getInputStream());
-		if (CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET.equals(qname(requestDoc.getDocumentElement()))) {
-			List<Element> properties = toList(elements(requestDoc, CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET, DavSchema.DAV_PROP));
-			
-			if (LOG.isDebugEnabled()) {
-				StringWriter out = new StringWriter();
-				out.write(req.getMethod() + " " + req.getPathInfo() + ": " + toList(qnames(properties)));
-				out.write('\n');
-				DebugUtil.dumpHeaders(out, req);
-				DebugUtil.dumpDoc(out, requestDoc);
-				LOG.debug(out.toString());
-			}
-			
-			Document responseDoc = builder.newDocument();
-			Element multistatus = appendElement(responseDoc, DavSchema.DAV_MULTISTATUS);
-			multistatus.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE, DavSchema.DAV_NS);
-			multistatus.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, XMLConstants.XMLNS_ATTRIBUTE + ':' + CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
-
-			for (Element href : filter(elements(filter(elements(requestDoc), CardDavSchema.CARDDAV_ADDRESSBOOK_MULTIGET)), DavSchema.DAV_HREF)) {
-				String url = href.getTextContent();
-				
-				Element response = appendElement(multistatus, DavSchema.DAV_RESPONSE);
-				appendTextElement(response, DavSchema.DAV_HREF, url);
-				
-				Resource content = resource.get(url);
-				
-				Element propstat = appendElement(response, DavSchema.DAV_PROPSTAT);
-				if (content != null) {
-					Element propElement = appendElement(propstat, DavSchema.DAV_PROP);
-					
-					String etag = content.getEtag();
-					if (etag != null) {
-						Element container = appendElement(propElement, DavSchema.DAV_GETETAG);
-						appendText(container, Resource.quote(etag));
-					}
-					
-					for (Element property : properties) {
-						QName qname = qname(property);
-						if (DavSchema.DAV_GETETAG.equals(qname)) {
-							// Unconditionally added above.
-							continue;
-						}
-						
-						content.fillProperty(req, propElement, qname);
-					}
-					appendTextElement(propstat, DavSchema.DAV_STATUS, "HTTP/1.1 " + HttpServletResponse.SC_OK + " " + EnglishReasonPhraseCatalog.INSTANCE.getReason(HttpServletResponse.SC_OK, null));
-				} else {
-					appendTextElement(propstat, DavSchema.DAV_STATUS, "HTTP/1.1 " + HttpServletResponse.SC_NOT_FOUND + " " + EnglishReasonPhraseCatalog.INSTANCE.getReason(HttpServletResponse.SC_NOT_FOUND, null));
-				}
-			}
-			
-			marshalMultiStatus(resp, responseDoc, collectionEtag);
-		} else {
-			StringWriter out = new StringWriter();
-			DebugUtil.dumpMethod(out, req);
-			DebugUtil.dumpHeaders(out, req);
-			DebugUtil.dumpDoc(out, requestDoc);
-			LOG.warn("Not implemented: " + out.toString());
-
+		MultiGetRequest report = CardDavRequestParser.parseMultiGetBody(req.getInputStream());
+		if (report == null) {
+			LOG.warn("Not implemented: " + DebugUtil.dumpRequestFull(req));
 			resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+			return;
 		}
+
+		if (!(resource instanceof AddressBookResource addressBook)) {
+			LOG.warn("addressbook-multiget on non-address-book resource: " + req.getPathInfo());
+			resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+			return;
+		}
+
+		if (LOG.isDebugEnabled()) {
+			StringWriter out = new StringWriter();
+			out.write(req.getMethod() + " " + req.getPathInfo() + ": " + report.properties());
+			out.write('\n');
+			DebugUtil.dumpHeaders(out, req);
+			LOG.debug(out.toString());
+		}
+
+		RenderContext ctx = renderContextOf(req);
+		beginMultiStatus(resp, collectionEtag);
+		XMLStreamWriter writer = MultiStatusWriter.open(resp.getOutputStream());
+		try {
+			addressBook.renderMultiGet(ctx, writer, report.hrefs(), report.properties());
+		} finally {
+			MultiStatusWriter.close(writer);
+		}
+	}
+
+	private static RenderContext renderContextOf(HttpServletRequest req) {
+		return new RenderContext(LoginFilter.getAuthenticatedUser(req));
+	}
+
+	private static void beginMultiStatus(HttpServletResponse resp, String etag) {
+		if (etag != null) {
+			resp.setHeader("ETag", EtagUtil.quote(etag));
+		}
+		resp.setStatus(SC_MULTI_STATUS);
+		resp.setCharacterEncoding("utf-8");
+		resp.setContentType("application/xml");
 	}
 
 	private void handleNotFound(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		LOG.warn("Not found: " + DebugUtil.dumpRequestFull(req));
-			
+
 		resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
 	}
 
 	private Resource getResource(HttpServletRequest req) {
 		String serverRoot = req.getContextPath() + req.getServletPath();
-		
+
 		String rootUrl = CardDavServlet.SERVER_LOC + serverRoot;
 		String resourcePath = req.getPathInfo();
 
@@ -334,29 +275,32 @@ public class CardDavServlet extends HttpServlet {
 			if ("/".equals(resourcePath)) {
 				return new RootResource(rootUrl, resourcePath);
 			}
-			
+
 			else if (resourcePath.startsWith(PRINCIPALS_PATH)) {
 				if (resourcePath.endsWith("/")) {
 					// Note: dataaccessd/1.0 on iOS adds a slash to the principal resource.
 					resourcePath = resourcePath.substring(0, resourcePath.length() - 1);
 				}
-				
+
 				String principal = resourcePath.substring(PRINCIPALS_PATH.length());
 				if (!isAuthenticated(req, principal, resourcePath)) {
 					return null;
 				}
-				
+
 				LOG.info("Starting synchronization for: " + principal);
+				String userAgent = req.getHeader("User-Agent");
+				UserSettings cachedSettings = LoginFilter.getUserSettings(req);
+				DBService.getInstance().updateLastAccess(principal, System.currentTimeMillis(), userAgent, cachedSettings);
 				return new PrincipalResource(rootUrl, resourcePath, principal);
 			}
-			
+
 			else if (resourcePath.startsWith(ADDRESSES_PATH)) {
 				int endIdx = resourcePath.indexOf('/', ADDRESSES_PATH.length());
 				if (endIdx < 0) {
 					LOG.warn("No principal found in address path: " + resourcePath);
 					return null;
 				}
-				
+
 				String principal = resourcePath.substring(ADDRESSES_PATH.length(), endIdx);
 				if (!isAuthenticated(req, principal, resourcePath)) {
 					return null;
@@ -378,7 +322,7 @@ public class CardDavServlet extends HttpServlet {
 					resourcePath = resourcePath.substring(matcher.end() - 1);
 					continue;
 				}
-				
+
 				LOG.warn("Addressbook resource not found: " + resourcePath);
 				return null;
 			}
@@ -391,12 +335,12 @@ public class CardDavServlet extends HttpServlet {
 			LOG.warn("No authentication accessing: " + resourcePath);
 			return false;
 		}
-		
+
 		if (!principal.equals(currentUser)) {
 			LOG.warn("Wrong user '" + principal + "' (expecting '" + currentUser + "') accessing: " + resourcePath);
 			return false;
 		}
-		
+
 		return true;
 	}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/CardDavServlet.java
@@ -20,6 +20,7 @@ import org.xml.sax.SAXException;
 import de.haumacher.phoneblock.app.LoginFilter;
 import de.haumacher.phoneblock.carddav.CardDavRequestParser.MultiGetRequest;
 import de.haumacher.phoneblock.carddav.resource.AddressBookCache;
+import de.haumacher.phoneblock.carddav.resource.AddressBookCollectionResource;
 import de.haumacher.phoneblock.carddav.resource.AddressBookResource;
 import de.haumacher.phoneblock.carddav.resource.MultiStatusWriter;
 import de.haumacher.phoneblock.carddav.resource.PrincipalResource;
@@ -162,7 +163,18 @@ public class CardDavServlet extends HttpServlet {
 	}
 
 	private void doPropfind(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException, XMLStreamException {
-		Resource resource = getResource(req);
+		Depth depth = Depth.fromHeader(req.getHeader("depth"));
+
+		Resource resource;
+		if (depth == Depth.EMPTY) {
+			// Lightweight path for Depth: 0 PROPFIND on the address-book URL —
+			// the dominant iOS-polling pattern. Falls through to the heavy
+			// resolver for everything else (root, principal, sub-resources).
+			Resource lightweight = resolveAddressBookCollectionLightweight(req);
+			resource = lightweight != null ? lightweight : getResource(req);
+		} else {
+			resource = getResource(req);
+		}
 		if (resource == null) {
 			handleNotFound(req, resp);
 			return;
@@ -176,7 +188,6 @@ public class CardDavServlet extends HttpServlet {
 		}
 
 		List<QName> properties = CardDavRequestParser.parsePropfindBody(req.getInputStream());
-		Depth depth = Depth.fromHeader(req.getHeader("depth"));
 
 		if (LOG.isDebugEnabled()) {
 			StringWriter out = new StringWriter();
@@ -199,6 +210,33 @@ public class CardDavServlet extends HttpServlet {
 		} finally {
 			MultiStatusWriter.close(writer);
 		}
+	}
+
+	/**
+	 * Resolves the request to a {@link AddressBookCollectionResource} if it
+	 * targets exactly the address-book URL ({@code /addresses/{user}/}) and
+	 * the user is authenticated. Returns {@code null} for any other path,
+	 * for sub-resources, or when authentication fails — caller falls through
+	 * to {@link #getResource}.
+	 */
+	private AddressBookCollectionResource resolveAddressBookCollectionLightweight(HttpServletRequest req) {
+		String resourcePath = req.getPathInfo();
+		if (resourcePath == null || !resourcePath.startsWith(ADDRESSES_PATH)) {
+			return null;
+		}
+		int endIdx = resourcePath.indexOf('/', ADDRESSES_PATH.length());
+		if (endIdx < 0 || endIdx != resourcePath.length() - 1) {
+			// Not exactly /addresses/{user}/ — could be a sub-resource (PUT/GET).
+			return null;
+		}
+		String principal = resourcePath.substring(ADDRESSES_PATH.length(), endIdx);
+		if (!isAuthenticated(req, principal, resourcePath)) {
+			return null;
+		}
+		UserSettings settings = LoginFilter.getUserSettings(req);
+		String etag = AddressBookCache.getInstance().lookupCollectionEtag(principal, settings);
+		String rootUrl = SERVER_LOC + req.getContextPath() + req.getServletPath();
+		return new AddressBookCollectionResource(rootUrl, resourcePath, etag);
 	}
 
 	private void doReport(HttpServletRequest req, HttpServletResponse resp) throws IOException, SAXException, XMLStreamException {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AbstractAddressBook.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AbstractAddressBook.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+import javax.xml.namespace.QName;
+
+import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
+
+/**
+ * Common base for the two flavors of an address book collection:
+ * {@link AddressBookResource} (full materialization with children) and
+ * {@link AddressBookCollectionResource} (lightweight, metadata-only — used to
+ * answer Depth: 0 PROPFINDs without constructing the per-child wrappers).
+ *
+ * <p>
+ * Both flavors emit identical {@code resourcetype}, {@code displayname} and
+ * {@code getctag}/{@code getetag} property values for the collection itself.
+ * The difference is whether children participate in the response.
+ * </p>
+ */
+public abstract class AbstractAddressBook extends Resource {
+
+	public AbstractAddressBook(String rootUrl, String resourcePath) {
+		super(rootUrl, resourcePath);
+	}
+
+	@Override
+	protected final boolean isCollection() {
+		return true;
+	}
+
+	@Override
+	protected final QName getResourceType() {
+		return CardDavSchema.CARDDAV_ADDRESSBOOK;
+	}
+
+	@Override
+	protected final String getDisplayName() {
+		return "BLOCKLIST";
+	}
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
@@ -105,7 +105,7 @@ public class AddressBookCache implements ServletContextListener {
 		LOG.info("Address book computed for: " + principal
 			+ " (" + result.path + ", " + result.blocks.size() + " blocks)");
 		AddressBookResource addressBook = new AddressBookResource(rootUrl, serverRoot, resourcePath, principal,
-				result.blocks, result.settingsHash);
+				result.blocks, result.etag);
 		return _userCache.put(principal, addressBook);
 	}
 
@@ -131,45 +131,53 @@ public class AddressBookCache implements ServletContextListener {
 			Set<String> exclusions = blocklist.getExcluded(userId);
 
 			if (personalizations.isEmpty() && exclusions.isEmpty()) {
-				return new LoadResult(getCommonList(reports, listType, now).blocks(),
-						listType.hashCode(), "common-only");
+				CommonList common = getCommonList(reports, listType, now);
+				int settingsHash = listType.hashCode();
+				String etag = CollectionEtag.compose(common.blocksHash(),
+					CollectionEtag.hashPersonalSingletons(List.of()), settingsHash);
+				return new LoadResult(common.blocks(), settingsHash, etag, "common-only");
 			}
 
 			CommonList common = getCommonList(reports, listType, now);
-			List<NumberBlock> blocks;
-			String path;
+			int settingsHash = listType.hashCode() ^ personalSettingsHash(personalizations, exclusions);
+
 			if (hasEffectiveExclusion(exclusions, common)) {
 				// Rare path (~0.3% of users): a personal exclusion intersects the
 				// common list and would change wildcard structure. Run the full
 				// per-user pipeline.
-				blocks = loadNumbersFull(reports, personalizations, exclusions, listType, now);
-				path = "full pipeline";
-			} else {
-				// Common buckets + personal singletons (deduplicated against common).
-				blocks = new ArrayList<>(common.blocks());
-				for (String phoneId : personalizations) {
-					String phone = NumberAnalyzer.toInternationalFormat(phoneId);
-					if (common.covers(phone)) {
-						continue;
-					}
-					blocks.add(new NumberBlock(phone, List.of(phone)));
-				}
-				path = "common+personal";
+				List<NumberBlock> blocks = loadNumbersFull(reports, personalizations, exclusions, listType, now);
+				String etag = CollectionEtag.forFullPipeline(blocks, settingsHash);
+				return new LoadResult(blocks, settingsHash, etag, "full pipeline");
 			}
-			int settingsHash = listType.hashCode() ^ personalSettingsHash(personalizations, exclusions);
-			return new LoadResult(blocks, settingsHash, path);
+
+			// Common buckets + personal singletons (deduplicated against common).
+			List<NumberBlock> blocks = new ArrayList<>(common.blocks());
+			List<String> personalSingletons = new ArrayList<>();
+			for (String phoneId : personalizations) {
+				String phone = NumberAnalyzer.toInternationalFormat(phoneId);
+				if (common.covers(phone)) {
+					continue;
+				}
+				blocks.add(new NumberBlock(phone, List.of(phone)));
+				personalSingletons.add(phone);
+			}
+			String etag = CollectionEtag.compose(common.blocksHash(),
+				CollectionEtag.hashPersonalSingletons(personalSingletons), settingsHash);
+			return new LoadResult(blocks, settingsHash, etag, "common+personal");
 		}
 	}
 
 	private static final class LoadResult {
 		final List<NumberBlock> blocks;
 		final int settingsHash;
+		final String etag;
 		final String path;
 
-		LoadResult(List<NumberBlock> blocks, int settingsHash, String path) {
+		LoadResult(List<NumberBlock> blocks, int settingsHash, String etag, String path) {
 			this.blocks = blocks;
-			this.path = path;
 			this.settingsHash = settingsHash;
+			this.etag = etag;
+			this.path = path;
 		}
 	}
 
@@ -292,6 +300,7 @@ public class AddressBookCache implements ServletContextListener {
 		private final List<NumberBlock> _blocks;
 		private final Set<String> _concrete;
 		private final List<String> _wildcardPrefixes;
+		private final String _blocksHash;
 
 		CommonList(List<NumberBlock> blocks) {
 			_blocks = blocks;
@@ -309,10 +318,20 @@ public class AddressBookCache implements ServletContextListener {
 			Collections.sort(wildcards);
 			_concrete = concrete;
 			_wildcardPrefixes = wildcards;
+			_blocksHash = CollectionEtag.hashBlocks(blocks);
 		}
 
 		List<NumberBlock> blocks() {
 			return _blocks;
+		}
+
+		/**
+		 * Precomputed hash of the {@link #blocks()} content, fed into the
+		 * collection ETag composition for every user that shares this common
+		 * list. Computed once per refresh of this cache entry.
+		 */
+		String blocksHash() {
+			return _blocksHash;
 		}
 
 		/**

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
@@ -117,6 +117,22 @@ public class AddressBookCache implements ServletContextListener {
 		return computeBlocks(principal, now, settings).blocks;
 	}
 
+	/**
+	 * Computes the collection ETag for the given user without materializing an
+	 * {@link AddressBookResource} (and therefore without allocating the
+	 * per-block {@link AddressResource} wrappers). Used to serve Depth: 0
+	 * PROPFINDs on the address-book URL — the dominant iOS-polling pattern.
+	 *
+	 * <p>
+	 * The returned ETag is byte-identical to
+	 * {@link AddressBookResource#getEtag()} for the same user state, because
+	 * both go through {@link CollectionEtag}.
+	 * </p>
+	 */
+	public String lookupCollectionEtag(String principal, UserSettings settings) {
+		return computeBlocks(principal, System.currentTimeMillis(), settings).etag;
+	}
+
 	private LoadResult computeBlocks(String principal, long now, UserSettings settings) {
 		ListType listType = ListType.valueOf(settings.getDialPrefix(), settings.getMinVotes(),
 				settings.getMaxLength(), settings.isWildcards(), settings.isNationalOnly());

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCollectionResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCollectionResource.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+/**
+ * Lightweight {@link AbstractAddressBook} that carries only the collection-
+ * level metadata (ETag), without materializing per-block child resources.
+ *
+ * <p>
+ * Used to answer Depth: 0 PROPFINDs on the address-book URL — the by far
+ * dominant pattern from iOS, which polls {@code getctag}/{@code getetag} every
+ * ~18 minutes and only descends to Depth: 1 when the ctag changed. Producing
+ * the small Depth: 0 response from this resource avoids the construction of
+ * ~1000 {@link AddressResource} wrappers per poll.
+ * </p>
+ *
+ * <p>
+ * The ETag must be byte-identical to what {@link AddressBookResource#getEtag}
+ * would return for the same user — guaranteed by both being derived through
+ * {@link CollectionEtag} from the same inputs.
+ * </p>
+ */
+public class AddressBookCollectionResource extends AbstractAddressBook {
+
+	private final String _etag;
+
+	public AddressBookCollectionResource(String rootUrl, String resourcePath, String etag) {
+		super(rootUrl, resourcePath);
+		_etag = etag;
+	}
+
+	@Override
+	public String getEtag() {
+		return _etag;
+	}
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
@@ -9,12 +9,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.haumacher.phoneblock.analysis.NumberBlock;
 import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
+import de.haumacher.phoneblock.carddav.schema.DavSchema;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * {@link Resource} representing a collection of {@link AddressBookResource}s.
@@ -67,12 +71,12 @@ public class AddressBookResource extends Resource {
 	protected boolean isCollection() {
 		return true;
 	}
-	
+
 	@Override
 	protected QName getResourceType() {
 		return CardDavSchema.CARDDAV_ADDRESSBOOK;
 	}
-	
+
 	@Override
 	public Collection<? extends Resource> list() {
 		return _addressById.values();
@@ -82,11 +86,11 @@ public class AddressBookResource extends Resource {
 	protected String getDisplayName() {
 		return "BLOCKLIST";
 	}
-	
+
 	@Override
 	public Resource get(String url) {
 		String rootUrl = getRootUrl();
-		
+
 		int prefixLength;
 		if (url.startsWith(rootUrl)) {
 			prefixLength = rootUrl.length();
@@ -111,7 +115,7 @@ public class AddressBookResource extends Resource {
 			LOG.warn("Received invalid contact URL outside address book '" + getResourcePath() + "': " + url);
 			return null;
 		}
-		
+
 		return lookupAddress(url.substring(prefixLength + getResourcePath().length()));
 	}
 
@@ -147,5 +151,54 @@ public class AddressBookResource extends Resource {
 		} catch (java.security.NoSuchAlgorithmException ex) {
 			throw new IllegalStateException("SHA-1 not available", ex);
 		}
+	}
+
+	/**
+	 * Renders the multistatus body of a {@code <c:addressbook-multiget>} REPORT
+	 * request: one {@code <d:response>} per addressed href, with the requested
+	 * properties of the resolved child resource (or 404 if it does not exist).
+	 */
+	public void renderMultiGet(RenderContext ctx, XMLStreamWriter writer,
+			List<String> hrefs, List<QName> properties) throws XMLStreamException {
+		for (String url : hrefs) {
+			writer.writeStartElement(DavSchema.DAV_NS, "response");
+			writer.writeStartElement(DavSchema.DAV_NS, "href");
+			writer.writeCharacters(url);
+			writer.writeEndElement();
+
+			Resource content = get(url);
+			writer.writeStartElement(DavSchema.DAV_NS, "propstat");
+			if (content != null) {
+				writer.writeStartElement(DavSchema.DAV_NS, "prop");
+
+				String etag = content.getEtag();
+				if (etag != null) {
+					writer.writeStartElement(DavSchema.DAV_NS, "getetag");
+					writer.writeCharacters(quote(etag));
+					writer.writeEndElement();
+				}
+
+				for (QName qname : properties) {
+					if (DavSchema.DAV_GETETAG.equals(qname)) {
+						// Unconditionally added above.
+						continue;
+					}
+					content.fillProperty(ctx, writer, qname);
+				}
+				writer.writeEndElement();
+				writeStatus(writer, HttpServletResponse.SC_OK, "OK");
+			} else {
+				writeStatus(writer, HttpServletResponse.SC_NOT_FOUND, "Not Found");
+			}
+			writer.writeEndElement();
+			writer.writeEndElement();
+		}
+	}
+
+	private static void writeStatus(XMLStreamWriter writer, int code, String reason)
+			throws XMLStreamException {
+		writer.writeStartElement(DavSchema.DAV_NS, "status");
+		writer.writeCharacters("HTTP/1.1 " + code + " " + reason);
+		writer.writeEndElement();
 	}
 }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
@@ -16,14 +16,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.haumacher.phoneblock.analysis.NumberBlock;
-import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
 import de.haumacher.phoneblock.carddav.schema.DavSchema;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * {@link Resource} representing a collection of {@link AddressBookResource}s.
  */
-public class AddressBookResource extends Resource {
+public class AddressBookResource extends AbstractAddressBook {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AddressBookResource.class);
 
@@ -67,23 +66,8 @@ public class AddressBookResource extends Resource {
 	}
 
 	@Override
-	protected boolean isCollection() {
-		return true;
-	}
-
-	@Override
-	protected QName getResourceType() {
-		return CardDavSchema.CARDDAV_ADDRESSBOOK;
-	}
-
-	@Override
 	public Collection<? extends Resource> list() {
 		return _addressById.values();
-	}
-
-	@Override
-	protected String getDisplayName() {
-		return "BLOCKLIST";
 	}
 
 	@Override

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookResource.java
@@ -32,7 +32,7 @@ public class AddressBookResource extends Resource {
 
 	private final Map<String, AddressResource> _addressById;
 
-	private final int _settingsHash;
+	private final String _etag;
 
 	/**
 	 * Creates a {@link AddressBookResource}.
@@ -45,17 +45,16 @@ public class AddressBookResource extends Resource {
 	 *        Blocks visible to the user. May be the common list alone, the common list
 	 *        with personal singletons appended, or the result of a full per-user pipeline —
 	 *        from this resource's point of view they are all just blocks.
-	 * @param settingsHash
-	 *        Additional hash mixed into the collection ETag to differentiate users
-	 *        whose visible block list happens to coincide but whose settings or personal
-	 *        list differ.
+	 * @param etag
+	 *        The collection ETag, precomputed from the user's blocks, personal
+	 *        singletons and settings. See {@link CollectionEtag}.
 	 */
-	AddressBookResource(String rootUrl, String serverRoot, String resourcePath, String principal,
-			List<NumberBlock> numbers, int settingsHash) {
+	public AddressBookResource(String rootUrl, String serverRoot, String resourcePath, String principal,
+			List<NumberBlock> numbers, String etag) {
 		super(rootUrl, resourcePath);
 		_serverRoot = serverRoot;
 		_principal = principal;
-		_settingsHash = settingsHash;
+		_etag = etag;
 
 		_addressById = numbers
 			.stream()
@@ -131,26 +130,7 @@ public class AddressBookResource extends Resource {
 
 	@Override
 	public String getEtag() {
-		try {
-			java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-1");
-			java.util.List<String> ids = new java.util.ArrayList<>(_addressById.keySet());
-			java.util.Collections.sort(ids);
-			for (String id : ids) {
-				md.update(id.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-				md.update((byte) 0);
-				md.update(_addressById.get(id).getEtag().getBytes(java.nio.charset.StandardCharsets.UTF_8));
-				md.update((byte) 0);
-			}
-			md.update(Integer.toString(_settingsHash).getBytes(java.nio.charset.StandardCharsets.UTF_8));
-			byte[] digest = md.digest();
-			StringBuilder hex = new StringBuilder(12);
-			for (int i = 0; i < 6; i++) {
-				hex.append(String.format("%02x", digest[i]));
-			}
-			return hex.toString();
-		} catch (java.security.NoSuchAlgorithmException ex) {
-			throw new IllegalStateException("SHA-1 not available", ex);
-		}
+		return _etag;
 	}
 
 	/**

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressResource.java
@@ -3,17 +3,15 @@
  */
 package de.haumacher.phoneblock.carddav.resource;
 
-import static de.haumacher.phoneblock.util.DomUtil.appendElement;
-import static de.haumacher.phoneblock.util.DomUtil.appendText;
-
 import java.io.IOException;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.ibatis.session.SqlSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Element;
 
 import de.haumacher.phoneblock.analysis.NumberAnalyzer;
 import de.haumacher.phoneblock.analysis.NumberBlock;
@@ -42,9 +40,9 @@ public class AddressResource extends Resource {
 
 	private NumberBlock _block;
 
-	/** 
+	/**
 	 * Creates a {@link AddressResource}.
-	 * 
+	 *
 	 * @param block The block of numbers represented by this resource.
 	 * @param principal The user name of the address books owner.
 	 */
@@ -53,7 +51,7 @@ public class AddressResource extends Resource {
 		_block = block;
 		_principal = principal;
 	}
-	
+
 	public String getId() {
 		return _block.getName();
 	}
@@ -74,20 +72,22 @@ public class AddressResource extends Resource {
 		resp.setContentType("text/x-vcard");
 		resp.setCharacterEncoding("utf-8");
 		resp.setHeader("ETag", quote(getEtag()));
-		
+
 		resp.getWriter().append(_block.vCardContent());
 	}
 
 	@Override
-	public int fillProperty(HttpServletRequest req, Element propElement, QName property) {
+	public int fillProperty(RenderContext ctx, XMLStreamWriter writer, QName property)
+			throws XMLStreamException {
 		if (CardDavSchema.CARDDAV_ADDRESS_DATA.equals(property)) {
-			Element container = appendElement(propElement, CardDavSchema.CARDDAV_ADDRESS_DATA);
-			appendText(container, _block.vCardContent());
+			writer.writeStartElement(CardDavSchema.CARDDAV_NS, "address-data");
+			writer.writeCharacters(_block.vCardContent());
+			writer.writeEndElement();
 			return HttpServletResponse.SC_OK;
 		}
-		return super.fillProperty(req, propElement, property);
+		return super.fillProperty(ctx, writer, property);
 	}
-	
+
 	@Override
 	public void put(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		VCardReader reader = new VCardReader(req.getReader(), VCardVersion.V3_0);
@@ -96,28 +96,28 @@ public class AddressResource extends Resource {
 			resp.setStatus(HttpServletResponse.SC_NOT_FOUND);
 			return;
 		}
-		
+
 		DB db = DBService.getInstance();
 		try (SqlSession session = db.openSession()) {
 			SpamReports spamreport = session.getMapper(SpamReports.class);
 			BlockList blockList = session.getMapper(BlockList.class);
 			Users users = session.getMapper(Users.class);
-			
+
 			long currentUser = users.getUserId(_principal);
 			String dialPrefix = users.getDialPrefix(_principal);
-			
+
 			if (card.getTelephoneNumbers().size() > 1) {
 				LOG.warn("Prevent putting card with multiple numbers: " + card);
 			} else {
 				for (Telephone phone : card.getTelephoneNumbers()) {
 					String phoneText = phone.getText();
-					
+
 					PhoneNumer number = NumberAnalyzer.parsePhoneNumber(phoneText, dialPrefix);
 					if (number == null) {
 						continue;
 					}
 					String phoneId = NumberAnalyzer.getPhoneId(number);
-					
+
 					Boolean state = blockList.getPersonalizationState(currentUser, phoneId);
 					if (state == null || !state.booleanValue()) {
 						LOG.info("Adding to block list: " + phoneId);
@@ -127,18 +127,18 @@ public class AddressResource extends Resource {
 						// Safety, prevent duplicate key constraint violation.
 						blockList.removePersonalization(currentUser, phoneId);
 						blockList.addPersonalization(currentUser, phoneId, sha1, System.currentTimeMillis());
-						
+
 						db.processVotesAndPublish(spamreport, number, dialPrefix, 2, System.currentTimeMillis());
 					}
 				}
-				
+
 				session.commit();
-				
+
 				// Ensure that the new number is added to the user's address book immediately.
 				AddressBookCache.getInstance().flushUserCache(_principal);
 			}
 		}
-		
+
 		resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 	}
 
@@ -146,7 +146,7 @@ public class AddressResource extends Resource {
 	public void delete(HttpServletResponse resp) {
 		// Cannot allow to delete a potential block of numbers.
 		LOG.warn("Prevent deleting card: " + _block.getName());
-		
+
 		resp.setStatus(HttpServletResponse.SC_OK);
 	}
 }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/CollectionEtag.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/CollectionEtag.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.haumacher.phoneblock.analysis.NumberBlock;
+
+/**
+ * Composable hashes that make up a CardDAV collection ETag.
+ *
+ * <p>
+ * The collection ETag is built from three inputs that change at very
+ * different rates:
+ * </p>
+ * <ul>
+ * <li><b>Blocks hash</b> — over the sorted block IDs and per-block content
+ *     hashes. For users without effective exclusions this is precomputed
+ *     once per {@code ListType} on the shared common-list cache, so the
+ *     per-user ETag computation never iterates the (large) common block
+ *     set.</li>
+ * <li><b>Personal-singletons hash</b> — over the sorted phone numbers added
+ *     as personal singletons after the common-list filter. Empty for
+ *     common-only and full-pipeline users.</li>
+ * <li><b>Settings hash</b> — {@code ListType.hashCode()}, optionally XORed
+ *     with a personal-settings hash for users with personal data.</li>
+ * </ul>
+ *
+ * <p>
+ * The composition function {@link #compose} produces the final 12-hex-char
+ * SHA-1 prefix that ends up in the {@code ETag}/{@code getctag} headers.
+ * </p>
+ */
+public final class CollectionEtag {
+
+	private CollectionEtag() {
+		// no instances
+	}
+
+	/**
+	 * Hash over a list of {@link NumberBlock}s, ordered by block name. Used
+	 * either as the precomputed common-blocks hash on a shared common list,
+	 * or as the per-user blocks hash on the full-pipeline path.
+	 */
+	public static String hashBlocks(List<NumberBlock> blocks) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-1");
+			List<NumberBlock> sorted = new ArrayList<>(blocks);
+			sorted.sort((a, b) -> a.getName().compareTo(b.getName()));
+			for (NumberBlock block : sorted) {
+				md.update(block.getName().getBytes(StandardCharsets.UTF_8));
+				md.update((byte) 0);
+				md.update(block.contentHash().getBytes(StandardCharsets.UTF_8));
+				md.update((byte) 0);
+			}
+			return toHex12(md.digest());
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-1 not available", ex);
+		}
+	}
+
+	/**
+	 * Hash over a list of personal singleton phone numbers, sorted. An empty
+	 * input yields the empty-input SHA-1 prefix.
+	 */
+	public static String hashPersonalSingletons(List<String> singletons) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-1");
+			List<String> sorted = new ArrayList<>(singletons);
+			Collections.sort(sorted);
+			for (String s : sorted) {
+				md.update(s.getBytes(StandardCharsets.UTF_8));
+				md.update((byte) 0);
+			}
+			return toHex12(md.digest());
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-1 not available", ex);
+		}
+	}
+
+	/**
+	 * Combines three precomputed components into the final collection ETag.
+	 */
+	public static String compose(String blocksHash, String personalHash, int settingsHash) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-1");
+			md.update(blocksHash.getBytes(StandardCharsets.UTF_8));
+			md.update((byte) 0);
+			md.update(personalHash.getBytes(StandardCharsets.UTF_8));
+			md.update((byte) 0);
+			md.update(Integer.toString(settingsHash).getBytes(StandardCharsets.UTF_8));
+			return toHex12(md.digest());
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("SHA-1 not available", ex);
+		}
+	}
+
+	/**
+	 * Direct ETag for the full-pipeline path, which has no shared common
+	 * list. Equivalent to {@code compose(hashBlocks(blocks),
+	 * hashPersonalSingletons(emptyList), settingsHash)}.
+	 */
+	public static String forFullPipeline(List<NumberBlock> blocks, int settingsHash) {
+		return compose(hashBlocks(blocks), hashPersonalSingletons(List.of()), settingsHash);
+	}
+
+	private static String toHex12(byte[] digest) {
+		StringBuilder hex = new StringBuilder(12);
+		for (int i = 0; i < 6; i++) {
+			hex.append(String.format("%02x", digest[i]));
+		}
+		return hex.toString();
+	}
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/MultiStatusWriter.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/MultiStatusWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+import java.io.OutputStream;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
+import de.haumacher.phoneblock.carddav.schema.DavSchema;
+
+/**
+ * Helpers to open and close the CardDAV {@code <d:multistatus>} envelope.
+ * Centralizes the namespace bindings used everywhere in the response so that
+ * resource render code can write elements without worrying about namespace
+ * declarations.
+ *
+ * <p>
+ * Predeclares: {@code DAV:} as default namespace, {@code carddav} as
+ * {@code c}, and {@code calendarserver.org/ns/} as {@code s}.
+ * </p>
+ */
+public final class MultiStatusWriter {
+
+	private static final XMLOutputFactory FACTORY = createFactory();
+
+	private static XMLOutputFactory createFactory() {
+		XMLOutputFactory factory = XMLOutputFactory.newInstance();
+		factory.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.FALSE);
+		return factory;
+	}
+
+	private MultiStatusWriter() {
+		// no instances
+	}
+
+	/**
+	 * Opens a UTF-8 {@link XMLStreamWriter} on the given output stream, writes
+	 * the XML declaration and the {@code <d:multistatus>} start element with
+	 * predeclared namespace bindings.
+	 */
+	public static XMLStreamWriter open(OutputStream out) throws XMLStreamException {
+		XMLStreamWriter writer = FACTORY.createXMLStreamWriter(out, "UTF-8");
+		writer.writeStartDocument("UTF-8", "1.0");
+		writer.setDefaultNamespace(DavSchema.DAV_NS);
+		writer.setPrefix(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
+		writer.setPrefix(CardDavSchema.CALENDARSERVER_PREFIX, CardDavSchema.CALENDARSERVER_NS);
+		writer.writeStartElement(DavSchema.DAV_NS, "multistatus");
+		writer.writeDefaultNamespace(DavSchema.DAV_NS);
+		writer.writeNamespace(CardDavSchema.CARDDAV_PREFIX, CardDavSchema.CARDDAV_NS);
+		writer.writeNamespace(CardDavSchema.CALENDARSERVER_PREFIX, CardDavSchema.CALENDARSERVER_NS);
+		return writer;
+	}
+
+	/**
+	 * Closes the multistatus element and the document, then flushes and closes
+	 * the writer.
+	 */
+	public static void close(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeEndElement();
+		writer.writeEndDocument();
+		writer.flush();
+		writer.close();
+	}
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/PrincipalResource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/PrincipalResource.java
@@ -3,22 +3,13 @@
  */
 package de.haumacher.phoneblock.carddav.resource;
 
-import static de.haumacher.phoneblock.util.DomUtil.appendElement;
-
-import java.util.List;
-
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
-import org.w3c.dom.Element;
-
-import de.haumacher.phoneblock.app.LoginFilter;
 import de.haumacher.phoneblock.carddav.CardDavServlet;
 import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
 import de.haumacher.phoneblock.carddav.schema.DavSchema;
-import de.haumacher.phoneblock.db.DBService;
-import de.haumacher.phoneblock.db.settings.UserSettings;
-import de.haumacher.phoneblock.util.DomUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -26,34 +17,28 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 public class PrincipalResource extends Resource {
 
-	private String _principal;
+	private final String _principal;
 
-	/** 
+	/**
 	 * Creates a {@link PrincipalResource}.
 	 */
 	public PrincipalResource(String rootUrl, String resourcePath, String principal) {
 		super(rootUrl, resourcePath);
 		_principal = principal;
 	}
-	
-	@Override
-	public void propfind(HttpServletRequest req, Resource parent, Element multistatus, List<QName> properties) {
-		String userAgent = req.getHeader("User-Agent");
-		UserSettings cachedSettings = LoginFilter.getUserSettings(req);
 
-		DBService.getInstance().updateLastAccess(_principal, System.currentTimeMillis(), userAgent, cachedSettings);
-
-		super.propfind(req, parent, multistatus, properties);
-	}
-	
 	@Override
-	public int fillProperty(HttpServletRequest req, Element propElement, QName property) {
+	public int fillProperty(RenderContext ctx, XMLStreamWriter writer, QName property)
+			throws XMLStreamException {
 		if (CardDavSchema.CARDDAV_ADDRESSBOOK_HOME_SET.equals(property)) {
-			Element container = appendElement(propElement, CardDavSchema.CARDDAV_ADDRESSBOOK_HOME_SET);
-			DomUtil.appendTextElement(container, DavSchema.DAV_HREF, url(CardDavServlet.ADDRESSES_PATH + _principal + "/"));
+			writer.writeStartElement(CardDavSchema.CARDDAV_NS, "addressbook-home-set");
+			writer.writeStartElement(DavSchema.DAV_NS, "href");
+			writer.writeCharacters(url(CardDavServlet.ADDRESSES_PATH + _principal + "/"));
+			writer.writeEndElement();
+			writer.writeEndElement();
 			return HttpServletResponse.SC_OK;
 		}
-		return super.fillProperty(req, propElement, property);
+		return super.fillProperty(ctx, writer, property);
 	}
 
 }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/RenderContext.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/RenderContext.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+/**
+ * Servlet-free render context passed to {@link Resource#propfind} and
+ * {@link Resource#fillProperty}. Carries the only request-derived values the
+ * render code actually needs, so unit tests can construct a context directly
+ * without a {@link jakarta.servlet.http.HttpServletRequest} stub.
+ *
+ * @param authenticatedUser
+ *        Login name of the authenticated user, or {@code null} if no
+ *        authentication is in place. Used by
+ *        {@code DAV:current-user-principal}.
+ */
+public record RenderContext(String authenticatedUser) {
+}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/Resource.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/Resource.java
@@ -3,10 +3,6 @@
  */
 package de.haumacher.phoneblock.carddav.resource;
 
-import static de.haumacher.phoneblock.util.DomUtil.appendElement;
-import static de.haumacher.phoneblock.util.DomUtil.appendText;
-import static de.haumacher.phoneblock.util.DomUtil.appendTextElement;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -16,13 +12,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Element;
 
-import de.haumacher.phoneblock.app.LoginFilter;
 import de.haumacher.phoneblock.carddav.CardDavServlet;
 import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
 import de.haumacher.phoneblock.carddav.schema.DavSchema;
@@ -35,54 +31,54 @@ import jakarta.servlet.http.HttpServletResponse;
 public abstract class Resource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Resource.class);
-	
+
 	private final String _rootUrl;
-	
+
 	private final String _resourcePath;
 
 	private static final Map<QName, QName> UNSUPPORTED_KNOWN = Arrays.asList(
-		new QName("DAV:", "add-member"), 
-		new QName("DAV:", "current-user-privilege-set"), 
+		new QName("DAV:", "add-member"),
+		new QName("DAV:", "current-user-privilege-set"),
 		new QName("DAV:", "getcontenttype"),
-		new QName("DAV:", "group-membership"), 
+		new QName("DAV:", "group-membership"),
 		new QName("DAV:", "owner"),
 		new QName("DAV:", "principal-collection-set"),
 		new QName("DAV:", "principal-URL"),
-		new QName("DAV:", "quota-available-bytes"), 
+		new QName("DAV:", "quota-available-bytes"),
 		new QName("DAV:", "quota-used-bytes"),
 		new QName("DAV:", "resource-id"),
-		new QName("DAV:", "supported-report-set"), 
+		new QName("DAV:", "supported-report-set"),
 		new QName("DAV:", "sync-token"),
 		new QName("http://apple.com/ns/ical/", "calendar-color"),
 		new QName("http://calendarserver.org/ns/", "email-address-set"),
-		new QName("http://calendarserver.org/ns/", "me-card"), 
+		new QName("http://calendarserver.org/ns/", "me-card"),
 		new QName("http://calendarserver.org/ns/", "pushkey"),
-		new QName("http://calendarserver.org/ns/", "push-transports"), 
-		new QName("http://calendarserver.org/ns/", "source"), 
+		new QName("http://calendarserver.org/ns/", "push-transports"),
+		new QName("http://calendarserver.org/ns/", "source"),
 		new QName("http://calendarserver.org/ns/", "xmpp-uri"),
-		new QName("http://icewarp.com/ns/", "conference-support"), 
-		new QName("http://icewarp.com/ns/", "default-calendar-URL"), 
-		new QName("http://icewarp.com/ns/", "default-contacts-URL"), 
-		new QName("http://icewarp.com/ns/", "default-notes-URL"), 
-		new QName("http://icewarp.com/ns/", "default-tasks-URL"), 
+		new QName("http://icewarp.com/ns/", "conference-support"),
+		new QName("http://icewarp.com/ns/", "default-calendar-URL"),
+		new QName("http://icewarp.com/ns/", "default-contacts-URL"),
+		new QName("http://icewarp.com/ns/", "default-notes-URL"),
+		new QName("http://icewarp.com/ns/", "default-tasks-URL"),
 		new QName("http://me.com/_namespace/", "bulk-requests"),
-		new QName("http://me.com/_namespace/", "guardian-restricted"), 
-		new QName("urn:ietf:params:xml:ns:caldav", "calendar-home-set"), 
-		new QName("urn:ietf:params:xml:ns:caldav", "calendar-user-address-set"), 
-		new QName("urn:ietf:params:xml:ns:caldav", "schedule-inbox-URL"), 
-		new QName("urn:ietf:params:xml:ns:caldav", "schedule-outbox-URL"), 
+		new QName("http://me.com/_namespace/", "guardian-restricted"),
+		new QName("urn:ietf:params:xml:ns:caldav", "calendar-home-set"),
+		new QName("urn:ietf:params:xml:ns:caldav", "calendar-user-address-set"),
+		new QName("urn:ietf:params:xml:ns:caldav", "schedule-inbox-URL"),
+		new QName("urn:ietf:params:xml:ns:caldav", "schedule-outbox-URL"),
 		new QName("urn:ietf:params:xml:ns:carddav", "addressbook-description"),
 		new QName("urn:ietf:params:xml:ns:carddav", "directory-gateway"),
 		new QName("urn:ietf:params:xml:ns:carddav", "max-image-size"),
-		new QName("urn:ietf:params:xml:ns:carddav", "max-resource-size"), 
-		new QName("urn:ietf:params:xml:ns:carddav", "supported-address-data"), 
+		new QName("urn:ietf:params:xml:ns:carddav", "max-resource-size"),
+		new QName("urn:ietf:params:xml:ns:carddav", "supported-address-data"),
 		new QName("urn:ietf:params:xml:ns:caldav", "calendar-description"),
 		new QName("urn:ietf:params:xml:ns:caldav", "supported-calendar-component-set"),
 		new QName("urn:mobileme:davservices", "quota-available"),
 		new QName("urn:mobileme:davservices", "quota-used")
 	).stream().collect(Collectors.toConcurrentMap(x -> x, x -> x));
-	
-	/** 
+
+	/**
 	 * Creates a {@link Resource}.
 	 *
 	 * @param rootUrl The base URL of the WEBDAV servlet.
@@ -93,17 +89,17 @@ public abstract class Resource {
 		_rootUrl = rootUrl;
 		_resourcePath = resourcePath;
 	}
-	
+
 	/**
 	 * The base URL of the WEBDAV servlet.
 	 */
 	public String getRootUrl() {
 		return _rootUrl;
 	}
-	
+
 	/**
 	 * The path of this resource relative to the root URL.
-	 * 
+	 *
 	 * @see #getRootUrl()
 	 */
 	public String getResourcePath() {
@@ -111,84 +107,105 @@ public abstract class Resource {
 	}
 
 	/**
-	 * Answers the <code>propfind</code> request.
-	 * 
-	 * @param req
-	 *        The current request.
+	 * Writes the {@code <d:response>} block of this resource into the given
+	 * multistatus stream.
+	 *
+	 * @param ctx
+	 *        Render context (authenticated user, etc.).
 	 * @param parent
-	 *        The parent resource in which context a property of this resource was requested. <code>null</code>, if this
-	 *        is the top-level requested resource.
-	 * @param multistatus
-	 *        The result element to add the response to.
+	 *        The parent resource in which context a property of this resource
+	 *        was requested. {@code null}, if this is the top-level requested
+	 *        resource.
+	 * @param writer
+	 *        The {@link XMLStreamWriter} positioned inside the open
+	 *        {@code <d:multistatus>} element.
 	 * @param properties
-	 *        The {@link Element}s describing the properties to retrieve.
+	 *        The qualified names of the properties to retrieve.
 	 */
-	public void propfind(HttpServletRequest req, Resource parent, Element multistatus, List<QName> properties) {
-		Element response = appendElement(multistatus, DavSchema.DAV_RESPONSE);
-		appendTextElement(response, DavSchema.DAV_HREF, url(parent));
+	public void propfind(RenderContext ctx, Resource parent, XMLStreamWriter writer,
+			List<QName> properties) throws XMLStreamException {
+		writer.writeStartElement(DavSchema.DAV_NS, "response");
+		writer.writeStartElement(DavSchema.DAV_NS, "href");
+		writer.writeCharacters(url(parent));
+		writer.writeEndElement();
 		for (QName property : properties) {
-			Element propstat = appendElement(response, DavSchema.DAV_PROPSTAT);
-			Element prop = appendElement(propstat, DavSchema.DAV_PROP);
-			int status = fillProperty(req, prop, property);
-			appendTextElement(propstat, DavSchema.DAV_STATUS, "HTTP/1.1 " + status + " " + EnglishReasonPhraseCatalog.INSTANCE.getReason(status, null));
+			writer.writeStartElement(DavSchema.DAV_NS, "propstat");
+			writer.writeStartElement(DavSchema.DAV_NS, "prop");
+			int status = fillProperty(ctx, writer, property);
+			writer.writeEndElement();
+			writer.writeStartElement(DavSchema.DAV_NS, "status");
+			writer.writeCharacters("HTTP/1.1 " + status + " "
+				+ EnglishReasonPhraseCatalog.INSTANCE.getReason(status, null));
+			writer.writeEndElement();
+			writer.writeEndElement();
 		}
+		writer.writeEndElement();
 	}
 
 	/**
-	 * Fills the given property container element with property information.
-	 * @param req
-	 *        The current request.
-	 * @param propElement
-	 *        The {@link Element} to fill with property information.
-	 * @param property
-	 *        The qualified name of the property to retrieve.
-	 * @return The status code for the request.
+	 * Writes the contents of the property {@code property} into the open
+	 * {@code <d:prop>} element on {@code writer}, returning the WebDAV property
+	 * status code.
+	 *
+	 * <p>
+	 * Implementations must either write the property element entirely (and
+	 * return {@link HttpServletResponse#SC_OK}) or write nothing (and return
+	 * {@link HttpServletResponse#SC_NOT_FOUND}).
+	 * </p>
 	 */
-	public int fillProperty(HttpServletRequest req, Element propElement, QName property) {
+	public int fillProperty(RenderContext ctx, XMLStreamWriter writer, QName property)
+			throws XMLStreamException {
 		if (DavSchema.DAV_CURRENT_USER_PRINCIPAL.equals(property)) {
-			String userName = LoginFilter.getAuthenticatedUser(req);
+			String userName = ctx.authenticatedUser();
 			if (userName != null) {
-				Element container = appendElement(propElement, DavSchema.DAV_CURRENT_USER_PRINCIPAL);
-				appendTextElement(container, DavSchema.DAV_HREF, url(CardDavServlet.PRINCIPALS_PATH + userName));
+				writer.writeStartElement(DavSchema.DAV_NS, "current-user-principal");
+				writer.writeStartElement(DavSchema.DAV_NS, "href");
+				writer.writeCharacters(url(CardDavServlet.PRINCIPALS_PATH + userName));
+				writer.writeEndElement();
+				writer.writeEndElement();
 				return HttpServletResponse.SC_OK;
 			}
 		}
 		else if (DavSchema.DAV_DISPLAYNAME.equals(property)) {
 			String displayName = getDisplayName();
 			if (displayName != null) {
-				Element container = appendElement(propElement, DavSchema.DAV_DISPLAYNAME);
-				appendText(container, displayName);
+				writer.writeStartElement(DavSchema.DAV_NS, "displayname");
+				writer.writeCharacters(displayName);
+				writer.writeEndElement();
 				return HttpServletResponse.SC_OK;
 			}
 		}
 		else if (DavSchema.DAV_RESOURCETYPE.equals(property)) {
-			Element container = appendElement(propElement, DavSchema.DAV_RESOURCETYPE);
+			writer.writeStartElement(DavSchema.DAV_NS, "resourcetype");
 			if (isCollection()) {
-				appendElement(container, DavSchema.DAV_COLLECTION);
+				writer.writeEmptyElement(DavSchema.DAV_NS, "collection");
 			}
 			QName type = getResourceType();
 			if (type != null) {
-				appendElement(container, type);
+				writer.writeEmptyElement(type.getNamespaceURI(), type.getLocalPart());
 			}
+			writer.writeEndElement();
 			return HttpServletResponse.SC_OK;
 		}
 		else if (DavSchema.DAV_GETETAG.equals(property)) {
 			String etag = getEtag();
 			if (etag != null) {
-				Element container = appendElement(propElement, DavSchema.DAV_GETETAG);
-				appendText(container, quote(etag));
+				writer.writeStartElement(DavSchema.DAV_NS, "getetag");
+				writer.writeCharacters(quote(etag));
+				writer.writeEndElement();
 				return HttpServletResponse.SC_OK;
 			}
 		}
 		else if (CardDavSchema.CALENDARSERVER_GETCTAG.equals(property)) {
 			String etag = getEtag();
 			if (etag != null) {
-				Element container = appendElement(propElement, CardDavSchema.CALENDARSERVER_GETCTAG);
-				appendText(container, etag);
+				writer.writeStartElement(CardDavSchema.CALENDARSERVER_NS, "getctag");
+				writer.writeCharacters(etag);
+				writer.writeEndElement();
 				return HttpServletResponse.SC_OK;
 			}
 		}
-		
+
 		if (UNSUPPORTED_KNOWN.putIfAbsent(property, property) == null) {
 			LOG.warn("Discovered new unsupported DAV property '" + property + "': " + _resourcePath);
 		}
@@ -196,7 +213,7 @@ public abstract class Resource {
 	}
 
 	/**
-	 * The display name of this resource. 
+	 * The display name of this resource.
 	 */
 	protected String getDisplayName() {
 		int sepIndex = _resourcePath.lastIndexOf('/');
@@ -206,16 +223,16 @@ public abstract class Resource {
 		return _resourcePath.substring(sepIndex + 1);
 	}
 
-	/** 
+	/**
 	 * The resource type of this resource.
 	 */
 	protected QName getResourceType() {
 		return null;
 	}
 
-	/** 
+	/**
 	 * Whether this resource is a WEBDAV collection.
-	 * 
+	 *
 	 * @see #list()
 	 */
 	protected boolean isCollection() {
@@ -224,7 +241,7 @@ public abstract class Resource {
 
 	/**
 	 * Quotes the given <code>etag</code> contents producing an <code>etag</code> string.
-	 * 
+	 *
 	 * @see #getEtag()
 	 */
 	public static String quote(String etag) {
@@ -233,7 +250,7 @@ public abstract class Resource {
 
 	/**
 	 * The unquoted <code>etag</code> content.
-	 * 
+	 *
 	 * @see #quote(String)
 	 */
 	public String getEtag() {
@@ -244,9 +261,9 @@ public abstract class Resource {
 		return _rootUrl + suffix;
 	}
 
-	/** 
+	/**
 	 * All sub-resources, if this is a collection resource.
-	 * 
+	 *
 	 * @see #isCollection()
 	 */
 	public Collection<? extends Resource> list() {
@@ -255,7 +272,7 @@ public abstract class Resource {
 
 	/**
 	 * The URL of this resource.
-	 * 
+	 *
 	 * @param parent
 	 *        The parent {@link Resource} from which a relative url can be constructed. <code>null</code> to construct
 	 *        an absolute URL.
@@ -264,7 +281,7 @@ public abstract class Resource {
 		// Note: Using short relative URLs prevents the Fritz!Box from issuing "DELETE" commands
 		// when a user removes a number from his block list. The effect is that the number is re-added
 		// to his block list upon the next synchronization. It is currently unclear what's the
-		// problem, since loading and adding new numbers works fine. 
+		// problem, since loading and adding new numbers works fine.
 		//
 		// if (parent != null) {
 		// 	return _resourcePath.substring(parent.getResourcePath().length());
@@ -272,19 +289,19 @@ public abstract class Resource {
 		return _rootUrl + _resourcePath;
 	}
 
-	/** 
+	/**
 	 * The sub-resource with the given URL, if this is a collection.
-	 * 
+	 *
 	 * @param url URL of a child resource to retrieve.
 	 * @return The URL of the child resource, or <code>null</code> of no such child exists.
-	 * 
+	 *
 	 * @see #isCollection()
 	 */
 	public Resource get(String url) {
 		return null;
 	}
 
-	/** 
+	/**
 	 * Requests to delete this resource.
 	 */
 	public void delete(HttpServletResponse resp) {
@@ -293,12 +310,12 @@ public abstract class Resource {
 
 	/**
 	 * Creates this resource from the data in the given request.
-	 * 
+	 *
 	 * @param req
 	 *        The request that carries the <code>vcard</code> data.
 	 * @param resp
 	 *        The response to report errors to.
-	 * 
+	 *
 	 * @throws IOException
 	 *         If reading the content fails.
 	 */
@@ -306,14 +323,14 @@ public abstract class Resource {
 		resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
 	}
 
-	/** 
+	/**
 	 * Retrieves the content of this resource.
 	 *
 	 * @param req
 	 *        The request.
 	 * @param resp
 	 *        The response where the contents is written to.
-	 * 
+	 *
 	 * @throws IOException
 	 *         If reading the content fails.
 	 */

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/util/DomUtil.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/util/DomUtil.java
@@ -41,37 +41,6 @@ public class DomUtil {
 		}
 	}
 
-	public static void appendTextElement(Element response, QName qname, String text) {
-		appendTextElement(response, qname.getNamespaceURI(), qname.getLocalPart(), qname.getPrefix(), text);
-	}
-	
-	public static void appendTextElement(Element response, String nsUri, String localName, String prefix, String text) {
-		appendText(appendElement(response, nsUri, localName, prefix), text);
-	}
-
-	public static void appendText(Element element, String string) {
-		element.appendChild(element.getOwnerDocument().createTextNode(string));
-	}
-
-	public static Element appendElement(Node parent, QName qname) {
-		return appendElement(parent, qname.getNamespaceURI(), qname.getLocalPart(), qname.getPrefix());
-	}
-	
-	public static Element appendElement(Node parent, String nsUri, String localName, String prefix) {
-		Element element;
-		if (prefix.isEmpty()) {
-			element = ownerDocument(parent).createElementNS(nsUri, localName);
-		} else {
-			element = ownerDocument(parent).createElementNS(nsUri, prefix + ':' + localName);
-		}
-		parent.appendChild(element);
-		return element;
-	}
-
-	public static Document ownerDocument(Node parent) {
-		return parent.getNodeType() == Node.DOCUMENT_NODE ? (Document) parent : parent.getOwnerDocument();
-	}
-
 	public static Iterable<Element> elements(Node root, QName... names) {
 		Iterable<Element> children = elements(root);
 		for (QName name : names) {

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestAddressBookCache.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestAddressBookCache.java
@@ -109,6 +109,68 @@ public class TestAddressBookCache {
 		Assertions.assertEquals(Arrays.asList("+39011111111", "+49333333333"), phoneNumbers(numbers));
 	}
 	
+	/**
+	 * The lightweight {@link AddressBookCache#lookupCollectionEtag} must
+	 * produce a byte-identical ETag to the heavy
+	 * {@link AddressBookCache#lookupAddressBook} path for the same user —
+	 * otherwise iOS would see a flapping ctag between the two paths and
+	 * resync constantly.
+	 */
+	@Test
+	public void testLookupCollectionEtag_matchesHeavyPath_commonOnly() {
+		_db.createUser("u1", "u1", "fr", "+39");
+		UserSettings settings = _db.getSettings("u1");
+		settings.setNationalOnly(false);
+		settings.setMinVotes(2);
+		_db.updateSettings(settings);
+
+		AddressBookResource heavy = _cache.lookupAddressBook(
+			"https://x", "/x", "/addresses/u1/", "u1", settings);
+		String light = _cache.lookupCollectionEtag("u1", settings);
+
+		Assertions.assertEquals(heavy.getEtag(), light);
+	}
+
+	@Test
+	public void testLookupCollectionEtag_matchesHeavyPath_personalized() {
+		_db.createUser("u1", "u1", "fr", "+39");
+		UserSettings settings = _db.getSettings("u1");
+		settings.setNationalOnly(false);
+		settings.setMinVotes(2);
+		_db.updateSettings(settings);
+
+		_db.addRating("u1", NumberAnalyzer.analyze("+39055555555", "+49"), "+39",
+			Rating.E_ADVERTISING, null, "fr", _now);
+
+		// Force a fresh lookup — settings changes invalidate caches but personal
+		// rating writes don't, so flush the user cache to mirror what the live
+		// PUT path does.
+		_cache.flushUserCache("u1");
+
+		AddressBookResource heavy = _cache.lookupAddressBook(
+			"https://x", "/x", "/addresses/u1/", "u1", settings);
+		String light = _cache.lookupCollectionEtag("u1", settings);
+
+		Assertions.assertEquals(heavy.getEtag(), light);
+	}
+
+	@Test
+	public void testLookupCollectionEtag_changesWithPersonalization() {
+		_db.createUser("u1", "u1", "fr", "+39");
+		UserSettings settings = _db.getSettings("u1");
+		settings.setNationalOnly(false);
+		settings.setMinVotes(2);
+		_db.updateSettings(settings);
+
+		String before = _cache.lookupCollectionEtag("u1", settings);
+
+		_db.addRating("u1", NumberAnalyzer.analyze("+39055555555", "+49"), "+39",
+			Rating.E_ADVERTISING, null, "fr", _now);
+
+		String after = _cache.lookupCollectionEtag("u1", settings);
+		Assertions.assertNotEquals(before, after);
+	}
+
 	@Test
 	public void testLookupPersonalized() {
 		_db.createUser("u1", "u1", "fr", "+39");

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestAddressBookEtag.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestAddressBookEtag.java
@@ -23,7 +23,9 @@ class TestAddressBookEtag {
 	}
 
 	private static AddressBookResource bookOf(int settingsHash, NumberBlock... blocks) {
-		return new AddressBookResource("https://x/", "/x/", "/x/", "u", Arrays.asList(blocks), settingsHash);
+		List<NumberBlock> blockList = Arrays.asList(blocks);
+		String etag = CollectionEtag.forFullPipeline(blockList, settingsHash);
+		return new AddressBookResource("https://x/", "/x/", "/x/", "u", blockList, etag);
 	}
 
 	// ===== Test 8: Block-ETag =====
@@ -78,8 +80,10 @@ class TestAddressBookEtag {
 		List<NumberBlock> second = List.of(
 			blockOf("+493012", "+493012345"),
 			blockOf("+491521", "+491521010"));
-		AddressBookResource a = new AddressBookResource("https://x/", "/x/", "/x/", "u", first, 42);
-		AddressBookResource b = new AddressBookResource("https://x/", "/x/", "/x/", "u", second, 42);
+		AddressBookResource a = new AddressBookResource("https://x/", "/x/", "/x/", "u", first,
+			CollectionEtag.forFullPipeline(first, 42));
+		AddressBookResource b = new AddressBookResource("https://x/", "/x/", "/x/", "u", second,
+			CollectionEtag.forFullPipeline(second, 42));
 		assertEquals(a.getEtag(), b.getEtag());
 	}
 

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestCollectionEtag.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestCollectionEtag.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import de.haumacher.phoneblock.analysis.NumberBlock;
+
+/**
+ * Phase-2 tests: input-based collection ETag composition.
+ *
+ * <p>
+ * Verifies that {@link CollectionEtag} produces stable, deterministic
+ * hashes from the components that drive a CardDAV collection ETag
+ * (block list, personal singletons, settings hash) and that the
+ * composition is sensitive to all three of them.
+ * </p>
+ */
+class TestCollectionEtag {
+
+	private static NumberBlock blockOf(String prefix, String... numbers) {
+		return new NumberBlock(prefix, Arrays.asList(numbers));
+	}
+
+	private static final List<NumberBlock> BLOCKS = List.of(
+		blockOf("+491521", "+491521010", "+491521011"),
+		blockOf("+493012", "+493012345"));
+
+	@Test
+	void hashBlocks_stableOnIdenticalInput() {
+		assertEquals(CollectionEtag.hashBlocks(BLOCKS), CollectionEtag.hashBlocks(BLOCKS));
+	}
+
+	@Test
+	void hashBlocks_orderIndependent() {
+		List<NumberBlock> reversed = List.of(BLOCKS.get(1), BLOCKS.get(0));
+		assertEquals(CollectionEtag.hashBlocks(BLOCKS), CollectionEtag.hashBlocks(reversed));
+	}
+
+	@Test
+	void hashBlocks_sensitiveToBlockSet() {
+		List<NumberBlock> reduced = List.of(BLOCKS.get(0));
+		assertNotEquals(CollectionEtag.hashBlocks(BLOCKS), CollectionEtag.hashBlocks(reduced));
+	}
+
+	@Test
+	void hashPersonalSingletons_orderIndependent() {
+		List<String> a = List.of("+491111", "+492222", "+493333");
+		List<String> b = List.of("+493333", "+491111", "+492222");
+		assertEquals(CollectionEtag.hashPersonalSingletons(a),
+			CollectionEtag.hashPersonalSingletons(b));
+	}
+
+	@Test
+	void hashPersonalSingletons_emptyIsStable() {
+		assertEquals(CollectionEtag.hashPersonalSingletons(List.of()),
+			CollectionEtag.hashPersonalSingletons(List.of()));
+	}
+
+	@Test
+	void hashPersonalSingletons_sensitiveToContent() {
+		assertNotEquals(CollectionEtag.hashPersonalSingletons(List.of("+491111")),
+			CollectionEtag.hashPersonalSingletons(List.of("+492222")));
+	}
+
+	/**
+	 * The full-pipeline ETag must be byte-identical to a {@code compose} call
+	 * with an empty personal hash and the same blocks/settings, because the
+	 * full-pipeline path is just the common-blocks path without personal
+	 * singletons.
+	 */
+	@Test
+	void forFullPipeline_equivalentToComposeWithEmptyPersonalHash() {
+		String full = CollectionEtag.forFullPipeline(BLOCKS, 42);
+		String composed = CollectionEtag.compose(
+			CollectionEtag.hashBlocks(BLOCKS),
+			CollectionEtag.hashPersonalSingletons(List.of()),
+			42);
+		assertEquals(full, composed);
+	}
+
+	@Test
+	void compose_sensitiveToBlocksHash() {
+		assertNotEquals(
+			CollectionEtag.compose("aaaaaaaaaaaa", "0", 42),
+			CollectionEtag.compose("bbbbbbbbbbbb", "0", 42));
+	}
+
+	@Test
+	void compose_sensitiveToPersonalHash() {
+		assertNotEquals(
+			CollectionEtag.compose("aaaaaaaaaaaa", "0", 42),
+			CollectionEtag.compose("aaaaaaaaaaaa", "1", 42));
+	}
+
+	@Test
+	void compose_sensitiveToSettingsHash() {
+		assertNotEquals(
+			CollectionEtag.compose("aaaaaaaaaaaa", "0", 42),
+			CollectionEtag.compose("aaaaaaaaaaaa", "0", 43));
+	}
+
+	/**
+	 * Format invariant: the ETag is a 12-character hex string (48 bits of
+	 * SHA-1 prefix), as expected by clients that have already cached an ETag
+	 * from before Phase 2 — and so that the wire format stays consistent.
+	 */
+	@Test
+	void format_is12HexChars() {
+		String etag = CollectionEtag.forFullPipeline(BLOCKS, 42);
+		assertEquals(12, etag.length(), "ETag length: " + etag);
+		assertEquals(etag, etag.toLowerCase(), "ETag should be lower-case hex: " + etag);
+		etag.chars().forEach(c -> {
+			if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) {
+				throw new AssertionError("Non-hex char in ETag: " + (char) c);
+			}
+		});
+	}
+}

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
@@ -56,7 +56,8 @@ class TestRenderPipeline {
 			new NumberBlock("+491521", Arrays.asList("+491521010", "+491521011")),
 			new NumberBlock("+493012", Arrays.asList("+493012345")));
 		return new AddressBookResource(ROOT_URL, SERVER_ROOT,
-			"/addresses/alice/", "alice", blocks, 42);
+			"/addresses/alice/", "alice", blocks,
+			CollectionEtag.forFullPipeline(blocks, 42));
 	}
 
 	private static Document render(RenderHook hook) throws Exception {

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Bernhard Haumacher et al. All Rights Reserved.
+ */
+package de.haumacher.phoneblock.carddav.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import de.haumacher.phoneblock.analysis.NumberBlock;
+import de.haumacher.phoneblock.carddav.schema.CardDavSchema;
+import de.haumacher.phoneblock.carddav.schema.DavSchema;
+
+/**
+ * Smoke tests for the StAX-based render pipeline. Constructs fixture resources,
+ * renders a multistatus response into a {@link ByteArrayOutputStream}, parses
+ * the bytes back into a DOM and asserts the structural shape.
+ *
+ * Per Phase 1 of {@code 2026-05-02-carddav-render-pipeline.md}: enough
+ * coverage to confirm the new pipeline produces correctly-namespaced,
+ * structurally-equivalent output. Goldfile-level coverage (Ebene 1) follows
+ * in a later commit.
+ */
+class TestRenderPipeline {
+
+	private static final String ROOT_URL = "https://phoneblock.net/phoneblock/contacts";
+	private static final String SERVER_ROOT = "/phoneblock/contacts";
+
+	private static final List<QName> COLLECTION_PROPS = List.of(
+		DavSchema.DAV_RESOURCETYPE,
+		DavSchema.DAV_DISPLAYNAME,
+		DavSchema.DAV_GETETAG,
+		CardDavSchema.CALENDARSERVER_GETCTAG);
+
+	private static final List<QName> ADDRESS_PROPS = List.of(
+		DavSchema.DAV_GETETAG,
+		CardDavSchema.CARDDAV_ADDRESS_DATA);
+
+	private static AddressBookResource fixtureBook() {
+		List<NumberBlock> blocks = List.of(
+			new NumberBlock("+491521", Arrays.asList("+491521010", "+491521011")),
+			new NumberBlock("+493012", Arrays.asList("+493012345")));
+		return new AddressBookResource(ROOT_URL, SERVER_ROOT,
+			"/addresses/alice/", "alice", blocks, 42);
+	}
+
+	private static Document render(RenderHook hook) throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		XMLStreamWriter writer = MultiStatusWriter.open(out);
+		try {
+			hook.write(writer);
+		} finally {
+			MultiStatusWriter.close(writer);
+		}
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+		return factory.newDocumentBuilder().parse(new ByteArrayInputStream(out.toByteArray()));
+	}
+
+	@FunctionalInterface
+	private interface RenderHook {
+		void write(XMLStreamWriter writer) throws Exception;
+	}
+
+	@Test
+	void multistatusRoot_isCorrectlyNamespaced() throws Exception {
+		Document doc = render(writer -> {
+			// Just open and close the envelope.
+		});
+		Element root = doc.getDocumentElement();
+		assertEquals("multistatus", root.getLocalName());
+		assertEquals(DavSchema.DAV_NS, root.getNamespaceURI());
+	}
+
+	@Test
+	void addressBook_propfind_writesOwnResponse() throws Exception {
+		AddressBookResource book = fixtureBook();
+		RenderContext ctx = new RenderContext("alice");
+
+		Document doc = render(writer -> book.propfind(ctx, null, writer, COLLECTION_PROPS));
+
+		NodeList responses = doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response");
+		assertEquals(1, responses.getLength());
+
+		Element response = (Element) responses.item(0);
+		String href = singleText(response, DavSchema.DAV_NS, "href");
+		assertEquals(ROOT_URL + "/addresses/alice/", href);
+
+		// resourcetype contains <d:collection/> + <c:addressbook/>
+		Element resourceType = descendant(response, DavSchema.DAV_NS, "resourcetype");
+		assertNotNull(resourceType);
+		assertNotNull(childElement(resourceType, DavSchema.DAV_NS, "collection"));
+		assertNotNull(childElement(resourceType, CardDavSchema.CARDDAV_NS, "addressbook"));
+
+		// displayname = BLOCKLIST
+		assertEquals("BLOCKLIST", singleText(response, DavSchema.DAV_NS, "displayname"));
+
+		// getetag and getctag carry the same hash; quote only on getetag.
+		String quotedEtag = singleText(response, DavSchema.DAV_NS, "getetag");
+		String unquotedEtag = singleText(response, CardDavSchema.CALENDARSERVER_NS, "getctag");
+		assertTrue(quotedEtag.startsWith("\"") && quotedEtag.endsWith("\""), "getetag should be quoted: " + quotedEtag);
+		assertEquals(quotedEtag, "\"" + unquotedEtag + "\"");
+		assertEquals(book.getEtag(), unquotedEtag);
+
+		// All four propstat blocks have status 200.
+		NodeList propstats = response.getElementsByTagNameNS(DavSchema.DAV_NS, "propstat");
+		assertEquals(COLLECTION_PROPS.size(), propstats.getLength());
+		for (int i = 0; i < propstats.getLength(); i++) {
+			Element propstat = (Element) propstats.item(i);
+			assertEquals("HTTP/1.1 200 OK", singleText(propstat, DavSchema.DAV_NS, "status"));
+		}
+	}
+
+	@Test
+	void addressBook_children_renderedFromList() throws Exception {
+		AddressBookResource book = fixtureBook();
+		RenderContext ctx = new RenderContext("alice");
+
+		Document doc = render(writer -> {
+			for (Resource child : book.list()) {
+				child.propfind(ctx, book, writer, ADDRESS_PROPS);
+			}
+		});
+
+		NodeList responses = doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response");
+		assertEquals(2, responses.getLength());
+
+		for (int i = 0; i < responses.getLength(); i++) {
+			Element response = (Element) responses.item(i);
+			String href = singleText(response, DavSchema.DAV_NS, "href");
+			assertTrue(href.startsWith(ROOT_URL + "/addresses/alice/"), "child href: " + href);
+
+			String addressData = singleText(response, CardDavSchema.CARDDAV_NS, "address-data");
+			assertTrue(addressData.startsWith("BEGIN:VCARD"), "address-data should be vCard: " + addressData);
+		}
+	}
+
+	@Test
+	void addressBook_renderMultiGet_mixesFoundAndMissing() throws Exception {
+		AddressBookResource book = fixtureBook();
+		RenderContext ctx = new RenderContext("alice");
+
+		String existingHref = ROOT_URL + "/addresses/alice/+491521";
+		// Out-of-collection URL — get(url) rejects it and renderMultiGet emits a 404.
+		// (A within-collection but unknown id would return a stub resource for the
+		// PUT path, which is not what this test asserts.)
+		String missingHref = ROOT_URL + "/elsewhere/foo";
+
+		Document doc = render(writer -> book.renderMultiGet(ctx, writer,
+			List.of(existingHref, missingHref), List.of(CardDavSchema.CARDDAV_ADDRESS_DATA)));
+
+		NodeList responses = doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response");
+		assertEquals(2, responses.getLength());
+
+		Element first = (Element) responses.item(0);
+		assertEquals(existingHref, singleText(first, DavSchema.DAV_NS, "href"));
+		assertEquals("HTTP/1.1 200 OK", singleText(first, DavSchema.DAV_NS, "status"));
+		assertNotNull(descendant(first, DavSchema.DAV_NS, "prop"));
+
+		Element second = (Element) responses.item(1);
+		assertEquals(missingHref, singleText(second, DavSchema.DAV_NS, "href"));
+		assertEquals("HTTP/1.1 404 Not Found", singleText(second, DavSchema.DAV_NS, "status"));
+		// 404 case: no <d:prop> at all, just status.
+		assertNull(descendant(second, DavSchema.DAV_NS, "prop"));
+	}
+
+	@Test
+	void resource_unsupportedProperty_writes404Status() throws Exception {
+		AddressBookResource book = fixtureBook();
+		RenderContext ctx = new RenderContext("alice");
+		QName unsupported = new QName(DavSchema.DAV_NS, "principal-URL", "");
+
+		Document doc = render(writer -> book.propfind(ctx, null, writer, List.of(unsupported)));
+
+		Element response = (Element) doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response").item(0);
+		Element propstat = childElement(response, DavSchema.DAV_NS, "propstat");
+		assertEquals("HTTP/1.1 404 Not Found", singleText(propstat, DavSchema.DAV_NS, "status"));
+		Element prop = childElement(propstat, DavSchema.DAV_NS, "prop");
+		assertNotNull(prop);
+		// Empty prop element on 404.
+		assertEquals(0, prop.getElementsByTagName("*").getLength());
+	}
+
+	@Test
+	void principal_currentUserPrincipal_emitsHrefForAuthenticated() throws Exception {
+		PrincipalResource principal = new PrincipalResource(ROOT_URL, "/principals/alice", "alice");
+		RenderContext ctx = new RenderContext("alice");
+
+		Document doc = render(writer -> principal.propfind(ctx, null, writer,
+			List.of(DavSchema.DAV_CURRENT_USER_PRINCIPAL,
+				CardDavSchema.CARDDAV_ADDRESSBOOK_HOME_SET)));
+
+		Element response = (Element) doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response").item(0);
+
+		Element cup = descendant(response, DavSchema.DAV_NS, "current-user-principal");
+		assertEquals(ROOT_URL + "/principals/alice", singleText(cup, DavSchema.DAV_NS, "href"));
+
+		Element home = descendant(response, CardDavSchema.CARDDAV_NS, "addressbook-home-set");
+		assertEquals(ROOT_URL + "/addresses/alice/", singleText(home, DavSchema.DAV_NS, "href"));
+	}
+
+	@Test
+	void principal_currentUserPrincipal_unauthenticated_returns404() throws Exception {
+		PrincipalResource principal = new PrincipalResource(ROOT_URL, "/principals/alice", "alice");
+		RenderContext ctx = new RenderContext(null);
+
+		Document doc = render(writer -> principal.propfind(ctx, null, writer,
+			List.of(DavSchema.DAV_CURRENT_USER_PRINCIPAL)));
+
+		Element response = (Element) doc.getElementsByTagNameNS(DavSchema.DAV_NS, "response").item(0);
+		Element propstat = childElement(response, DavSchema.DAV_NS, "propstat");
+		assertEquals("HTTP/1.1 404 Not Found", singleText(propstat, DavSchema.DAV_NS, "status"));
+	}
+
+	/**
+	 * Returns the text content of the first descendant element with the given
+	 * qualified name within {@code parent}. Asserts the element exists.
+	 */
+	private static String singleText(Element parent, String ns, String localName) {
+		Element child = descendant(parent, ns, localName);
+		assertNotNull(child, () -> "Expected descendant {" + ns + "}" + localName);
+		return child.getTextContent();
+	}
+
+	/**
+	 * First descendant element with the given qualified name, or {@code null}.
+	 */
+	private static Element descendant(Element parent, String ns, String localName) {
+		if (parent == null) {
+			return null;
+		}
+		NodeList all = parent.getElementsByTagNameNS(ns, localName);
+		return all.getLength() == 0 ? null : (Element) all.item(0);
+	}
+
+	private static Element childElement(Element parent, String ns, String localName) {
+		if (parent == null) {
+			return null;
+		}
+		NodeList children = parent.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			if (children.item(i) instanceof Element child
+				&& ns.equals(child.getNamespaceURI())
+				&& localName.equals(child.getLocalName())) {
+				return child;
+			}
+		}
+		return null;
+	}
+}

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/carddav/resource/TestRenderPipeline.java
@@ -215,6 +215,50 @@ class TestRenderPipeline {
 		assertEquals(ROOT_URL + "/addresses/alice/", singleText(home, DavSchema.DAV_NS, "href"));
 	}
 
+	/**
+	 * Phase-3 regression: the lightweight {@link AddressBookCollectionResource}
+	 * must render byte-identical Depth: 0 output to the heavy
+	 * {@link AddressBookResource} when both carry the same ETag — otherwise
+	 * the two paths would emit different XML for the same client poll.
+	 */
+	@Test
+	void addressBookCollection_lightweight_matchesHeavyForCollectionProps() throws Exception {
+		AddressBookResource heavy = fixtureBook();
+		RenderContext ctx = new RenderContext("alice");
+
+		AddressBookCollectionResource light = new AddressBookCollectionResource(
+			ROOT_URL, "/addresses/alice/", heavy.getEtag());
+
+		Document heavyDoc = render(writer -> heavy.propfind(ctx, null, writer, COLLECTION_PROPS));
+		Document lightDoc = render(writer -> light.propfind(ctx, null, writer, COLLECTION_PROPS));
+
+		Element heavyResponse = (Element) heavyDoc.getElementsByTagNameNS(DavSchema.DAV_NS, "response").item(0);
+		Element lightResponse = (Element) lightDoc.getElementsByTagNameNS(DavSchema.DAV_NS, "response").item(0);
+
+		// Property values must coincide one-by-one.
+		assertEquals(singleText(heavyResponse, DavSchema.DAV_NS, "displayname"),
+			singleText(lightResponse, DavSchema.DAV_NS, "displayname"));
+		assertEquals(singleText(heavyResponse, DavSchema.DAV_NS, "getetag"),
+			singleText(lightResponse, DavSchema.DAV_NS, "getetag"));
+		assertEquals(singleText(heavyResponse, CardDavSchema.CALENDARSERVER_NS, "getctag"),
+			singleText(lightResponse, CardDavSchema.CALENDARSERVER_NS, "getctag"));
+
+		// resourcetype contents are identical (both have collection + addressbook children).
+		Element heavyType = descendant(heavyResponse, DavSchema.DAV_NS, "resourcetype");
+		Element lightType = descendant(lightResponse, DavSchema.DAV_NS, "resourcetype");
+		assertNotNull(childElement(lightType, DavSchema.DAV_NS, "collection"));
+		assertNotNull(childElement(lightType, CardDavSchema.CARDDAV_NS, "addressbook"));
+		assertNotNull(childElement(heavyType, DavSchema.DAV_NS, "collection"));
+		assertNotNull(childElement(heavyType, CardDavSchema.CARDDAV_NS, "addressbook"));
+	}
+
+	@Test
+	void addressBookCollection_lightweight_listIsEmpty() {
+		AddressBookCollectionResource light = new AddressBookCollectionResource(
+			ROOT_URL, "/addresses/alice/", "abc123");
+		assertEquals(0, light.list().size());
+	}
+
 	@Test
 	void principal_currentUserPrincipal_unauthenticated_returns404() throws Exception {
 		PrincipalResource principal = new PrincipalResource(ROOT_URL, "/principals/alice", "alice");


### PR DESCRIPTION
## Summary

Setzt die Hebel B (StAX-Render) und E (Lightweight Depth-0) aus dem
[CardDAV-Performance-Plan](docs/plans/2026-05-02-carddav-performance.md) gemeinsam um, weil beide den Render-Pfad anfassen — separat würden sie zu Patch-Chaos führen. Vier Phasen, dokumentiert in [`docs/plans/2026-05-02-carddav-render-pipeline.md`](docs/plans/2026-05-02-carddav-render-pipeline.md).

- **Phase 1 — DOM → StAX**: Resource-Hierarchie schreibt direkt per `XMLStreamWriter` in den Output-Stream. `RenderContext` als servletfreier Wertobjekt, `MultiStatusWriter` als Envelope-Helper, `CardDavRequestParser` für die Body-Parser. Polymorphe Render-Schicht, kein Renderer-Facade.
- **Phase 2 — Inputbasierter ETag**: `CollectionEtag` komponiert den Collection-ETag aus drei Komponenten (Common-Blocks-Hash, Personal-Singletons-Hash, Settings-Hash). `CommonList.blocksHash` einmal pro Refresh berechnet — der Per-User-ETag kostet danach ein paar Set-Probes und ein SHA-1-Update.
- **Phase 3 — Lightweight Depth-0**: `AddressBookCollectionResource` als schlanke Subklasse für PROPFIND Depth: 0 auf `/addresses/{user}/`. `AddressBookCache.lookupCollectionEtag` umgeht die Materialisierung der ~1086 `AddressResource`-Wrapper pro iOS-Poll. ETag byte-identisch zum Heavy-Pfad.
- **Phase 4 — Cleanup**: tote DOM-Output-Helper aus `DomUtil` raus, Performance-Plan auf "B+E umgesetzt" gestellt.

## Erwartete Wirkung (zu verifizieren nach Deploy)

- **iOS-Polling-Pfad** (~21 % Volumen, alle 18 min): Mini-PROPFIND ohne Wrapper-Allokation. `Address book computed for: …`-Logs sollten für common-only und common+personal-User auf null fallen.
- **FritzBox-Full-Sync** (72 % Volumen, jeder Poll Depth: 1): StAX direkt in den Output-Stream, Faktor 2-3 schneller, weniger Heap-Druck.
- **DAVx5 Sync-Bursts** (multiget × N): pro REPORT günstiger Render via StAX, `_userCache` amortisiert die Wrapper-Allokation über die ganze Session.

## Migrations-Effekt

Einmalige ETag-Wave beim Deploy: alle Clients sehen einen neuen ETag-Wert (geänderte Komposition), machen einen Vollsync, danach stationär. Wie bei Hebel A — Deployment-Fenster wählen, in dem das verträglich ist (nicht parallel zur 22:00-Release-Welle).

## Test plan

- [x] `mvn test` — 249 Tests grün (vorher 226), neue Tests: `TestRenderPipeline` (10), `TestCollectionEtag` (11), Erweiterungen in `TestAddressBookCache` (3) und `TestAddressBookEtag`.
- [x] Render-Equivalenz: Lightweight-Resource produziert byte-identischen ETag und kanonisch identisches Depth-0-XML wie der Heavy-Pfad.
- [x] ETag-Identität zwischen `lookupCollectionEtag` und `lookupAddressBook(...).getEtag()` getestet für common-only und common+personal.
- [ ] **Vor Merge — Live-Smoke auf Staging**:
  - iOS: ctag akzeptiert, Sync läuft, Übergang von altem zu neuem ETag löst genau einen Vollsync aus.
  - FritzBox: Full-Sync gibt korrekte Liste, DELETE-Verhalten unverändert.
  - PeopleSync: weiterhin 304 bei unverändertem ETag (einziger Client mit echtem `If-None-Match`-Pfad).

## Out of Scope

- **Hebel C** (geteilter `byte[]`-Cache pro `ListType`) — kommt erst, wenn die Wirkung von B+E gemessen ist.
- **Hebel D** (FritzBox-Auth-Loop) — orthogonal, Apache-Reverse-Proxy-Thema.
- **sync-collection (RFC 6578)** — bleibt verworfen, würde DB-Versionierung der Snapshot-Daten brauchen. Nach den Mess-Ergebnissen ggf. neu evaluieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)