### PR TITLE
fix(ab): drop default '*' test-prefix that doubled with accept-local

### DIFF
--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -22,6 +22,12 @@ services:
       - PORT_COUNT=10
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Whether to accept calls from local phones (numbers starting with '*').
+      - ACCEPT_LOCAL=yes
+      # Phone number prefix that forces the answer bot to respond, even if the
+      # caller is not on the blocklist. Useful to test the bot from an external
+      # number that is not flagged as spam. Leave empty in production.
+      - TEST_PREFIX=
     volumes:
       # Default conversation files are built-in. Only map them if you want to use a custom conversation.
       # - ./conversation:/opt/phoneblock/conversation

--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -23,6 +23,9 @@ services:
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
       # Whether to accept calls from local phones (numbers starting with '*').
+      # Set to 'no' if the answerbot is part of a Fritz!Box group call (Sammelruf),
+      # e.g. when a doorbell on Phone1 rings all phones in the group — otherwise the
+      # bot picks up the doorbell call (see discussion #327).
       - ACCEPT_LOCAL=yes
       # Phone number prefix that forces the answer bot to respond, even if the
       # caller is not on the blocklist. Useful to test the bot from an external

--- a/phoneblock-ab/configs/phoneblock-answerbot.template
+++ b/phoneblock-ab/configs/phoneblock-answerbot.template
@@ -66,9 +66,14 @@ min-votes = 4
 # separate answering machine in you router to gracefully handle anonymous calls.
 accept-anonymous=no
 
-# Prefix of a number that triggers PhoneBlock to respond to the call (for testing). A local number typically starts
-# with a '*' character. Using this prefix allows to call PhoneBlock locally to verify it is working. 
-test-prefix=*
+# Whether to accept calls from local phones (numbers starting with '*'). Enabled by default,
+# which already allows calling the answerbot locally for verification.
+accept-local=yes
+
+# Prefix of a number that forces the answerbot to respond, even if the calling number is
+# not on the blocklist. Useful to test the bot from an external number that is not flagged
+# as spam. Do not set this to '*': local calls are handled by 'accept-local' above.
+#test-prefix=
 
 # Enables the report of spam calls to the PhoneBlock  project. You need a PhoneBlock  account
 # https://phoneblock.net/phoneblock/signup.jsp for this.

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotConfig.java
@@ -28,9 +28,8 @@ public class AnswerbotConfig implements AnswerbotOptions {
 	@Option(name = "--recordings", aliases = "--recodings", usage = "Directory where to store recordings to, 'none' to disable recording.")
 	private String _recordingDir = "none";
 	
-	@Option(name = "--test-prefix", usage = "Phone number prefix that triggers the answer bot to respond (for testing). " + 
-			"A local number typically starts with '*', therefore this prefix can be used to allow calling the answer bot locally.")
-	private String _testPrefix = "*";
+	@Option(name = "--test-prefix", usage = "Phone number prefix that triggers the answer bot to respond (for testing). ")
+	private String _testPrefix = null;
 	
 	@Option(name = "--buffer-time", usage = "Time in milliseconds to buffer the audio stream for silence detection.")
 	private int _bufferTime = 20;

--- a/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotOptions.java
+++ b/phoneblock-ab/src/main/java/de/haumacher/phoneblock/answerbot/AnswerbotOptions.java
@@ -32,7 +32,8 @@ public interface AnswerbotOptions extends DialogOptions, StaticOptions {
 	 * Whether a {@link #getTestPrefix()} has been configured.
 	 */
 	default boolean hasTestPrefix() {
-		return getTestPrefix() != null;
+		String testPrefix = getTestPrefix();
+		return testPrefix != null && !testPrefix.isBlank();
 	}
 
 	/** 


### PR DESCRIPTION
## Summary
- The answer bot had two overlapping mechanisms for picking up local test calls: `accept-local=yes` (default) **and** `test-prefix=*` (default). Both triggered on numbers starting with `*`, so local test calls were handled twice.
- Default `--test-prefix` is now empty (blank values treated as unset). Local calls keep working through `accept-local`; `test-prefix` is reserved for forcing the bot on an external number that is not on the blocklist.
- `compose.yaml` and `configs/phoneblock-answerbot.template` now document both options (with a hint not to set `test-prefix=*` because that re-introduces the double mechanism).

## Test plan
- [x] `mvn -B -pl phoneblock-ab -DskipTests install`
- [ ] Start answer bot with defaults, call from a local Fritz\!Box phone (number starts with `*`) → bot picks up once (via `accept-local`)
- [ ] Set `accept-local=no` and `test-prefix=*` → bot still picks up local test calls (legacy behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)