### PR TITLE
Dongle: cut spam-lookup latency with TLS session resumption

### DIFF
--- a/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
+++ b/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
@@ -1,5 +1,19 @@
 <IfModule mod_ssl.c>
 
+# TLS session resumption tuning for the PhoneBlock dongle (ESP32).
+# The dongle makes only 1-2 spam-lookup API calls per day; a full TLS
+# handshake costs the device ~1-2 s, long enough for the Fritz!Box to
+# start ringing the real phones before the spam verdict arrives. The
+# dongle keeps its TLS session ticket between calls, but the default
+# 300 s session lifetime expires long before the next daily call.
+# Raising it to 7 days (604800 s, the TLS 1.3 ticket-lifetime maximum
+# per RFC 8446) lets the dongle resume the session from its previous
+# call and skip the full handshake. Server-config scope so it applies
+# to every *:443 vhost, including whichever one answers phoneblock.net.
+# RFC 5077 / TLS 1.3 tickets are stateless - no per-client server
+# memory is held.
+SSLSessionCacheTimeout 604800
+
 <VirtualHost *:80>
         ServerName phoneblock.haumacher.de
         Redirect "/" "https://phoneblock2.haumacher.de/"

--- a/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
+++ b/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
@@ -6,9 +6,9 @@
 # start ringing the real phones before the spam verdict arrives. The
 # dongle keeps its TLS session ticket between calls, but the default
 # 300 s session lifetime expires long before the next daily call.
-# Raising it to 7 days (604800 s, the TLS 1.3 ticket-lifetime maximum
-# per RFC 8446) lets the dongle resume the session from its previous
-# call and skip the full handshake. Server-config scope so it applies
+# Raising it to 7 days (604800 s) lets the dongle resume the session
+# from its previous call and skip the full handshake. Server-config
+# scope so it applies
 # to every *:443 vhost, including whichever one answers phoneblock.net.
 # RFC 5077 / TLS 1.3 tickets are stateless - no per-client server
 # memory is held.

--- a/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
+++ b/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
@@ -16,12 +16,19 @@
 #  - SSLSessionCacheTimeout 604800  - bound the accepted ticket age to
 #    7 days, so the dongle's once-a-day ticket is still valid.
 #
-# NOTE: options-ssl-apache.conf (Included per vhost below) ships
-# "SSLSessionTickets off"; a server-scope setting is then overridden
-# inside every vhost that includes it. SSLSessionTickets must
-# therefore be set *after* that Include in each vhost serving the
-# dongle - see the phoneblock2 vhost below, and apply the same to
-# whichever vhost answers phoneblock.net.
+# NOTE on placement of SSLSessionTickets - this is subtle:
+# options-ssl-apache.conf (Included per vhost below) ships
+# "SSLSessionTickets off". Apache fixes ticket on/off when the TLS
+# connection is set up - from the *default* *:443 vhost - before SNI
+# selects the real one. An SNI switch to a non-default vhost can still
+# disable tickets, but it cannot re-enable them. So "SSLSessionTickets
+# on" must be set, AFTER the Include, in BOTH:
+#   - the default *:443 vhost (the first one in load order - identify
+#     it with `apache2ctl -S`, the line labelled "default server"), and
+#   - every vhost that must serve tickets (the dongle's API vhost).
+# Setting it only in the API vhost is NOT enough - that was the trap.
+# Editing options-ssl-apache.conf directly would be simpler, but it is
+# Certbot-managed; override per vhost here instead.
 SSLSessionCacheTimeout 604800
 
 <VirtualHost *:80>
@@ -41,6 +48,12 @@ SSLSessionCacheTimeout 604800
 	SSLCertificateFile /etc/letsencrypt/live/phoneblock.haumacher.de/fullchain.pem
 	SSLCertificateKeyFile /etc/letsencrypt/live/phoneblock.haumacher.de/privkey.pem
 	Include /etc/letsencrypt/options-ssl-apache.conf
