### PR TITLE
Register SpamBlocker app for token-login redirect (#310)

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/CreateAuthTokenServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/CreateAuthTokenServlet.java
@@ -113,6 +113,12 @@ public class CreateAuthTokenServlet extends HttpServlet {
 				redirectUrl = ServletUtil.withParam("PhoneSpamBlocker://auth",
 					TOKEN_PARAM, loginToken.getToken());
 				break;
+			case "SpamBlocker":
+				redirectUrl = ServletUtil.withParam("spamblocker://auth",
+					TOKEN_PARAM, loginToken.getToken());
+				redirectUrl = ServletUtil.withParam(redirectUrl,
+					STATE, req.getParameter(STATE));
+				break;
 			case APP_ID_DONGLE:
 				redirectUrl = ServletUtil.withParam(callback,
 					TOKEN_PARAM, loginToken.getToken());


### PR DESCRIPTION
## Summary
- Adds `spam.blocker` (issue #310) to the `appId` switch in `CreateAuthTokenServlet`, redirecting the fresh API token to `spamblocker://auth`.
- Propagates the caller-supplied `state` parameter for CSRF (same pattern as the dongle flow); the existing `PhoneSpamBlocker` case is left unchanged.

Closes #310.

## Test plan
- [x] `mvn -am -pl phoneblock compile` — BUILD SUCCESS
- [ ] Manual: call `/create-token?appId=SpamBlocker&state=xyz` while logged in, verify redirect to `spamblocker://auth?loginToken=…&state=xyz`
- [ ] Confirm with @aj3423 that the Android app actually registers the `spamblocker://auth` deep-link intent filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)