### PR TITLE
Issue #315: Filter /check-prefix wildcard ranges by aggregation threshold

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PrefixCheckServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PrefixCheckServlet.java
@@ -148,12 +148,14 @@ public class PrefixCheckServlet extends HttpServlet {
 			if (prefix10Hex != null) {
 				byte[] low = prefixLow(prefix10Hex);
 				byte[] high = prefixHigh(prefix10Hex);
-				result.setRange10(toRangeMatches(reports.getAggregation10ByHashPrefix(low, high)));
+				result.setRange10(toRangeMatches(
+					reports.getAggregation10ByHashPrefix(low, high, DB.MIN_AGGREGATE_10)));
 			}
 			if (prefix100Hex != null) {
 				byte[] low = prefixLow(prefix100Hex);
 				byte[] high = prefixHigh(prefix100Hex);
-				result.setRange100(toRangeMatches(reports.getAggregation100ByHashPrefix(low, high)));
+				result.setRange100(toRangeMatches(
+					reports.getAggregation100ByHashPrefix(low, high, DB.MIN_AGGREGATE_100)));
 			}
 		}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
@@ -98,15 +98,15 @@ public interface SpamReports {
 
 	@Select("""
 			select PREFIX, CNT, VOTES from NUMBERS_AGGREGATION_10
-			where SHA1 >= #{low} and SHA1 < #{high}
+			where SHA1 >= #{low} and SHA1 < #{high} and CNT >= #{minCnt}
 			""")
-	List<AggregationInfo> getAggregation10ByHashPrefix(byte[] low, byte[] high);
+	List<AggregationInfo> getAggregation10ByHashPrefix(byte[] low, byte[] high, int minCnt);
 
 	@Select("""
 			select PREFIX, CNT, VOTES from NUMBERS_AGGREGATION_100
-			where SHA1 >= #{low} and SHA1 < #{high}
+			where SHA1 >= #{low} and SHA1 < #{high} and CNT >= #{minCnt}
 			""")
-	List<AggregationInfo> getAggregation100ByHashPrefix(byte[] low, byte[] high);
+	List<AggregationInfo> getAggregation100ByHashPrefix(byte[] low, byte[] high, int minCnt);
 
 	@Update("update NUMBERS_AGGREGATION_10 set SHA1 = #{hash} where PREFIX = #{prefix}")
 	int updateAggregation10Hash(String prefix, byte[] hash);

--- a/phoneblock/src/main/webapp/api/phoneblock.json
+++ b/phoneblock/src/main/webapp/api/phoneblock.json
@@ -1288,14 +1288,14 @@
 					},
 					"range10": {
 						"type": "array",
-						"description": "10-digit range aggregations whose SHA1 hash starts with the 'prefix10' prefix from the request. Empty if no 'prefix10' was supplied or no match was found.",
+						"description": "10-digit range aggregations whose SHA1 hash starts with the 'prefix10' prefix from the request. Only blocks that have crossed the server-side wildcard-vote threshold are returned, matching the behavior of /check; sparsely-populated ranges are filtered out. Empty if no 'prefix10' was supplied or no qualifying match was found.",
 						"items": {
 							"$ref": "#/components/schemas/RangeMatch"
 						}
 					},
 					"range100": {
 						"type": "array",
-						"description": "100-digit range aggregations whose SHA1 hash starts with the 'prefix100' prefix from the request. Empty if no 'prefix100' was supplied or no match was found.",
+						"description": "100-digit range aggregations whose SHA1 hash starts with the 'prefix100' prefix from the request. Only blocks that have crossed the server-side wildcard-vote threshold are returned, matching the behavior of /check; sparsely-populated ranges are filtered out. Empty if no 'prefix100' was supplied or no qualifying match was found.",
 						"items": {
 							"$ref": "#/components/schemas/RangeMatch"
 						}

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -481,7 +481,72 @@ public class TestDB {
 
 		checkPhone("040299962999", 0, 0, 0, 0, 0);
 	}
-	
+
+	/**
+	 * The hash-prefix mappers used by {@code /check-prefix} must skip aggregation rows whose
+	 * {@code CNT} is below the wildcard-vote thresholds. Otherwise the API would leak ranges
+	 * that don't contribute to a wildcard vote — inconsistent with {@code /check} and with
+	 * {@link DB#computeWildcardVotes(AggregationInfo, AggregationInfo)}.
+	 */
+	@Test
+	void testAggregationByHashPrefixFiltersThreshold() {
+		long now = 0;
+
+		// Block-of-10 "0402999629_0": 4 distinct numbers → qualifies (cnt10 = MIN_AGGREGATE_10).
+		processVotes("040299962900", 1, now);
+		processVotes("040299962901", 1, now);
+		processVotes("040299962902", 1, now);
+		processVotes("040299962903", 1, now);
+
+		// Block-of-10 "0402999628_0": 1 number only → has a hash row but cnt10 = 1 < 4.
+		processVotes("040299962800", 1, now);
+
+		byte[] low = new byte[20];
+		byte[] high = new byte[20];
+		Arrays.fill(high, (byte) 0xff);
+
+		try (SqlSession tx = _db.openSession()) {
+			SpamReports reports = tx.getMapper(SpamReports.class);
+
+			// Aggregation rows are keyed on the block prefix (last digit stripped).
+			// Unfiltered (minCnt = 0) sees both 10-blocks.
+			List<AggregationInfo> all10 = reports.getAggregation10ByHashPrefix(low, high, 0);
+			Set<String> all10Prefixes = all10.stream().map(AggregationInfo::getPrefix).collect(Collectors.toSet());
+			assertTrue(all10Prefixes.contains("04029996290"));
+			assertTrue(all10Prefixes.contains("04029996280"));
+
+			// Threshold filter drops the under-populated 10-block.
+			List<AggregationInfo> filtered10 = reports.getAggregation10ByHashPrefix(low, high, DB.MIN_AGGREGATE_10);
+			Set<String> filtered10Prefixes = filtered10.stream().map(AggregationInfo::getPrefix).collect(Collectors.toSet());
+			assertTrue(filtered10Prefixes.contains("04029996290"));
+			assertFalse(filtered10Prefixes.contains("04029996280"));
+		}
+
+		// Promote two more 10-sub-blocks so the 100-block "040299962" qualifies (cnt100 = 3).
+		processVotes("040299962910", 1, now);
+		processVotes("040299962911", 1, now);
+		processVotes("040299962912", 1, now);
+		processVotes("040299962913", 1, now);
+
+		processVotes("040299962920", 1, now);
+		processVotes("040299962921", 1, now);
+		processVotes("040299962922", 1, now);
+		processVotes("040299962923", 1, now);
+
+		try (SqlSession tx = _db.openSession()) {
+			SpamReports reports = tx.getMapper(SpamReports.class);
+
+			List<AggregationInfo> filtered100 = reports.getAggregation100ByHashPrefix(low, high, DB.MIN_AGGREGATE_100);
+			Set<String> filtered100Prefixes = filtered100.stream().map(AggregationInfo::getPrefix).collect(Collectors.toSet());
+			assertTrue(filtered100Prefixes.contains("0402999629"));
+
+			// Raise the threshold one above what this 100-block delivers → it must drop out.
+			List<AggregationInfo> tooStrict = reports.getAggregation100ByHashPrefix(low, high, DB.MIN_AGGREGATE_100 + 1);
+			Set<String> tooStrictPrefixes = tooStrict.stream().map(AggregationInfo::getPrefix).collect(Collectors.toSet());
+			assertFalse(tooStrictPrefixes.contains("0402999629"));
+		}
+	}
+
 	private void processVotes(String phone, int votes, long time) {
 		_db.processVotes(NumberAnalyzer.analyze(phone, "+49"), "+49", votes, time);
 	}


### PR DESCRIPTION
## Summary
- `/check-prefix` returned every aggregation row matching the requested SHA1 hash prefix, regardless of how many neighbouring numbers were reported as spam.
- The hash-prefix mappers now require `CNT >= minCnt`, and `PrefixCheckServlet` passes `DB.MIN_AGGREGATE_10` / `DB.MIN_AGGREGATE_100`. Sparsely-populated buckets no longer leak into the response, matching `/check` and `DB.computeWildcardVotes`.
- Filter is applied in SQL (not in Java) so under-threshold rows aren't fetched at all.
- OpenAPI description of `range10` / `range100` updated to document the server-side threshold behaviour.

Fixes #315.

## Test plan
- [x] New `TestDB.testAggregationByHashPrefixFiltersThreshold` — confirms `minCnt = 0` returns both blocks, `minCnt = MIN_AGGREGATE_*` drops the under-populated one, and bumping the threshold past a qualifying 100-block removes it.
- [x] Existing `TestPrefixCheckServlet` and full `phoneblock` test suite (266 tests) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)