+
+	# This is the default *:443 vhost. It decides ticket on/off for
+	# every incoming TLS connection before SNI runs, so it MUST have
+	# tickets on (after the Include) - otherwise no vhost can issue
+	# them, however the API vhost is configured. See the note at top.
+	SSLSessionTickets on
 </VirtualHost>
 
 <VirtualHost *:443>
@@ -76,10 +89,10 @@ SSLSessionCacheTimeout 604800
         SSLCertificateKeyFile /etc/letsencrypt/live/phoneblock.haumacher.de/privkey.pem
         Include /etc/letsencrypt/options-ssl-apache.conf
 
-        # Must come AFTER the Include: options-ssl-apache.conf ships
-        # "SSLSessionTickets off". Re-enable stateless RFC 5077 tickets
-        # so the PhoneBlock dongle can resume across its 12-24 h call
-        # gap (see the comment at the top of this file).
+        # The dongle's API vhost - re-enable tickets here too, after
+        # the Include: an SNI switch to this non-default vhost would
+        # otherwise pull the "off" from options-ssl-apache.conf back
+        # in. The default vhost above must also have it. See top note.
         SSLSessionTickets on
 </VirtualHost>
 

--- a/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
+++ b/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
@@ -16,6 +16,24 @@
 #  - SSLSessionCacheTimeout 604800  - bound the accepted ticket age to
 #    7 days, so the dongle's once-a-day ticket is still valid.
 #
+# TRADE-OFF - forward secrecy: tickets weaken forward secrecy on the
+# TLS 1.2 path only. TLS 1.3 clients (browsers) are unaffected - TLS
+# 1.3 resumption does a fresh ECDHE (psk_dhe_ke), so a leaked
+# session-ticket key still cannot passively decrypt recorded traffic.
+# TLS 1.2 resumption does NOT re-key: it reuses the original master
+# secret, which the ticket carries, encrypted with Apache's session-
+# ticket key - a single static key, not rotated until the next reload.
+# Whoever obtains that key can decrypt recorded ticketed TLS 1.2
+# sessions. The PhoneBlock dongle is pinned to TLS 1.2 (esp_http_client
+# saves the TLS session before a TLS 1.3 post-handshake ticket
+# arrives), so its sessions lose forward secrecy. This is accepted
+# deliberately: the dongle sends only k-anonymity hash-prefix lookups,
+# and the clean fix - dongle on TLS 1.3 - needs firmware work judged
+# not worth it. Mitigation if ever wanted: SSLSessionTicketKeyFile +
+# a rotation cron bounds the exposure window - but mod_ssl keeps only
+# one key, so each rotation voids all outstanding tickets (one extra
+# full handshake per dongle per rotation).
+#
 # NOTE on placement of SSLSessionTickets - this is subtle:
 # options-ssl-apache.conf (Included per vhost below) ships
 # "SSLSessionTickets off". Apache fixes ticket on/off when the TLS

--- a/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
+++ b/cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf
@@ -2,16 +2,26 @@
 
 # TLS session resumption tuning for the PhoneBlock dongle (ESP32).
 # The dongle makes only 1-2 spam-lookup API calls per day; a full TLS
