### PR TITLE
Mobile: copy number to clipboard, rename "view on PhoneBlock"

### DIFF
--- a/phoneblock_mobile/lib/l10n/app_ar.arb
+++ b/phoneblock_mobile/lib/l10n/app_ar.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "مزامنة...",
   "blocklistSyncSuccess": "تمت مزامنة قائمة الحظر بنجاح",
   "blocklistSyncFailed": "فشل مزامنة قائمة الحظر",
-  "personalizedAddedDate": "تمت الإضافة: {date}"
+  "personalizedAddedDate": "تمت الإضافة: {date}",
+  "copyNumber": "رقم النسخة",
+  "numberCopied": "الرقم المنسوخ إلى الحافظة"
 }

--- a/phoneblock_mobile/lib/l10n/app_da.arb
+++ b/phoneblock_mobile/lib/l10n/app_da.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synkroniser...",
   "blocklistSyncSuccess": "Bloklistesynkronisering vellykket",
   "blocklistSyncFailed": "Bloklistesynkronisering mislykkedes",
-  "personalizedAddedDate": "Tilføjet: {date}."
+  "personalizedAddedDate": "Tilføjet: {date}.",
+  "copyNumber": "Kopienummer",
+  "numberCopied": "Nummer kopieret til udklipsholder"
 }

--- a/phoneblock_mobile/lib/l10n/app_de.arb
+++ b/phoneblock_mobile/lib/l10n/app_de.arb
@@ -310,10 +310,20 @@
     "description": "Menu item to report as spam",
     "x-translated": "9866ae0e"
   },
-  "viewOnPhoneBlockMenu": "Auf PhoneBlock ansehen",
+  "viewOnPhoneBlockMenu": "Im Browser öffnen",
   "@viewOnPhoneBlockMenu": {
-    "description": "Menu item to view on PhoneBlock",
-    "x-translated": "3b852ae7"
+    "description": "Menu item to open the number's PhoneBlock page in the in-app browser",
+    "x-translated": "fd61eaad"
+  },
+  "copyNumber": "Nummer kopieren",
+  "@copyNumber": {
+    "description": "Menu item to copy the phone number to the clipboard",
+    "x-translated": "b60977d3"
+  },
+  "numberCopied": "Nummer in Zwischenablage kopiert",
+  "@numberCopied": {
+    "description": "Snackbar message after copying the phone number to the clipboard",
+    "x-translated": "4edacb15"
   },
   "deleteCall": "Löschen",
   "@deleteCall": {

--- a/phoneblock_mobile/lib/l10n/app_el.arb
+++ b/phoneblock_mobile/lib/l10n/app_el.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Συγχρονισμός...",
   "blocklistSyncSuccess": "Επιτυχής συγχρονισμός λίστας αποκλεισμού",
   "blocklistSyncFailed": "Αποτυχία συγχρονισμού λίστας αποκλεισμού",
-  "personalizedAddedDate": "Προστέθηκε: {date}"
+  "personalizedAddedDate": "Προστέθηκε: {date}",
+  "copyNumber": "Αριθμός αντιγράφου",
+  "numberCopied": "Αριθμός που αντιγράφεται στο πρόχειρο"
 }

--- a/phoneblock_mobile/lib/l10n/app_en.arb
+++ b/phoneblock_mobile/lib/l10n/app_en.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synchronize...",
   "blocklistSyncSuccess": "Blocklist synchronization successful",
   "blocklistSyncFailed": "Blocklist synchronization failed",
-  "personalizedAddedDate": "Added: {date}"
+  "personalizedAddedDate": "Added: {date}",
+  "copyNumber": "Copy number",
+  "numberCopied": "Number copied to clipboard"
 }

--- a/phoneblock_mobile/lib/l10n/app_es.arb
+++ b/phoneblock_mobile/lib/l10n/app_es.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Sincroniza...",
   "blocklistSyncSuccess": "Sincronización correcta de la lista de bloqueo",
   "blocklistSyncFailed": "Error de sincronización de la lista de bloqueo",
-  "personalizedAddedDate": "Añadido: {date}"
+  "personalizedAddedDate": "Añadido: {date}",
+  "copyNumber": "Número de copia",
+  "numberCopied": "Número copiado en el portapapeles"
 }

