### PR TITLE
Issue #301: Return user's own comment in /num, /check, /check-prefix

### DIFF
--- a/phoneblock-shared/src/main/java/de/haumacher/phoneblock/app/api/model/PhoneInfo.java
+++ b/phoneblock-shared/src/main/java/de/haumacher/phoneblock/app/api/model/PhoneInfo.java
@@ -48,6 +48,9 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 	/** @see #getLocation() */
 	private static final String LOCATION__PROP = "location";
 
+	/** @see #getUserComment() */
+	private static final String USER_COMMENT__PROP = "userComment";
+
 	private String _phone = "";
 
 	private int _votes = 0;
@@ -69,6 +72,8 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 	private String _label = null;
 
 	private String _location = null;
+
+	private String _userComment = null;
 
 	/**
 	 * Creates a {@link PhoneInfo} instance.
@@ -318,6 +323,37 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 		return _location != null;
 	}
 
+	/**
+	 * The comment that the requesting user has previously stored for this number, or <code>null</code>.
+	 *
+	 * <p>
+	 * Only populated when the request is authenticated and a comment was previously submitted by the same user (e.g., via the {@code /rate} endpoint). This is the user's own note about the number, not a community comment.
+	 * </p>
+	 */
+	public final String getUserComment() {
+		return _userComment;
+	}
+
+	/**
+	 * @see #getUserComment()
+	 */
+	public de.haumacher.phoneblock.app.api.model.PhoneInfo setUserComment(String value) {
+		internalSetUserComment(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #getUserComment()} without chain call utility. */
+	protected final void internalSetUserComment(String value) {
+		_userComment = value;
+	}
+
+	/**
+	 * Checks, whether {@link #getUserComment()} has a value.
+	 */
+	public final boolean hasUserComment() {
+		return _userComment != null;
+	}
+
 	/** Reads a new instance from the given reader. */
 	public static de.haumacher.phoneblock.app.api.model.PhoneInfo readPhoneInfo(de.haumacher.msgbuf.json.JsonReader in) throws java.io.IOException {
 		de.haumacher.phoneblock.app.api.model.PhoneInfo result = new de.haumacher.phoneblock.app.api.model.PhoneInfo();
@@ -359,6 +395,10 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 			out.name(LOCATION__PROP);
 			out.value(getLocation());
 		}
+		if (hasUserComment()) {
+			out.name(USER_COMMENT__PROP);
+			out.value(getUserComment());
+		}
 	}
 
 	@Override
@@ -375,6 +415,7 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 			case LAST_UPDATE__PROP: setLastUpdate(in.nextLong()); break;
 			case LABEL__PROP: setLabel(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case LOCATION__PROP: setLocation(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
+			case USER_COMMENT__PROP: setUserComment(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			default: super.readField(in, field);
 		}
 	}
@@ -415,6 +456,9 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 	/** XML attribute or element name of a {@link #getLocation} property. */
 	private static final String LOCATION__XML_ATTR = "location";
 
+	/** XML attribute or element name of a {@link #getUserComment} property. */
+	private static final String USER_COMMENT__XML_ATTR = "user-comment";
+
 	@Override
 	public String getXmlTagName() {
 		return PHONE_INFO__XML_ELEMENT;
@@ -439,6 +483,7 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 		out.writeAttribute(LAST_UPDATE__XML_ATTR, Long.toString(getLastUpdate()));
 		out.writeAttribute(LABEL__XML_ATTR, getLabel());
 		out.writeAttribute(LOCATION__XML_ATTR, getLocation());
+		out.writeAttribute(USER_COMMENT__XML_ATTR, getUserComment());
 	}
 
 	/** Serializes all fields that are written as XML elements. */
@@ -520,6 +565,10 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 				setLocation(value);
 				break;
 			}
+			case USER_COMMENT__XML_ATTR: {
+				setUserComment(value);
+				break;
+			}
 			default: {
 				// Skip unknown attribute.
 			}
@@ -571,6 +620,10 @@ public class PhoneInfo extends de.haumacher.msgbuf.data.AbstractDataObject imple
 			}
 			case LOCATION__XML_ATTR: {
 				setLocation(in.getElementText());
+				break;
+			}
+			case USER_COMMENT__XML_ATTR: {
+				setUserComment(in.getElementText());
 				break;
 			}
 			default: {

--- a/phoneblock-shared/src/main/java/de/haumacher/phoneblock/app/api/model/api.proto
+++ b/phoneblock-shared/src/main/java/de/haumacher/phoneblock/app/api/model/api.proto
@@ -164,6 +164,16 @@ message PhoneInfo {
 	/** The city or region from where the call originated (e.g., "Berlin"). */
 	@Nullable
 	string location;
+
+	/**
+	 * The comment that the requesting user has previously stored for this number, or <code>null</code>.
+	 *
+	 * <p>
+	 * Only populated when the request is authenticated and a comment was previously submitted by the same user (e.g., via the {@code /rate} endpoint). This is the user's own note about the number, not a community comment.
+	 * </p>
+	 */
+	@Nullable
+	string userComment;
 }
 
 /** A single aggregated SPAM range matching a hash prefix in a {@link PrefixCheckResult}. */

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/NumServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/NumServlet.java
@@ -16,6 +16,7 @@ import de.haumacher.phoneblock.app.api.model.Rating;
 import de.haumacher.phoneblock.db.BlockList;
 import de.haumacher.phoneblock.db.DB;
 import de.haumacher.phoneblock.db.DBService;
+import de.haumacher.phoneblock.db.DBUserComment;
 import de.haumacher.phoneblock.db.SpamReports;
 import de.haumacher.phoneblock.db.Users;
 import de.haumacher.phoneblock.db.settings.AuthToken;
@@ -66,13 +67,13 @@ public class NumServlet extends HttpServlet {
 			DB db = DBService.getInstance();
 			try (SqlSession session = db.openSession()) {
 				BlockList blocklist = session.getMapper(BlockList.class);
+				SpamReports reports = session.getMapper(SpamReports.class);
 				Boolean state = blocklist.getPersonalizationState(auth.getUserId(), phoneId);
 				if (state != null) {
 					PhoneInfo info;
 					if (state.booleanValue()) {
 						// User has personally blocked this number — return real community data
 						// with blackListed flag so the client can force-block.
-						SpamReports reports = session.getMapper(SpamReports.class);
 						info = db.getPhoneApiInfo(reports, phoneId);
 						info.setBlackListed(true);
 					} else {
@@ -84,6 +85,7 @@ public class NumServlet extends HttpServlet {
 					if (number.hasCity()) {
 						info.setLocation(number.getCity());
 					}
+					applyUserComment(reports, auth, info, phoneId);
 					ServletUtil.sendResult(req, resp, info);
 					return;
 				}
@@ -109,6 +111,8 @@ public class NumServlet extends HttpServlet {
 				result.setLocation(number.getCity());
 			}
 
+			applyUserComment(reports, LoginFilter.getAuthorization(req), result, phoneId);
+
 			// Do not hand out any information for non-spam numbers, even if they have been
 			// (accidentally) recorded in the DB.
 			if (result.getVotes() <= 0 && result.getVotesWildcard() <= 0) {
@@ -127,6 +131,20 @@ public class NumServlet extends HttpServlet {
 			}
 
 			return result;
+		}
+	}
+
+	/**
+	 * Sets {@link PhoneInfo#getUserComment()} from the authenticated user's own
+	 * previously-submitted comment for the given number, if any.
+	 */
+	static void applyUserComment(SpamReports reports, AuthToken auth, PhoneInfo info, String phoneId) {
+		if (auth == null) {
+			return;
+		}
+		DBUserComment own = reports.getUserComment(auth.getUserId(), phoneId);
+		if (own != null) {
+			info.setUserComment(own.getComment());
 		}
 	}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PrefixCheckServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PrefixCheckServlet.java
@@ -22,6 +22,7 @@ import de.haumacher.phoneblock.db.BlockList;
 import de.haumacher.phoneblock.db.DB;
 import de.haumacher.phoneblock.db.DBNumberInfo;
 import de.haumacher.phoneblock.db.DBPersonalization;
+import de.haumacher.phoneblock.db.DBPhoneComment;
 import de.haumacher.phoneblock.db.DBService;
 import de.haumacher.phoneblock.db.SpamReports;
 import de.haumacher.phoneblock.db.settings.AuthToken;
@@ -141,6 +142,16 @@ public class PrefixCheckServlet extends HttpServlet {
 					// path already relies on.
 					pi.setWhiteListed(true);
 					pi.setRating(Rating.A_LEGITIMATE);
+				}
+			}
+			// Annotate each matching number with the user's own previously-submitted comment, if any.
+			if (!byPhone.isEmpty()) {
+				List<DBPhoneComment> ownComments = reports.getUserComments(auth.getUserId(), byPhone.keySet());
+				for (DBPhoneComment c : ownComments) {
+					PhoneInfo pi = byPhone.get(c.getPhone());
+					if (pi != null) {
+						pi.setUserComment(c.getComment());
+					}
 				}
 			}
 			result.setNumbers(new ArrayList<>(byPhone.values()));

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/SpamCheckServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/SpamCheckServlet.java
@@ -69,20 +69,22 @@ public class SpamCheckServlet extends HttpServlet {
 		if (auth != null) {
 			try (SqlSession session = db.openSession()) {
 				BlockList blocklist = session.getMapper(BlockList.class);
+				SpamReports reports = session.getMapper(SpamReports.class);
 				DBPersonalization personalized = blocklist.resolvePersonalizationByHash(auth.getUserId(), hash);
 				if (personalized != null) {
+					PhoneInfo info;
 					if (personalized.isBlocked()) {
 						// User has personally blocked this number — return real community data
 						// with blackListed flag. The client uses the flag to force-block.
-						PhoneInfo info = db.getPhoneApiInfo(personalized.getPhone());
+						info = db.getPhoneApiInfo(reports, personalized.getPhone());
 						info.setBlackListed(true);
-						ServletUtil.sendResult(req, resp, info);
 					} else {
 						// User has personally whitelisted this number.
-						PhoneInfo info = NumberAnalyzer.phoneInfoFromId(personalized.getPhone())
+						info = NumberAnalyzer.phoneInfoFromId(personalized.getPhone())
 							.setRating(Rating.A_LEGITIMATE);
-						ServletUtil.sendResult(req, resp, info);
 					}
+					NumServlet.applyUserComment(reports, auth, info, personalized.getPhone());
+					ServletUtil.sendResult(req, resp, info);
 					return;
 				}
 			}
@@ -107,8 +109,11 @@ public class SpamCheckServlet extends HttpServlet {
 			if (info.getVotes() <= 0 && info.getVotesWildcard() <= 0) {
 				// Provide no additional information for non-SPAM numbers that have an
 				// accidental match in the DB (because they were recorded by a non-hashed
-				// lookup).
+				// lookup). Preserve the user's own comment though — it is their own note
+				// and not community data we are protecting.
+				String preservedUserComment = info.getUserComment();
 				info = createUnknownResult();
+				info.setUserComment(preservedUserComment);
 			}
 		}
 
@@ -116,6 +121,9 @@ public class SpamCheckServlet extends HttpServlet {
 		if (info.getVotes() <= 0 && info.getVotesWildcard() <= 0) {
 			PhoneInfo prefixInfo = lookupPrefixHashes(req, db);
 			if (prefixInfo != null) {
+				// Carry over the user's own comment (if any) so the prefix-only result
+				// still surfaces the user's note for the originally-requested number.
+				prefixInfo.setUserComment(info.getUserComment());
 				info = prefixInfo;
 			}
 		}

--- a/phoneblock/src/main/webapp/api/phoneblock.json
+++ b/phoneblock/src/main/webapp/api/phoneblock.json
@@ -17,7 +17,7 @@
 		"/num/{num}": {
 			"get": {
 				"summary": "Checks whether the given phone number in on the blocklist.",
-				"description": "The calling phone number is sent in plaintext — the server learns which number the authenticated user is asking about. For a privacy-preserving alternative that hides the queried number from the server, use the k-anonymity prefix lookup at /check-prefix.",
+				"description": "The calling phone number is sent in plaintext — the server learns which number the authenticated user is asking about. For a privacy-preserving alternative that hides the queried number from the server, use the k-anonymity prefix lookup at /check-prefix.\n\nAuthentication is optional on this endpoint. When the request carries a valid bearer token, the response additionally honors the user's personal blocklist/whitelist for that number and the `userComment` field is populated from the user's own previously-submitted comment (if any).",
 				"responses": {
 					"200": {
 						"description": "Checks whether the given phone number is in the PhoneBlock database.",
@@ -1361,6 +1361,11 @@
 					"location": {
 						"type": "string",
 						"description": "The city or region from where the call originated (e.g., 'Berlin').",
+						"nullable": true
+					},
+					"userComment": {
+						"type": "string",
+						"description": "The comment that the requesting user previously stored for this number, or null. Only populated when the request is authenticated and a comment was previously submitted by the same user (e.g., via the /rate endpoint). This is the user's own note about the number, not a community comment.",
 						"nullable": true
 					}
 				}


### PR DESCRIPTION
## Summary

Closes #301.

Adds a nullable `userComment` field to `PhoneInfo`. When a lookup is authenticated, the response now carries the requesting user's own previously-submitted comment for that number (resolved from `COMMENTS` by user id + phone id). This lets clients like SpamBlocker show the user their own note about the caller without exposing community comments through the lookup endpoints — those remain available via `/search`.

- `/api/num/{num}` — auth is **optional** here (already wired through `ContentFilter`); a request with `Authorization: Bearer …` additionally honors the user's personal blacklist/whitelist and populates `userComment`.
- `/api/check` — already authenticated; `userComment` is now set in the personalized-blacklist/whitelist paths, the hash-resolved path, and is preserved across the "non-SPAM → unknown" downgrade and the prefix-range fallback.
- `/api/check-prefix` — uses the existing bulk mapper `SpamReports#getUserComments(userId, phones)`, so the additional cost is one DB round-trip independent of the number of matches.

OpenAPI spec updated accordingly.

## Test plan

- [x] `mvn -pl phoneblock test` — 265/265 green, incl. `TestPrefixCheckServlet`
- [x] Manual smoke test: rate a number via `/api/rate` with `comment`, then verify the same comment is returned by `/api/num/{num}`, `/api/check` and `/api/check-prefix` for that user
- [x] Verify anonymous `/api/num/{num}` still returns `userComment: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)