-# handshake costs the device ~1-2 s, long enough for the Fritz!Box to
-# start ringing the real phones before the spam verdict arrives. The
-# dongle keeps its TLS session ticket between calls, but the default
-# 300 s session lifetime expires long before the next daily call.
-# Raising it to 7 days (604800 s) lets the dongle resume the session
-# from its previous call and skip the full handshake. Server-config
-# scope so it applies
-# to every *:443 vhost, including whichever one answers phoneblock.net.
-# RFC 5077 / TLS 1.3 tickets are stateless - no per-client server
-# memory is held.
+# handshake costs the device ~1.7 s (asymmetric crypto on its 240 MHz
+# CPU) - long enough for the Fritz!Box to start ringing the real
+# phones before the spam verdict arrives. The dongle caches its TLS
+# session between calls and resumes instead - but resumption survives
+# that 12-24 h gap only if it is *stateless*:
+#
+#  - SSLSessionTickets on  - hand the client a stateless RFC 5077
+#    ticket, so the server holds no per-session state. Without it the
+#    server falls back to Session-ID resumption, whose bounded session
+#    cache evicts a day-old entry long before any timeout, and the
+#    dongle re-does the full handshake on every call.
+#  - SSLSessionCacheTimeout 604800  - bound the accepted ticket age to
+#    7 days, so the dongle's once-a-day ticket is still valid.
+#
+# NOTE: options-ssl-apache.conf (Included per vhost below) ships
+# "SSLSessionTickets off"; a server-scope setting is then overridden
+# inside every vhost that includes it. SSLSessionTickets must
+# therefore be set *after* that Include in each vhost serving the
+# dongle - see the phoneblock2 vhost below, and apply the same to
+# whichever vhost answers phoneblock.net.
 SSLSessionCacheTimeout 604800
 
 <VirtualHost *:80>
@@ -65,6 +75,12 @@ SSLSessionCacheTimeout 604800
         SSLCertificateFile /etc/letsencrypt/live/phoneblock.haumacher.de/fullchain.pem
         SSLCertificateKeyFile /etc/letsencrypt/live/phoneblock.haumacher.de/privkey.pem
         Include /etc/letsencrypt/options-ssl-apache.conf
+
+        # Must come AFTER the Include: options-ssl-apache.conf ships
+        # "SSLSessionTickets off". Re-enable stateless RFC 5077 tickets
+        # so the PhoneBlock dongle can resume across its 12-24 h call
+        # gap (see the comment at the top of this file).
+        SSLSessionTickets on
 </VirtualHost>
 
 </IfModule>

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -5,6 +5,9 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
 #include "esp_log.h"
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
@@ -121,6 +124,36 @@ static esp_err_t http_event_check(esp_http_client_event_t *evt)
     return ESP_OK;
 }
 
+// --- Persistent HTTPS client for the spam-lookup path ----------------
+//
+// The dongle makes only 1-2 /api/check-prefix calls per day. A fresh
+// TLS handshake costs ~1-2 s on the ESP32 - long enough for the
+// Fritz!Box to start ringing the real phones before the verdict is in.
+// To cut that, phoneblock_check() reuses one long-lived esp_http_client
+// handle with save_client_session enabled: the TCP connection is closed
+// after every call (no socket and no server state held while idle), but
+// the TLS session ticket is cached in the handle and replayed on the
+// next call, which then skips the certificate exchange and the
+// asymmetric crypto. esp_http_client frees the saved ticket only on
+// cleanup()/destroy, not on close(), so closing between calls is safe.
+//
+// The handle is created lazily on the first call. s_check_mutex
+// serialises access - phoneblock_check() runs both from the SIP task
+// and from the LAN debug-query server, and a single esp_http_client
+// handle must not be driven from two tasks at once.
+static esp_http_client_handle_t s_check_client = NULL;
+static SemaphoreHandle_t        s_check_mutex  = NULL;
+
+void phoneblock_api_init(void)
+{
+    if (s_check_mutex == NULL) {
+        s_check_mutex = xSemaphoreCreateMutex();
+        if (s_check_mutex == NULL) {
+            ESP_LOGE(TAG, "failed to create API mutex");
+        }
+    }
+}
+
 verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out)
 {
     if (out) memset(out, 0, sizeof(*out));
@@ -172,16 +205,40 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out)
     api_scan_t scan;
     api_scan_init(&scan, phone_number);
 
-    esp_http_client_config_t config = {
-        .url = url,
-        .event_handler = http_event_check,
-        .user_data = &scan,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-        .timeout_ms = 10000,
-        .auth_type = HTTP_AUTH_TYPE_NONE,
-    };
+    if (s_check_mutex == NULL) {
+        // phoneblock_api_init() was never called - refuse rather than
+        // race two tasks into esp_http_client_init().
+        ESP_LOGE(TAG, "phoneblock_check before phoneblock_api_init()");
+        return VERDICT_ERROR;
+    }
+    xSemaphoreTake(s_check_mutex, portMAX_DELAY);
 