--- a/phoneblock_mobile/lib/l10n/app_fr.arb
+++ b/phoneblock_mobile/lib/l10n/app_fr.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synchroniser...",
   "blocklistSyncSuccess": "Synchronisation des listes de blocage réussie",
   "blocklistSyncFailed": "Échec de la synchronisation de la liste de blocage",
-  "personalizedAddedDate": "Ajouté à la liste : {date}"
+  "personalizedAddedDate": "Ajouté à la liste : {date}",
+  "copyNumber": "Copier le numéro",
+  "numberCopied": "Numéro copié dans le presse-papiers"
 }

--- a/phoneblock_mobile/lib/l10n/app_it.arb
+++ b/phoneblock_mobile/lib/l10n/app_it.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Sincronizzare...",
   "blocklistSyncSuccess": "Sincronizzazione della lista di blocco riuscita",
   "blocklistSyncFailed": "Sincronizzazione della lista di blocco fallita",
-  "personalizedAddedDate": "Aggiunto: {date}"
+  "personalizedAddedDate": "Aggiunto: {date}",
+  "copyNumber": "Numero di copia",
+  "numberCopied": "Numero copiato negli appunti"
 }

--- a/phoneblock_mobile/lib/l10n/app_localizations.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations.dart
@@ -470,11 +470,23 @@ abstract class AppLocalizations {
   /// **'Als SPAM melden'**
   String get reportAsSpam;
 
-  /// Menu item to view on PhoneBlock
+  /// Menu item to open the number's PhoneBlock page in the in-app browser
   ///
   /// In de, this message translates to:
-  /// **'Auf PhoneBlock ansehen'**
+  /// **'Im Browser öffnen'**
   String get viewOnPhoneBlockMenu;
+
+  /// Menu item to copy the phone number to the clipboard
+  ///
+  /// In de, this message translates to:
+  /// **'Nummer kopieren'**
+  String get copyNumber;
+
+  /// Snackbar message after copying the phone number to the clipboard
+  ///
+  /// In de, this message translates to:
+  /// **'Nummer in Zwischenablage kopiert'**
+  String get numberCopied;
 
   /// Menu item to delete call
   ///

--- a/phoneblock_mobile/lib/l10n/app_localizations_ar.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_ar.dart
@@ -205,6 +205,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'عرض على PhoneBlock';
 
   @override
+  String get copyNumber => 'رقم النسخة';
+
+  @override
+  String get numberCopied => 'الرقم المنسوخ إلى الحافظة';
+
+  @override
   String get deleteCall => 'حذف';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_da.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_da.dart
@@ -204,6 +204,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Se på PhoneBlock';
 
   @override
+  String get copyNumber => 'Kopienummer';
+
+  @override
+  String get numberCopied => 'Nummer kopieret til udklipsholder';
+
+  @override
   String get deleteCall => 'Sletning';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_de.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_de.dart
@@ -202,7 +202,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get reportAsSpam => 'Als SPAM melden';
 
   @override
-  String get viewOnPhoneBlockMenu => 'Auf PhoneBlock ansehen';
+  String get viewOnPhoneBlockMenu => 'Im Browser öffnen';
+
+  @override
+  String get copyNumber => 'Nummer kopieren';
+
+  @override
+  String get numberCopied => 'Nummer in Zwischenablage kopiert';
 
   @override
   String get deleteCall => 'Löschen';

--- a/phoneblock_mobile/lib/l10n/app_localizations_el.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_el.dart
@@ -206,6 +206,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Προβολή στο PhoneBlock';
 
   @override
+  String get copyNumber => 'Αριθμός αντιγράφου';
+
+  @override
+  String get numberCopied => 'Αριθμός που αντιγράφεται στο πρόχειρο';
+
+  @override
   String get deleteCall => 'Διαγραφή';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_en.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_en.dart
@@ -204,6 +204,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'View on PhoneBlock';
 
   @override
+  String get copyNumber => 'Copy number';
+
+  @override
+  String get numberCopied => 'Number copied to clipboard';
+
+  @override
   String get deleteCall => 'Delete';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_es.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_es.dart
@@ -205,6 +205,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Ver en PhoneBlock';
 
   @override
+  String get copyNumber => 'Número de copia';
+
+  @override
+  String get numberCopied => 'Número copiado en el portapapeles';
+
+  @override
   String get deleteCall => 'Borrar';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_fr.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_fr.dart
@@ -206,6 +206,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Voir sur PhoneBlock';
 
   @override
+  String get copyNumber => 'Copier le numéro';
+
+  @override
+  String get numberCopied => 'Numéro copié dans le presse-papiers';
+
+  @override
   String get deleteCall => 'Supprimer';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_it.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_it.dart
@@ -206,6 +206,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Vista su PhoneBlock';
 
   @override
+  String get copyNumber => 'Numero di copia';
+
+  @override
+  String get numberCopied => 'Numero copiato negli appunti';
+
+  @override
   String get deleteCall => 'Cancellare';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_nb.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_nb.dart
@@ -206,6 +206,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Vis på PhoneBlock';
 
   @override
+  String get copyNumber => 'Kopi nummer';
+
+  @override
+  String get numberCopied => 'Nummer kopiert til utklippstavlen';
+
+  @override
   String get deleteCall => 'Slett';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_nl.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_nl.dart
@@ -206,6 +206,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Bekijk op PhoneBlock';
 
   @override
+  String get copyNumber => 'Kopieernummer';
+
+  @override
+  String get numberCopied => 'Nummer gekopieerd naar klembord';
+
+  @override
   String get deleteCall => 'Verwijder';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_pl.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_pl.dart
@@ -206,6 +206,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Wyświetl w PhoneBlock';
 
   @override
+  String get copyNumber => 'Numer kopii';
+
+  @override
+  String get numberCopied => 'Liczba skopiowana do schowka';
+
+  @override
   String get deleteCall => 'Usuń';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_sv.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_sv.dart
@@ -207,6 +207,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Visa på PhoneBlock';
 
   @override
+  String get copyNumber => 'Kopia nummer';
+
+  @override
+  String get numberCopied => 'Nummer kopierat till urklipp';
+
+  @override
   String get deleteCall => 'Radera';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_uk.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_uk.dart
@@ -204,6 +204,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get viewOnPhoneBlockMenu => 'Переглянути на PhoneBlock';
 
   @override
+  String get copyNumber => 'Номер копії';
+
+  @override
+  String get numberCopied => 'Номер скопійовано в буфер обміну';
+
+  @override
   String get deleteCall => 'Видалити';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_localizations_zh.dart
+++ b/phoneblock_mobile/lib/l10n/app_localizations_zh.dart
@@ -194,6 +194,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get viewOnPhoneBlockMenu => '在 PhoneBlock 上查看';
 
   @override
+  String get copyNumber => '副本编号';
+
+  @override
+  String get numberCopied => '复制到剪贴板的数字';
+
+  @override
   String get deleteCall => '删除';
 
   @override

--- a/phoneblock_mobile/lib/l10n/app_nb.arb
+++ b/phoneblock_mobile/lib/l10n/app_nb.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synkroniser...",
   "blocklistSyncSuccess": "Synkronisering av blokkliste vellykket",
   "blocklistSyncFailed": "Synkronisering av blokkeringslisten mislyktes",
-  "personalizedAddedDate": "Lagt til: {date}"
+  "personalizedAddedDate": "Lagt til: {date}",
+  "copyNumber": "Kopi nummer",
+  "numberCopied": "Nummer kopiert til utklippstavlen"
 }

