### PR TITLE
fix(dongle): Daily timers fired every ~8 min due to pdMS_TO_TICKS overflow (#348)

### DIFF
--- a/phoneblock-dongle/firmware/CLAUDE.md
+++ b/phoneblock-dongle/firmware/CLAUDE.md
@@ -28,3 +28,10 @@ stays comfortably inside `uint32_t`. Use the helpers in
 
 Plain `pdMS_TO_TICKS` is fine for short, obviously-safe intervals
 (seconds to a few minutes).
+
+This is a temporary workaround: FreeRTOS-Kernel PR #866 widened
+`pdMS_TO_TICKS` to `uint64_t` upstream and shipped in kernel V11.0.0
+(Dec 2023). ESP-IDF v5.3 still bundles V10.5.1 with the 32-bit
+multiplication. When we upgrade to ESP-IDF >= v5.4 (kernel V11+),
+plain `pdMS_TO_TICKS` becomes safe again and `ticks_util.h` (plus the
+`seconds_to_ticks` / `pb_ms_to_ticks` call sites) can be retired.

--- a/phoneblock-dongle/firmware/CLAUDE.md
+++ b/phoneblock-dongle/firmware/CLAUDE.md
@@ -14,11 +14,13 @@ value above ~42_949_672 (≈12 h) overflows the multiplication and wraps
 to a much shorter delay — a 24 h interval becomes ~8.3 min, which is
 how issue #348 leaked.
 
-Use the helpers in `main/ticks_util.h` for anything bigger than a
-minute or two:
+The fix is the unit, not wider arithmetic: in seconds, even a 24 h delay
+stays comfortably inside `uint32_t`. Use the helpers in
+`main/ticks_util.h` for anything bigger than a minute or two:
 
-- `seconds_to_ticks(uint32_t seconds)` — runtime values; does the
-  multiplication in 64-bit.
+- `seconds_to_ticks(uint32_t seconds)` — takes the interval in seconds,
+  so the `* configTICK_RATE_HZ` multiplication can't overflow for any
+  delay short enough to fit in a `TickType_t` at all.
 - `pb_ms_to_ticks(ms)` — drop-in replacement for `pdMS_TO_TICKS` that
   refuses to compile if a *constant* `ms` would overflow. Use this
   whenever you'd reach for `pdMS_TO_TICKS` with a literal, so the

--- a/phoneblock-dongle/firmware/CLAUDE.md
+++ b/phoneblock-dongle/firmware/CLAUDE.md
@@ -1,0 +1,28 @@
+# Dongle firmware
+
+ESP-IDF firmware for the PhoneBlock dongle (ESP32). Build with
+`idf.py build` after `source ~/tools/esp/esp-idf/export.sh`. See
+`README.md` for the full setup, QEMU recipes and on-device flashing.
+
+## Conventions
+
+### Long-running timer intervals
+
+`pdMS_TO_TICKS(ms)` multiplies its argument by `configTICK_RATE_HZ` in
+32-bit `TickType_t`. At the project's 100 Hz tick rate, any millisecond
+value above ~42_949_672 (≈12 h) overflows the multiplication and wraps
+to a much shorter delay — a 24 h interval becomes ~8.3 min, which is
+how issue #348 leaked.
+
+Use the helpers in `main/ticks_util.h` for anything bigger than a
+minute or two:
+
+- `seconds_to_ticks(uint32_t seconds)` — runtime values; does the
+  multiplication in 64-bit.
+- `pb_ms_to_ticks(ms)` — drop-in replacement for `pdMS_TO_TICKS` that
+  refuses to compile if a *constant* `ms` would overflow. Use this
+  whenever you'd reach for `pdMS_TO_TICKS` with a literal, so the
+  build catches the gotcha for you.
+
+Plain `pdMS_TO_TICKS` is fine for short, obviously-safe intervals
+(seconds to a few minutes).

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -26,15 +26,13 @@
 #include "sdkconfig.h"
 
 #include "config.h"
+#include "ticks_util.h"
 
 static const char *TAG = "fwup";
 
 // 24 h between scheduled checks — same cadence as the daily token
 // self-test, with the same ±30 min skew so a fleet-wide power blip
 // doesn't line every dongle up onto the same minute on the CDN.
-// In seconds, not ms: pdMS_TO_TICKS would overflow 32-bit TickType_t
-// at 100 Hz for a 24 h delay. We multiply by configTICK_RATE_HZ in
-// 64-bit at the call site.
 #define FWUP_INTERVAL_S     (24 * 3600)
 #define FWUP_JITTER_S       (30 * 60)
 
@@ -661,7 +659,7 @@ static void update_task(void *arg)
     while (1) {
         uint32_t jitter  = esp_random() % (2u * FWUP_JITTER_S);
         uint32_t delay_s = FWUP_INTERVAL_S - FWUP_JITTER_S + jitter;
-        vTaskDelay((TickType_t)((uint64_t)delay_s * configTICK_RATE_HZ));
+        vTaskDelay(seconds_to_ticks(delay_s));
         // Skip until the device is provisioned. Using the PhoneBlock
         // token as the "is configured" proxy mirrors the self-test
         // task — an unconfigured dongle has nothing to lose by

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -32,8 +32,11 @@ static const char *TAG = "fwup";
 // 24 h between scheduled checks — same cadence as the daily token
 // self-test, with the same ±30 min skew so a fleet-wide power blip
 // doesn't line every dongle up onto the same minute on the CDN.
-#define FWUP_INTERVAL_MS    (24 * 3600 * 1000)
-#define FWUP_JITTER_MS      (30 * 60 * 1000)
+// In seconds, not ms: pdMS_TO_TICKS would overflow 32-bit TickType_t
+// at 100 Hz for a 24 h delay. We multiply by configTICK_RATE_HZ in
+// 64-bit at the call site.
+#define FWUP_INTERVAL_S     (24 * 3600)
+#define FWUP_JITTER_S       (30 * 60)
 
 static TaskHandle_t s_task = NULL;
 
@@ -656,9 +659,9 @@ static void update_task(void *arg)
     // path already validated the running image; no point overwriting
     // it the moment we come up.
     while (1) {
-        uint32_t jitter = esp_random() % (2u * FWUP_JITTER_MS);
-        uint32_t delay  = FWUP_INTERVAL_MS - FWUP_JITTER_MS + jitter;
-        vTaskDelay(pdMS_TO_TICKS(delay));
+        uint32_t jitter  = esp_random() % (2u * FWUP_JITTER_S);
+        uint32_t delay_s = FWUP_INTERVAL_S - FWUP_JITTER_S + jitter;
+        vTaskDelay((TickType_t)((uint64_t)delay_s * configTICK_RATE_HZ));
         // Skip until the device is provisioned. Using the PhoneBlock
         // token as the "is configured" proxy mirrors the self-test
         // task — an unconfigured dongle has nothing to lose by

--- a/phoneblock-dongle/firmware/main/selftest.c
+++ b/phoneblock-dongle/firmware/main/selftest.c
@@ -10,13 +10,11 @@
 
 #include "api.h"
 #include "config.h"
+#include "ticks_util.h"
 
 static const char *TAG = "selftest";
 
 // 24 h between scheduled runs — same cadence as the sync task.
-// In seconds, not ms: pdMS_TO_TICKS would overflow 32-bit TickType_t
-// at 100 Hz for a 24 h delay. We multiply by configTICK_RATE_HZ in
-// 64-bit at the call site.
 #define SELFTEST_INTERVAL_S     (24 * 3600)
 // ±30 min skew so a fleet-wide power blip doesn't line every dongle
 // up to the same minute on /api/test forever after.
@@ -32,7 +30,7 @@ static void selftest_task(void *arg)
     while (1) {
         uint32_t jitter  = esp_random() % (2u * SELFTEST_JITTER_S);
         uint32_t delay_s = SELFTEST_INTERVAL_S - SELFTEST_JITTER_S + jitter;
-        vTaskDelay((TickType_t)((uint64_t)delay_s * configTICK_RATE_HZ));
+        vTaskDelay(seconds_to_ticks(delay_s));
         if (strlen(config_phoneblock_token()) == 0) continue;
         ESP_LOGI(TAG, "scheduled token self-test");
         phoneblock_selftest(NULL);

--- a/phoneblock-dongle/firmware/main/selftest.c
+++ b/phoneblock-dongle/firmware/main/selftest.c
@@ -14,10 +14,13 @@
 static const char *TAG = "selftest";
 
 // 24 h between scheduled runs — same cadence as the sync task.
-#define SELFTEST_INTERVAL_MS    (24 * 3600 * 1000)
+// In seconds, not ms: pdMS_TO_TICKS would overflow 32-bit TickType_t
+// at 100 Hz for a 24 h delay. We multiply by configTICK_RATE_HZ in
+// 64-bit at the call site.
+#define SELFTEST_INTERVAL_S     (24 * 3600)
 // ±30 min skew so a fleet-wide power blip doesn't line every dongle
 // up to the same minute on /api/test forever after.
-#define SELFTEST_JITTER_MS      (30 * 60 * 1000)
+#define SELFTEST_JITTER_S       (30 * 60)
 
 static TaskHandle_t s_task = NULL;
 
@@ -27,9 +30,9 @@ static void selftest_task(void *arg)
     // The boot-time check runs synchronously from app_main, so the
     // first scheduled iteration happens one full interval later.
     while (1) {
-        uint32_t jitter = esp_random() % (2u * SELFTEST_JITTER_MS);
-        uint32_t delay  = SELFTEST_INTERVAL_MS - SELFTEST_JITTER_MS + jitter;
-        vTaskDelay(pdMS_TO_TICKS(delay));
+        uint32_t jitter  = esp_random() % (2u * SELFTEST_JITTER_S);
+        uint32_t delay_s = SELFTEST_INTERVAL_S - SELFTEST_JITTER_S + jitter;
+        vTaskDelay((TickType_t)((uint64_t)delay_s * configTICK_RATE_HZ));
         if (strlen(config_phoneblock_token()) == 0) continue;
         ESP_LOGI(TAG, "scheduled token self-test");
         phoneblock_selftest(NULL);

--- a/phoneblock-dongle/firmware/main/sync.c
+++ b/phoneblock-dongle/firmware/main/sync.c
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "http_util.h"
 #include "stats.h"
+#include "ticks_util.h"
 #include "tr064.h"
 #include "tr064_parse.h"
 
@@ -248,10 +249,7 @@ static void run_once(void)
 static void sync_task(void *arg)
 {
     (void)arg;
-    // pdMS_TO_TICKS multiplies in 32-bit TickType_t, so a 24 h value in
-    // ms overflows at 100 Hz tick rate (86_400_000 * 100 wraps). Compute
-    // ticks directly from seconds in 64-bit instead.
-    TickType_t timeout = (TickType_t)((uint64_t)SYNC_INTERVAL_S * configTICK_RATE_HZ);
+    TickType_t timeout = seconds_to_ticks(SYNC_INTERVAL_S);
     // On first boot don't fire immediately — the user may still be
     // in the middle of setup. Wait one interval before the first
     // scheduled run; a manual trigger can fire sooner.

--- a/phoneblock-dongle/firmware/main/sync.c
+++ b/phoneblock-dongle/firmware/main/sync.c
@@ -23,7 +23,7 @@
 static const char *TAG = "sync";
 
 // 24 h between scheduled runs, as per design.
-#define SYNC_INTERVAL_US    (24LL * 3600LL * 1000000LL)
+#define SYNC_INTERVAL_S     (24 * 3600)
 
 static TaskHandle_t     s_task       = NULL;
 static SemaphoreHandle_t s_trigger   = NULL;    // binary semaphore
@@ -248,7 +248,10 @@ static void run_once(void)
 static void sync_task(void *arg)
 {
     (void)arg;
-    TickType_t timeout = pdMS_TO_TICKS(SYNC_INTERVAL_US / 1000);
+    // pdMS_TO_TICKS multiplies in 32-bit TickType_t, so a 24 h value in
+    // ms overflows at 100 Hz tick rate (86_400_000 * 100 wraps). Compute
+    // ticks directly from seconds in 64-bit instead.
+    TickType_t timeout = (TickType_t)((uint64_t)SYNC_INTERVAL_S * configTICK_RATE_HZ);
     // On first boot don't fire immediately — the user may still be
     // in the middle of setup. Wait one interval before the first
     // scheduled run; a manual trigger can fire sooner.

--- a/phoneblock-dongle/firmware/main/ticks_util.h
+++ b/phoneblock-dongle/firmware/main/ticks_util.h
@@ -6,11 +6,14 @@
 
 // pdMS_TO_TICKS multiplies its argument by configTICK_RATE_HZ in 32-bit
 // TickType_t and overflows for daily intervals (86_400_000 ms * 100 Hz
-// wraps to ~8.3 min). Express long delays in seconds and convert with
-// this helper, which does the multiplication in 64-bit.
+// wraps to ~8.3 min). The fix is the unit, not wider arithmetic: in
+// seconds, even a 24 h delay stays comfortably inside uint32_t
+// (86_400 * 100 = 8_640_000). At 100 Hz, TickType_t itself caps out
+// around 497 days, so any input that would overflow this multiplication
+// is unrepresentable as a tick count anyway.
 static inline TickType_t seconds_to_ticks(uint32_t seconds)
 {
-    return (TickType_t)((uint64_t)seconds * configTICK_RATE_HZ);
+    return (TickType_t)(seconds * configTICK_RATE_HZ);
 }
 
 // Drop-in replacement for pdMS_TO_TICKS that refuses to compile when a

--- a/phoneblock-dongle/firmware/main/ticks_util.h
+++ b/phoneblock-dongle/firmware/main/ticks_util.h
@@ -11,6 +11,13 @@
 // (86_400 * 100 = 8_640_000). At 100 Hz, TickType_t itself caps out
 // around 497 days, so any input that would overflow this multiplication
 // is unrepresentable as a tick count anyway.
+//
+// Background: FreeRTOS-Kernel PR #866 widened pdMS_TO_TICKS to uint64_t
+// upstream and shipped in kernel V11.0.0 (Dec 2023). ESP-IDF v5.3 still
+// bundles V10.5.1 with the 32-bit macro, which is why this helper is
+// needed today. When we eventually move to ESP-IDF >= v5.4 (kernel V11+),
+// plain pdMS_TO_TICKS becomes safe again and the helpers in this header
+// can be retired in favour of it.
 static inline TickType_t seconds_to_ticks(uint32_t seconds)
 {
     return (TickType_t)(seconds * configTICK_RATE_HZ);

--- a/phoneblock-dongle/firmware/main/ticks_util.h
+++ b/phoneblock-dongle/firmware/main/ticks_util.h
@@ -12,3 +12,16 @@ static inline TickType_t seconds_to_ticks(uint32_t seconds)
 {
     return (TickType_t)((uint64_t)seconds * configTICK_RATE_HZ);
 }
+
+// Drop-in replacement for pdMS_TO_TICKS that refuses to compile when a
+// constant millisecond value would overflow TickType_t at the current
+// tick rate. Catches the most common form of the gotcha — a literal
+// like `pb_ms_to_ticks(24 * 3600 * 1000)` — at build time. For runtime
+// values where the upper bound is unknown, use seconds_to_ticks
+// instead.
+#define pb_ms_to_ticks(ms) __extension__ ({ \
+    _Static_assert((uint64_t)(ms) * configTICK_RATE_HZ <= UINT32_MAX, \
+        "pb_ms_to_ticks: value overflows TickType_t at this tick rate " \
+        "— use seconds_to_ticks for long intervals"); \
+    pdMS_TO_TICKS(ms); \
+})

--- a/phoneblock-dongle/firmware/main/ticks_util.h
+++ b/phoneblock-dongle/firmware/main/ticks_util.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "freertos/FreeRTOS.h"
+
+// pdMS_TO_TICKS multiplies its argument by configTICK_RATE_HZ in 32-bit
+// TickType_t and overflows for daily intervals (86_400_000 ms * 100 Hz
+// wraps to ~8.3 min). Express long delays in seconds and convert with
+// this helper, which does the multiplication in 64-bit.
+static inline TickType_t seconds_to_ticks(uint32_t seconds)
+{
+    return (TickType_t)((uint64_t)seconds * configTICK_RATE_HZ);
+}


### PR DESCRIPTION
## Summary
- **Fixes #348.** The dongle's daily blocklist sync (and, for the same root cause, the daily firmware-update check and daily token self-test) fired roughly every 8 min instead of every 24 h. `pdMS_TO_TICKS(86_400_000)` multiplies in 32-bit `TickType_t`; at 100 Hz tick rate, `86_400_000 * 100` overflows and wraps to ~50_065 ticks ≈ 8.3 min. The reporter sees this as "Last run x min ago" never exceeding ~9 min.
- Express the three daily intervals in seconds and convert to ticks in 64-bit. Extracted as `seconds_to_ticks()` in a new `main/ticks_util.h` so all three call sites read as one line and the gotcha is documented exactly once next to the helper.
- Added a tripwire for the next person who reaches for `pdMS_TO_TICKS` with a daily constant: `pb_ms_to_ticks(ms)` is a drop-in replacement that uses `_Static_assert` to refuse constants whose tick conversion would overflow `TickType_t`. A new `phoneblock-dongle/firmware/CLAUDE.md` documents the convention so the next contributor is steered to the safe helpers.

## Test plan
- [x] `idf.py build` clean after every commit.
- [x] On real hardware: confirm "Blocklist Sync — Last run" timer crosses 10 min, eventually reaches 24 h.
- [ ] On real hardware: confirm scheduled firmware-update check + self-test no longer fire every ~8 min in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)