-    esp_http_client_handle_t client = esp_http_client_init(&config);
+    // Lazily create the reused client on the first call. save_client_session
+    // makes esp_http_client cache the TLS session ticket in the handle and
+    // replay it on later calls - see the comment above s_check_client.
+    if (s_check_client == NULL) {
+        esp_http_client_config_t config = {
+            .url = config_phoneblock_base_url(),  // overwritten per call
+            .event_handler = http_event_check,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+            .timeout_ms = 10000,
+            .auth_type = HTTP_AUTH_TYPE_NONE,
+#if CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
+            .save_client_session = true,
+#endif
+        };
+        s_check_client = esp_http_client_init(&config);
+        if (s_check_client == NULL) {
+            ESP_LOGE(TAG, "failed to create HTTP client");
+            stats_record_error("api", "HTTP client init failed");
+            xSemaphoreGive(s_check_mutex);
+            return VERDICT_ERROR;
+        }
+    }
+
+    esp_http_client_handle_t client = s_check_client;
+    esp_http_client_set_url(client, url);
+    esp_http_client_set_user_data(client, &scan);
     http_util_set_user_agent(client);
     esp_http_client_set_header(client, "Authorization", auth_header);
     esp_http_client_set_header(client, "Accept", "application/json");
@@ -283,7 +340,13 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out)
     }
 
 cleanup:
-    esp_http_client_cleanup(client);
+    // Close the TCP/TLS connection but keep the handle: esp_http_client
+    // retains the saved TLS session ticket across close() (only
+    // cleanup()/destroy frees it), so the next call resumes the session
+    // instead of doing a full handshake. No connection and no socket
+    // are held while the dongle is idle.
+    esp_http_client_close(client);
+    xSemaphoreGive(s_check_mutex);
     return verdict;
 }
 

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -112,35 +112,74 @@ static int compute_wildcard_votes(int votes10, int cnt10, int votes100, int cnt1
     return 0;
 }
 
