### PR TITLE
Stabilise dongle TLS session resumption with single-process Apache (#351)

### DIFF
--- a/cloud-settings/root/etc/apache2/mods-available/mpm_event.conf
+++ b/cloud-settings/root/etc/apache2/mods-available/mpm_event.conf
@@ -1,0 +1,23 @@
+# event MPM - single-process override for a STABLE TLS session-ticket key.
+#
+# TLS resumption needs ONE ticket key across all connections, but mod_ssl's
+# SSLSessionTicketKeyFile is ignored on this OpenSSL 3 build (the key loads
+# - AH02288 - but is never used), so each worker PROCESS picked its own
+# random key and the dongle's session resumption was hit-or-miss (~1/N).
+# Confining Apache to ONE process makes all worker THREADS share OpenSSL's
+# single per-process auto-key -> consistent resumption.
+#
+# Capacity is unchanged: MaxRequestWorkers stays 150 (= ServerLimit 1 x
+# ThreadsPerChild 150). On 2 cores these are I/O-concurrency slots, not
+# parallelism. Trade-off: no elastic process scaling and a crash drops all
+# connections at once (parent re-forks in <1s). MinSpare/MaxSpareThreads
+# are inert with ServerLimit 1 (cannot spawn/kill a second process).
+# This is a stopgap until the nginx rebuild (Phase 2) terminates TLS.
+StartServers            1
+ServerLimit             1
+MinSpareThreads         25
+MaxSpareThreads         150
+ThreadLimit             150
+ThreadsPerChild         150
+MaxRequestWorkers       150
+MaxConnectionsPerChild  0

--- a/cloud-settings/root/etc/logrotate.d/apache2
+++ b/cloud-settings/root/etc/logrotate.d/apache2
@@ -1,0 +1,16 @@
+/var/log/apache2/*.log {
+	daily
+	missingok
+	rotate 14
+	compress
+	delaycompress
+	notifempty
+	# copytruncate instead of the default create + "reload" postrotate:
+	# a graceful reload spawns a new single worker process (see
+	# mods-available/mpm_event.conf) with a fresh TLS session-ticket key,
+	# which would break the dongle's session resumption once a day.
+	# copytruncate rotates the logs without signalling Apache, so the
+	# running process keeps its key. Tiny race: log lines written during
+	# the copy+truncate window may be lost (access logs only).
+	copytruncate
+}


### PR DESCRIPTION
Fixes the dongle's unreliable TLS session resumption — the cause of the "sometimes ~1.5 s" spam-verdict latency (full handshake instead of resume).

## Root cause (verified live on phoneblock.net)

Apache MPM **event** runs several worker **processes**, each with its own random TLS session-ticket key. The dongle (1–2 calls/day) only resumed when its next call happened to hit the worker that issued the ticket — roughly `1/N`.

`SSLSessionTicketKeyFile` would normally pin one key across all workers, but on this **Apache 2.4.58 / OpenSSL 3** build it is **ignored**: the key loads (`AH02288 "successfully loaded"`) yet is never used for ticket encryption — the Debian #880565 symptom class. A ticket does not even survive a restart with an unchanged key file. So pinning is a dead end here.

## Phase 1 (this PR) — stopgap, no new component

- **`mods-available/mpm_event.conf`**: `ServerLimit 1` + `ThreadsPerChild 150` → a single process serves everything and all worker *threads* share OpenSSL's one auto-key. Verified **10/10** consistent resumptions. `MaxRequestWorkers` stays 150 (unchanged ceiling).
- **`logrotate.d/apache2`**: `copytruncate` instead of the daily graceful reload, which would otherwise respawn the worker with a fresh key every day. Verified: a forced rotation keeps resumption working (**6/6 Reused**).

Trade-off: no process-level fault isolation, no elastic process scaling.

## Phase 2 (follow-up #352)

Rebuild on a modern nginx stack — nginx terminates TLS with a shared `ssl_session_ticket_key` across all workers, surviving reloads (CGI/awstats dropped). Afterwards this single-process workaround is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)