### PR TITLE
Support PUID/PGID in the answer bot Docker image (#345)

### DIFF
--- a/phoneblock-ab/Dockerfile
+++ b/phoneblock-ab/Dockerfile
@@ -1,15 +1,22 @@
 FROM eclipse-temurin:17
 LABEL org.opencontainers.image.authors=play@haumacher.de
-USER root
-RUN adduser --system  --uid 999 --group --home /opt/phoneblock phoneblock
 
-USER phoneblock
-RUN mkdir  /opt/phoneblock/bin /opt/phoneblock/conversation /opt/phoneblock/recordings
+# gosu is used by the entrypoint to drop from root to the phoneblock user
+# after applying the PUID/PGID overrides.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends gosu \
+ && rm -rf /var/lib/apt/lists/* \
+ && adduser --system --uid 999 --group --home /opt/phoneblock phoneblock \
+ && mkdir /opt/phoneblock/bin /opt/phoneblock/conversation /opt/phoneblock/recordings \
+ && chown -R phoneblock:phoneblock /opt/phoneblock
+
 COPY --chown=phoneblock:phoneblock .phoneblock.docker /opt/phoneblock/.phoneblock
 COPY --chown=phoneblock:phoneblock target/phoneblock-ab-*-jar-with-dependencies.jar /opt/phoneblock/bin/phoneblock-ab.jar
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR /opt/phoneblock/
-ENTRYPOINT ["java", "-jar", "/opt/phoneblock/bin/phoneblock-ab.jar"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["-f", "/opt/phoneblock/.phoneblock"]
 EXPOSE 50060/tcp
 EXPOSE 50060/udp

--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -5,10 +5,14 @@ services:
     container_name: phoneblock
     network_mode: host
     environment:
-      # PUID/PGID override the in-container user (default 999) so it matches the
-      # host owner of the bind-mounted ./recordings directory. Set these to the
-      # numeric UID/GID that owns ./recordings on the host (e.g. `id -u` / `id -g`
-      # of the user running docker). Omit both to keep the image default.
+      # The container chowns the bind-mounted ./recordings directory to its
+      # internal user on startup, so recording works out of the box without
+      # any host-side chown. By default that user is UID/GID 999.
+      #
+      # Only set PUID/PGID if you want the recordings to be owned by a
+      # specific host user instead — e.g. so you can browse them via SMB/NFS
+      # under your normal account. Use the numeric UID/GID of that user
+      # (`id -u <name>` / `id -g <name>`).
       #- PUID=1000
       #- PGID=1000
       - PHONEBLOCK_API_KEY=<your API key, create one at https://phoneblock.net/phoneblock/settings>   <==== ADJUST HERE!

--- a/phoneblock-ab/compose.yaml
+++ b/phoneblock-ab/compose.yaml
@@ -5,6 +5,12 @@ services:
     container_name: phoneblock
     network_mode: host
     environment:
+      # PUID/PGID override the in-container user (default 999) so it matches the
+      # host owner of the bind-mounted ./recordings directory. Set these to the
+      # numeric UID/GID that owns ./recordings on the host (e.g. `id -u` / `id -g`
+      # of the user running docker). Omit both to keep the image default.
+      #- PUID=1000
+      #- PGID=1000
       - PHONEBLOCK_API_KEY=<your API key, create one at https://phoneblock.net/phoneblock/settings>   <==== ADJUST HERE!
       - SIP_USER=<your VOIP-Phone-User as configured in FRITZ!Box>         <==== ADJUST HERE!
       - SIP_PASSWD=<your VOIP-phone-password as configured in FRITZ!Box>   <==== ADJUST HERE!

--- a/phoneblock-ab/docker-entrypoint.sh
+++ b/phoneblock-ab/docker-entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Entry point for the phoneblock answer bot container.
+#
+# Honors PUID and PGID environment variables to adjust the runtime user to
+# match the host owner of bind-mounted directories (typical for NAS setups,
+# where /opt/phoneblock/recordings is mounted from the host). If unset, the
+# image default (999) is used.
+#
+set -e
+
+PUID="${PUID:-999}"
+PGID="${PGID:-999}"
+
+current_uid="$(id -u phoneblock)"
+current_gid="$(getent group phoneblock | cut -d: -f3)"
+
+if [ "$PGID" != "$current_gid" ]; then
+    groupmod -o -g "$PGID" phoneblock
+fi
+if [ "$PUID" != "$current_uid" ]; then
+    usermod -o -u "$PUID" phoneblock
+fi
+
+# The recordings directory may be a bind-mount whose host owner does not match
+# the in-container user; ensure the (possibly remapped) phoneblock user can
+# write into it. Non-recursive on purpose to avoid touching existing recordings.
+chown phoneblock:phoneblock /opt/phoneblock/recordings 2>/dev/null || true
+
+exec gosu phoneblock java -jar /opt/phoneblock/bin/phoneblock-ab.jar "$@"


### PR DESCRIPTION
## Summary
- Closes #345: the answer bot image hard-codes the runtime user to UID/GID 999, so when a host directory is bind-mounted to `/opt/phoneblock/recordings` (typical on NAS setups), the bot cannot create recording files because the host directory is owned by a different UID.
- The actual fix is to start the container as root, run `chown phoneblock:phoneblock /opt/phoneblock/recordings` in an entrypoint script, then drop privileges via `gosu`. Because bind-mounts share inodes with the host, this also adjusts the ownership of the host directory — no host-side `chown` required from the operator.
- `PUID` / `PGID` are exposed as an **optional** convenience for operators who want recordings to be owned by a specific host user (e.g. so the files are browsable via SMB/NFS under a normal user account). Defaults stay at 999/999.

## Behavior matrix

| Scenario | Configuration | Result |
|---|---|---|
| Default — no env vars set | nothing | Container runs as UID 999, recordings dir chowned to 999:999 on the host. Bot can write. |
| Operator wants files under their NAS user | `PUID=1000`, `PGID=100` | Container runs as 1000:100, recordings dir chowned to 1000:100. Bot can write, host user can browse normally. |

## Test plan
- [x] `docker build` succeeds against the new Dockerfile.
- [x] Default run (no `PUID`/`PGID`): `id phoneblock` reports `uid=999 gid=999`, recordings dir owned by 999:999.
- [x] Override (`PUID=1234 PGID=5678`): `id phoneblock` reports the remapped IDs, `/opt/phoneblock/recordings` is chowned to the new user, Java starts via `gosu`.
- [ ] Verify on a real NAS with a host-mounted recordings directory whose owner UID differs from 999 — confirm recordings are created without host-side `chown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)