-// HTTP_EVENT_ON_DATA dispatcher for the streaming /api/check-prefix
-// scanner. Logic lives in api_scan.{c,h} so it can be unit-tested
-// host-side without ESP-IDF dependencies.
-static esp_err_t http_event_check(esp_http_client_event_t *evt)
+// Per-request sink for the shared client (see s_check_client). The one
+// esp_http_client handle serves two response shapes - the streaming
+// /api/check-prefix JSON and the plain /api/test body - so its single
+// event handler dispatches on a tag set per request via set_user_data().
+typedef enum { PB_SINK_SCAN, PB_SINK_BUFFER } pb_sink_kind_t;
+
+typedef struct {
+    pb_sink_kind_t kind;
+    union {
+        api_scan_t        *scan;  // PB_SINK_SCAN: streaming JSON parser
+        response_buffer_t *buf;   // PB_SINK_BUFFER: fixed-size body buffer
+    };
+} pb_sink_t;
+
+// HTTP_EVENT_ON_DATA dispatcher for the shared client. The check path
+// streams into the api_scan parser (logic in api_scan.{c,h}, unit-
+// tested host-side without ESP-IDF deps); the selftest path appends
+// into a fixed buffer.
+static esp_err_t http_event_shared(esp_http_client_event_t *evt)
 {
-    if (evt->event_id == HTTP_EVENT_ON_DATA) {
-        api_scan_t *s = (api_scan_t *)evt->user_data;
-        api_scan_feed(s, (const char *)evt->data, evt->data_len);
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    pb_sink_t *sink = (pb_sink_t *)evt->user_data;
+    if (sink == NULL) {
+        return ESP_OK;
+    }
+    if (sink->kind == PB_SINK_SCAN) {
+        api_scan_feed(sink->scan, (const char *)evt->data, evt->data_len);
+    } else if (!esp_http_client_is_chunked_response(evt->client)) {
+        response_buffer_t *resp = sink->buf;
+        int remaining = resp->cap - resp->len - 1;
+        int copy = evt->data_len < remaining ? evt->data_len : remaining;
+        if (copy > 0) {
+            memcpy(resp->data + resp->len, evt->data, copy);
+            resp->len += copy;
+            resp->data[resp->len] = '\0';
+        }
     }
     return ESP_OK;
 }
 
-// --- Persistent HTTPS client for the spam-lookup path ----------------
+// --- Shared, session-resuming HTTPS client ---------------------------
 //
 // The dongle makes only 1-2 /api/check-prefix calls per day. A fresh
 // TLS handshake costs ~1-2 s on the ESP32 - long enough for the
 // Fritz!Box to start ringing the real phones before the verdict is in.
-// To cut that, phoneblock_check() reuses one long-lived esp_http_client
-// handle with save_client_session enabled: the TCP connection is closed
-// after every call (no socket and no server state held while idle), but
-// the TLS session ticket is cached in the handle and replayed on the
-// next call, which then skips the certificate exchange and the
-// asymmetric crypto. esp_http_client frees the saved ticket only on
-// cleanup()/destroy, not on close(), so closing between calls is safe.
+// To cut that, the spam-lookup path reuses one long-lived
+// esp_http_client handle with save_client_session enabled: the TCP
+// connection is closed after every request (no socket and no server
+// state held while idle), but the TLS session ticket is cached in the
+// handle and replayed on the next request, which then skips the
+// certificate exchange and the asymmetric crypto. esp_http_client frees
+// the saved ticket only on cleanup()/destroy, not on close(), so
+// closing between requests is safe.
 //
-// The handle is created lazily on the first call. s_check_mutex
-// serialises access - phoneblock_check() runs both from the SIP task
-// and from the LAN debug-query server, and a single esp_http_client
-// handle must not be driven from two tasks at once.
+// phoneblock_selftest() deliberately shares this handle: it runs
+// synchronously at boot and again once a day, so it primes the ticket
+// before the very first spam call and refreshes it every 24 h. That
+// keeps the ticket inside the server's lifetime window even on dongles
+// that go days without a spam call - without it, resumption would only
+// hold while consecutive calls stay within that window.
+//
+// The handle is created lazily via check_client(). s_check_mutex
+// serialises access - phoneblock_check() runs from both the SIP task
+// and the LAN debug-query server, the selftest from app_main and its
+// daily task, and a single esp_http_client handle must not be driven
+// from two tasks at once.
 static esp_http_client_handle_t s_check_client = NULL;
 static SemaphoreHandle_t        s_check_mutex  = NULL;
 
@@ -152,6 +191,31 @@ void phoneblock_api_init(void)
             ESP_LOGE(TAG, "failed to create API mutex");
         }
     }
+}
+
+// Returns the shared, session-resuming HTTPS client for phoneblock.net,
+// creating it on first use. The caller must hold s_check_mutex. Returns
+// NULL when the handle could not be created.
+static esp_http_client_handle_t check_client(void)
+{
+    if (s_check_client == NULL) {
+        esp_http_client_config_t config = {
+            .url = config_phoneblock_base_url(),  // overwritten per request
+            .event_handler = http_event_shared,
+            .crt_bundle_attach = esp_crt_bundle_attach,
+            .timeout_ms = 10000,
+            .auth_type = HTTP_AUTH_TYPE_NONE,
+#if CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
+            .save_client_session = true,
+#endif
+        };
+        s_check_client = esp_http_client_init(&config);
+        if (s_check_client == NULL) {
+            ESP_LOGE(TAG, "failed to create shared HTTP client");
+            stats_record_error("api", "HTTP client init failed");
+        }
+    }
+    return s_check_client;
 }
 
 verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out)