--- a/phoneblock_mobile/lib/l10n/app_nl.arb
+++ b/phoneblock_mobile/lib/l10n/app_nl.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synchroniseren...",
   "blocklistSyncSuccess": "Synchronisatie van bloklijst geslaagd",
   "blocklistSyncFailed": "Synchronisatie blokkadelijst mislukt",
-  "personalizedAddedDate": "Toegevoegd: {date}"
+  "personalizedAddedDate": "Toegevoegd: {date}",
+  "copyNumber": "Kopieernummer",
+  "numberCopied": "Nummer gekopieerd naar klembord"
 }

--- a/phoneblock_mobile/lib/l10n/app_pl.arb
+++ b/phoneblock_mobile/lib/l10n/app_pl.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synchronizacja...",
   "blocklistSyncSuccess": "Synchronizacja listy bloków powiodła się",
   "blocklistSyncFailed": "Synchronizacja listy bloków nie powiodła się",
-  "personalizedAddedDate": "Dodano: {date}"
+  "personalizedAddedDate": "Dodano: {date}",
+  "copyNumber": "Numer kopii",
+  "numberCopied": "Liczba skopiowana do schowka"
 }

--- a/phoneblock_mobile/lib/l10n/app_sv.arb
+++ b/phoneblock_mobile/lib/l10n/app_sv.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Synkronisera...",
   "blocklistSyncSuccess": "Synkroniseringen av blocklistan lyckades",
   "blocklistSyncFailed": "Synkroniseringen av blocklistan misslyckades",