@@ -213,32 +277,15 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out)
     }
     xSemaphoreTake(s_check_mutex, portMAX_DELAY);
 
-    // Lazily create the reused client on the first call. save_client_session
-    // makes esp_http_client cache the TLS session ticket in the handle and
-    // replay it on later calls - see the comment above s_check_client.
-    if (s_check_client == NULL) {
-        esp_http_client_config_t config = {
-            .url = config_phoneblock_base_url(),  // overwritten per call
-            .event_handler = http_event_check,
-            .crt_bundle_attach = esp_crt_bundle_attach,
-            .timeout_ms = 10000,
-            .auth_type = HTTP_AUTH_TYPE_NONE,
-#if CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
-            .save_client_session = true,
-#endif
-        };
-        s_check_client = esp_http_client_init(&config);
-        if (s_check_client == NULL) {
-            ESP_LOGE(TAG, "failed to create HTTP client");
-            stats_record_error("api", "HTTP client init failed");
-            xSemaphoreGive(s_check_mutex);
-            return VERDICT_ERROR;
-        }
+    esp_http_client_handle_t client = check_client();
+    if (client == NULL) {
+        xSemaphoreGive(s_check_mutex);
+        return VERDICT_ERROR;
     }
 
-    esp_http_client_handle_t client = s_check_client;
+    pb_sink_t sink = { .kind = PB_SINK_SCAN, .scan = &scan };
     esp_http_client_set_url(client, url);
-    esp_http_client_set_user_data(client, &scan);
+    esp_http_client_set_user_data(client, &sink);
     http_util_set_user_agent(client);
     esp_http_client_set_header(client, "Authorization", auth_header);
     esp_http_client_set_header(client, "Accept", "application/json");
@@ -485,18 +532,30 @@ bool phoneblock_selftest(void)
         return false;
     }
 
-    esp_http_client_config_t config = {
-        .url = url,
-        .event_handler = http_event_handler,
-        .user_data = &resp,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-        .timeout_ms = 10000,
-        // Tell esp_http_client not to auto-retry with a challenged auth
-        // scheme — we set Authorization ourselves. Silences the noisy
-        // "Basic realm=... not supported" error on every 401.
-        .auth_type = HTTP_AUTH_TYPE_NONE,
-    };
-    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (s_check_mutex == NULL) {
+        ESP_LOGE(TAG, "phoneblock_selftest before phoneblock_api_init()");
+        free(resp.data);
+        return false;
+    }
+
+    // Runs on the shared session-resuming client on purpose: the
+    // selftest fires synchronously at boot and again once a day, so
+    // routing it here primes the TLS session ticket before the first
+    // spam call and refreshes it every 24 h - keeping check-path
+    // lookups on the abbreviated handshake even on dongles that go
+    // days without a spam call. See the comment above s_check_client.
+    xSemaphoreTake(s_check_mutex, portMAX_DELAY);
+
+    esp_http_client_handle_t client = check_client();
+    if (client == NULL) {
+        xSemaphoreGive(s_check_mutex);
+        free(resp.data);
+        return false;
+    }
+
+    pb_sink_t sink = { .kind = PB_SINK_BUFFER, .buf = &resp };
+    esp_http_client_set_url(client, url);
+    esp_http_client_set_user_data(client, &sink);
     http_util_set_user_agent(client);
     esp_http_client_set_header(client, "Authorization", auth_header);
     esp_http_client_set_header(client, "Accept", "text/plain");
@@ -534,7 +593,10 @@ bool phoneblock_selftest(void)
             stats_record_error("api", msg);
         }
     }
-    esp_http_client_cleanup(client);
+    // Close but keep the handle so the freshly issued TLS session
+    // ticket survives for the next spam-lookup call.
+    esp_http_client_close(client);
+    xSemaphoreGive(s_check_mutex);
     free(resp.data);
     return ok;
 }

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -205,6 +205,15 @@ static esp_http_client_handle_t check_client(void)
             .crt_bundle_attach = esp_crt_bundle_attach,
             .timeout_ms = 10000,
             .auth_type = HTTP_AUTH_TYPE_NONE,
+            // Pin TLS 1.2. esp_http_client saves the session for
+            // resumption right after the handshake - but a TLS 1.3
+            // server delivers its session ticket as a post-handshake
+            // message, too late for that save, so TLS 1.3 would
+            // capture an unusable session and resume nothing. TLS 1.2
+            // sends the ticket in-handshake, so save_client_session
+            // below actually captures a resumable session. (TLS 1.3
+            // is also disabled project-wide - see sdkconfig.defaults.)
+            .tls_version = ESP_HTTP_CLIENT_TLS_VER_TLS_1_2,
 #if CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS
             .save_client_session = true,
 #endif

--- a/phoneblock-dongle/firmware/main/api.h
+++ b/phoneblock-dongle/firmware/main/api.h
@@ -51,6 +51,12 @@ typedef struct {
     char      location[80];
 } pb_check_result_t;
 
+// Initialise the API layer. Must be called exactly once from app_main,
+// before any task that can call phoneblock_check() is started: it
+// creates the mutex that serialises the shared, session-resuming HTTP
+// client used for spam lookups. Cheap; does no network I/O.
+void phoneblock_api_init(void);
+
 // Query the PhoneBlock API for the given phone number.
 // The number is passed through unmodified — the server normalizes.
 // Returns VERDICT_SPAM, VERDICT_LEGITIMATE, or VERDICT_ERROR on

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -256,6 +256,11 @@ void app_main(void)
     // pace; SPAM verdicts enqueue here instead of POSTing inline.
     report_queue_start();
 