-  "personalizedAddedDate": "Tillagd: {date}"
+  "personalizedAddedDate": "Tillagd: {date}",
+  "copyNumber": "Kopia nummer",
+  "numberCopied": "Nummer kopierat till urklipp"
 }

--- a/phoneblock_mobile/lib/l10n/app_uk.arb
+++ b/phoneblock_mobile/lib/l10n/app_uk.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "Синхронізувати...",
   "blocklistSyncSuccess": "Синхронізація блокчейну успішна",
   "blocklistSyncFailed": "Не вдалося синхронізувати блокчейн",
-  "personalizedAddedDate": "Додано: {date}"
+  "personalizedAddedDate": "Додано: {date}",
+  "copyNumber": "Номер копії",
+  "numberCopied": "Номер скопійовано в буфер обміну"
 }

--- a/phoneblock_mobile/lib/l10n/app_zh.arb
+++ b/phoneblock_mobile/lib/l10n/app_zh.arb
@@ -306,5 +306,7 @@
   "blocklistSyncing": "同步...",
   "blocklistSyncSuccess": "拦截列表同步成功",
   "blocklistSyncFailed": "拦截列表同步失败",
-  "personalizedAddedDate": "已添加：<x1>日期</x1"
+  "personalizedAddedDate": "已添加：<x1>日期</x1",
+  "copyNumber": "副本编号",
+  "numberCopied": "复制到剪贴板的数字"
 }

--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -1769,6 +1769,26 @@ class _MainScreenState extends State<MainScreen> {
       ),
     );
 
+    // Copy number to clipboard option
+    items.add(
+      PopupMenuItem(
+        child: Row(
+          children: [
+            Icon(Icons.copy, color: Colors.blueGrey),
+            SizedBox(width: 12),
+            Text(context.l10n.copyNumber),
+          ],
+        ),
+        onTap: () {
+          Future.delayed(Duration.zero, () {
+            if (context.mounted) {
+              _copyNumber(context, call);
+            }
+          });
+        },
+      ),
+    );
+
     // Always show delete option
     items.add(
       PopupMenuItem(
@@ -2408,6 +2428,18 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   /// Opens the phone number on PhoneBlock website in a WebView.
+  /// Copies the call's phone number to the system clipboard.
+  Future<void> _copyNumber(BuildContext context, ScreenedCall call) async {
+    await Clipboard.setData(ClipboardData(text: call.phoneNumber));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.numberCopied),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
   Future<void> _viewOnPhoneBlock(ScreenedCall call) async {
     String? token = await getAuthToken();
     if (token == null) {


### PR DESCRIPTION
## Summary
- Add a "Nummer kopieren" entry to the per-call popup menu that copies the phone number to the system clipboard and shows a confirmation snackbar.
- Rename the existing "Auf PhoneBlock ansehen" entry to "Im Browser öffnen", matching the `open_in_browser` icon and what the action actually does (push a WebView with the PhoneBlock page for the number).
- Regenerate all locale ARBs via `./gradlew translateArb` and the Dart `app_localizations*.dart` via `flutter gen-l10n`.

Closes #309

## Test plan
- [ ] Open caller list, long-press (or tap the more-vert) on an entry → see "Im Browser öffnen" (instead of "Auf PhoneBlock ansehen") and a new "Nummer kopieren" item.
- [ ] Tap "Nummer kopieren" → snackbar "Nummer in Zwischenablage kopiert" appears; paste in another app yields the number.
- [ ] Tap "Im Browser öffnen" → in-app WebView opens with the PhoneBlock page for that number (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)