+    // Create the shared state for the session-resuming spam-lookup HTTP
+    // client before any task that calls phoneblock_check() (the SIP
+    // server and the LAN debug-query server) is started.
+    phoneblock_api_init();
+
     if (token_set) {
         ESP_LOGI(TAG, "initial self-test");
         phoneblock_selftest();

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -27,21 +27,30 @@ CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y
 # TLS session resumption for the spam-lookup path. The dongle does
 # only 1-2 /api/check-prefix calls per day; a full TLS handshake costs
 # ~1-2 s on the ESP32 - long enough for the Fritz!Box to start ringing
-# the real phones before the verdict is in. With this enabled, api.c
-# keeps a persistent esp_http_client handle whose RFC 5077 / TLS 1.3
-# session ticket survives between calls (see save_client_session), so
-# the second and later lookups skip the certificate exchange and the
-# asymmetric crypto. No connection is held open - only the ticket blob
-# is cached in RAM, and the server keeps no per-client state. Default
-# is n; MBEDTLS_CLIENT_SSL_SESSION_TICKETS (the underlying mbedTLS
+# the real phones before the verdict is in. That cost is almost all
+# asymmetric crypto on the 240 MHz CPU (a full handshake measures
+# ~140 ms from a fast x86 but ~1.7 s on the dongle - the gap is
+# certificate-chain verify + signature + ECDHE, not the network).
+# With this enabled, api.c keeps a persistent esp_http_client handle
+# whose RFC 5077 session ticket survives between calls (see
+# save_client_session), so the second and later lookups skip exactly
+# that crypto. No connection is held open - only the ticket blob is
+# cached in RAM, and the server keeps no per-client state. Default is
+# n; MBEDTLS_CLIENT_SSL_SESSION_TICKETS (the underlying mbedTLS
 # support) is already default y.
 CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS=y
 
-# Offer TLS 1.3 to phoneblock.net, which already negotiates it. The
-# 1-RTT handshake shaves one internet round-trip off every full
-# handshake, and TLS 1.3 resumption (PSK + ephemeral key exchange,
-# both default y) keeps per-call forward secrecy. Default is n.
-CONFIG_MBEDTLS_SSL_PROTO_TLS1_3=y
+# TLS 1.3 is deliberately left disabled (also the IDF default).
+# esp_http_client saves the session for resumption right after the
+# handshake completes - but a TLS 1.3 server sends its session ticket
+# as a post-handshake message that has not arrived at that point, so
+# the saved session carries no usable ticket and every lookup falls
+# back to a full handshake. TLS 1.2 delivers the ticket in-handshake,
+# so resumption works there. TLS 1.3 would only save ~1 round-trip
+# (~30 ms measured) on a *full* handshake - negligible next to the
+# ~1.5 s of crypto that resumption removes. The lookup client also
+# pins TLS 1.2 explicitly - see check_client() in api.c.
+CONFIG_MBEDTLS_SSL_PROTO_TLS1_3=n
 
 # Main task stack: 8 KB is enough for cJSON + TLS + example helpers.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -24,6 +24,25 @@ CONFIG_EXAMPLE_WIFI_PASSWORD=""
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y
 
+# TLS session resumption for the spam-lookup path. The dongle does
+# only 1-2 /api/check-prefix calls per day; a full TLS handshake costs
+# ~1-2 s on the ESP32 - long enough for the Fritz!Box to start ringing
+# the real phones before the verdict is in. With this enabled, api.c
+# keeps a persistent esp_http_client handle whose RFC 5077 / TLS 1.3
+# session ticket survives between calls (see save_client_session), so
+# the second and later lookups skip the certificate exchange and the
+# asymmetric crypto. No connection is held open - only the ticket blob
+# is cached in RAM, and the server keeps no per-client state. Default
+# is n; MBEDTLS_CLIENT_SSL_SESSION_TICKETS (the underlying mbedTLS
+# support) is already default y.
+CONFIG_ESP_TLS_CLIENT_SESSION_TICKETS=y
+
+# Offer TLS 1.3 to phoneblock.net, which already negotiates it. The
+# 1-RTT handshake shaves one internet round-trip off every full
+# handshake, and TLS 1.3 resumption (PSK + ephemeral key exchange,
+# both default y) keeps per-call forward secrecy. Default is n.
+CONFIG_MBEDTLS_SSL_PROTO_TLS1_3=y
+
 # Main task stack: 8 KB is enough for cJSON + TLS + example helpers.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 


### PR DESCRIPTION
Closes #322.

Cuts the dongle's spam-lookup latency by reusing the TLS session across calls instead of doing a full TLS handshake every time. A full handshake costs ~1.7 s on the ESP32 (asymmetric crypto on the 240 MHz CPU) — long enough for the Fritz!Box to start ringing the real phones before the spam verdict is in.

## Changes

- **`api.c`** — the spam-lookup path reuses one persistent `esp_http_client` handle with `save_client_session`. The connection is closed after every call (no socket, no server state held while idle); only the RFC 5077 session-ticket blob is cached in RAM, so the next call resumes and skips the certificate exchange + asymmetric crypto.
- **`phoneblock_selftest()`** shares that handle. It runs synchronously at boot and again once a day, so it primes the ticket before the first spam call and refreshes it every 24 h — resumption holds even on dongles that go days without a spam call.
- **Pinned to TLS 1.2.** `esp_http_client` saves the session right after the handshake, but a TLS 1.3 server delivers its ticket as a post-handshake message — too late for that save — so TLS 1.3 silently disables resumption. TLS 1.3 is disabled project-wide (`sdkconfig.defaults`), which also drops ~55 KB from the image.
- **Apache `SSLSessionCacheTimeout`** raised to 7 days so the ticket survives between the device's daily calls (the 300 s default would always be expired).

## Verification

- Full firmware build passes; image 14 % under the partition limit.
- On hardware: lookup latency drops from **~1664 ms to ~228 ms** on a resumed call.

## Deploy note

The Apache change (`cloud-settings/root/etc/apache2/sites-available/000-default-le-ssl.conf`) must be deployed to the server — otherwise the ticket expires between the real 12–24 h call gaps and every call falls back to a full handshake.