### PR TITLE
fix(dongle): Telekom SIP setup + make all warnings/errors visible on the web UI (#363)

### DIFF
--- a/phoneblock-dongle/firmware/CLAUDE.md
+++ b/phoneblock-dongle/firmware/CLAUDE.md
@@ -6,6 +6,20 @@ ESP-IDF firmware for the PhoneBlock dongle (ESP32). Build with
 
 ## Conventions
 
+### Warnings/errors are mirrored to the web UI
+
+`main/log_capture.c` installs a global `esp_log_set_vprintf` hook that
+copies every `ESP_LOGW`/`ESP_LOGE` line — ours and the ESP-IDF
+libraries' — into the stats error ring, shown as the "Protokoll" panel on
+the dongle's web page. This is the field-diagnosis path: customers read
+problems off the web UI instead of needing a serial console.
+
+Consequence for new code: **log an unusual condition at WARN or ERROR and
+it shows up on the UI automatically** — no per-call-site plumbing. Keep
+`ESP_LOGI` for normal progress; don't `ESP_LOGW` things that recur every
+few seconds (they'd flush the 32-entry ring). The parsing of the formatted
+log line is host-tested in `test/test_log_capture.c`.
+
 ### Long-running timer intervals
 
 `pdMS_TO_TICKS(ms)` multiplies its argument by `configTICK_RATE_HZ` in

--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "config.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c"
+    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -301,7 +301,6 @@ static esp_http_client_handle_t check_client(void)
         s_check_client = esp_http_client_init(&config);
         if (s_check_client == NULL) {
             ESP_LOGE(TAG, "failed to create shared HTTP client");
-            stats_record_error("api", "HTTP client init failed");
         }
     }
     return s_check_client;
@@ -388,20 +387,15 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out,
 
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(err));
-        char msg[96];
-        snprintf(msg, sizeof(msg), "HTTP transport: %s", esp_err_to_name(err));
-        stats_record_error("api", msg);
+        goto cleanup;
+    }
+
+    if (status != 200) {
+        ESP_LOGE(TAG, "check-prefix HTTP %d for hash %s", status, hash_full);
         goto cleanup;
     }
 
     ESP_LOGI(TAG, "HTTP %d", status);
-
-    if (status != 200) {
-        char msg[96];
-        snprintf(msg, sizeof(msg), "HTTP %d for hash %s", status, hash_full);
-        stats_record_error("api", msg);
-        goto cleanup;
-    }
 
     if (scan.error) {
         // Per-entry buffer overflow or per-entry parse failure — verdict
@@ -410,9 +404,6 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out,
         // and the device dashboard.
         const char *reason = scan.error_reason ? scan.error_reason : "unknown";
         ESP_LOGE(TAG, "check-prefix scanner: %s", reason);
-        char msg[96];
-        snprintf(msg, sizeof(msg), "check-prefix scanner: %s", reason);
-        stats_record_error("api", msg);
         goto cleanup;
     }
 
@@ -532,16 +523,10 @@ bool phoneblock_report_call(const char *phone)
 
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "report-call transport: %s", esp_err_to_name(err));
-        char msg[96];
-        snprintf(msg, sizeof(msg), "report-call transport: %s", esp_err_to_name(err));
-        stats_record_error("api", msg);
         return false;
     }
     if (status != 204 && status != 200) {
         ESP_LOGE(TAG, "report-call: HTTP %d for %s", status, phone);
-        char msg[96];
-        snprintf(msg, sizeof(msg), "report-call: HTTP %d", status);
-        stats_record_error("api", msg);
         return false;
     }
     return true;
@@ -662,22 +647,12 @@ bool phoneblock_selftest(api_phases_t *phases_opt)
     bool ok = false;
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "self-test transport: %s", esp_err_to_name(err));
-        char msg[96];
-        snprintf(msg, sizeof(msg), "self-test transport: %s", esp_err_to_name(err));
-        stats_record_error("api", msg);
+    } else if (status == 200) {
+        ESP_LOGI(TAG, "self-test: HTTP 200, token accepted");
+        ok = true;
     } else {
-        if (status == 200) {
-            ESP_LOGI(TAG, "self-test: HTTP 200, token accepted");
-            ok = true;
-        } else {
-            ESP_LOGE(TAG, "self-test: HTTP %d, body: %.*s",
-                     status, resp.len, resp.data);
-            char msg[96];
-            int body_len = resp.len < 48 ? resp.len : 48;
-            snprintf(msg, sizeof(msg), "self-test: HTTP %d: %.*s",
-                     status, body_len, resp.data);
-            stats_record_error("api", msg);
-        }
+        ESP_LOGE(TAG, "self-test: HTTP %d, body: %.*s",
+                 status, resp.len, resp.data);
     }
     // Close but keep the handle so the freshly issued TLS session
     // ticket survives for the next spam-lookup call.

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -380,7 +380,8 @@ esp_err_t config_update(const config_update_t *u)
 
     err = set_str_if(h, K_SIP_HOST, u->sip_host,
                      s_config.sip_host, sizeof(s_config.sip_host));
-    if (err == ESP_OK) err = set_int_if(h, K_SIP_PORT, u->sip_port, &s_config.sip_port);
+    if (err == ESP_OK) err = set_int_explicit(h, K_SIP_PORT, u->has_sip_port,
+                                              u->sip_port, &s_config.sip_port);
     if (err == ESP_OK) err = set_str_if(h, K_SIP_USER, u->sip_user,
                                         s_config.sip_user, sizeof(s_config.sip_user));
     if (err == ESP_OK) err = set_str_if(h, K_SIP_PASS, u->sip_pass,

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -27,6 +27,7 @@ static const char *NS   = "phoneblock";
 #define K_FB_APP_PASS   "fb_app_pass"
 #define K_SYNC_ENABLED  "sync_enabled"
 #define K_LOG_KNOWN     "log_known_calls"
+#define K_LOG_INFO      "log_info"
 #define K_AUTH_ENABLED  "auth_enabled"
 #define K_AUTH_USER     "auth_user"
 #define K_AUTH_PERSIST  "auth_persist"
@@ -73,6 +74,7 @@ typedef struct {
     char fb_app_pass[40];    // spec cap is 32; 40 for NUL + padding
     char sync_enabled[4];    // "1" | "0" (or empty = default off)
     char log_known[4];       // "1" | "0" (or empty = default on)
+    char log_info[4];        // "1" = also mirror INFO lines to the log panel (default off)
     char auth_enabled[4];    // "1" | "0" (or empty = default off)
     char auth_user[64];      // pinned PhoneBlock user-name; empty = no pin
     char auth_persist[33];   // 32 hex chars + NUL; empty = nobody is "remembered"
@@ -141,6 +143,7 @@ void config_load(void)
         s_config.fb_app_pass[0]   = '\0';
         s_config.sync_enabled[0]  = '\0';
         s_config.log_known[0]     = '\0';
+        s_config.log_info[0]      = '\0';
         s_config.auth_enabled[0]  = '\0';
         s_config.auth_user[0]     = '\0';
         s_config.auth_persist[0]  = '\0';
@@ -189,6 +192,8 @@ void config_load(void)
              s_config.sync_enabled, sizeof(s_config.sync_enabled));
     load_str(h, K_LOG_KNOWN, "",
              s_config.log_known, sizeof(s_config.log_known));
+    load_str(h, K_LOG_INFO, "",
+             s_config.log_info, sizeof(s_config.log_info));
     load_str(h, K_AUTH_ENABLED, "",
              s_config.auth_enabled, sizeof(s_config.auth_enabled));
     load_str(h, K_AUTH_USER, "",
@@ -246,6 +251,13 @@ bool        config_log_known_calls(void)
     // Default on (empty / unrecognised → log) so new users see every
     // call the dongle handled. Only an explicit "0" disables listing.
     return s_config.log_known[0] != '0';
+}
+bool        config_log_info(void)
+{
+    // Default off: the log panel shows only WARN/ERROR. Switched on from
+    // the UI for troubleshooting, when the context that only INFO lines
+    // carry (e.g. "registrar host:port") is needed. Only "1" enables it.
+    return s_config.log_info[0] == '1';
 }
 bool        config_auth_enabled(void)
 {
@@ -407,6 +419,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.sync_enabled, sizeof(s_config.sync_enabled));
     if (err == ESP_OK) err = set_str_if(h, K_LOG_KNOWN, u->log_known_calls,
                                         s_config.log_known, sizeof(s_config.log_known));
+    if (err == ESP_OK) err = set_str_if(h, K_LOG_INFO, u->log_info,
+                                        s_config.log_info, sizeof(s_config.log_info));
     if (err == ESP_OK) err = set_str_if(h, K_AUTH_ENABLED, u->auth_enabled,
                                         s_config.auth_enabled, sizeof(s_config.auth_enabled));
     if (err == ESP_OK) err = set_str_if(h, K_AUTH_USER, u->auth_user,

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -68,6 +68,13 @@ bool        config_sync_enabled(void);
 // Default on so new users see every call the dongle handled.
 bool        config_log_known_calls(void);
 
+// Whether the global log hook also mirrors INFO lines (not just
+// WARN/ERROR) into the log panel. Default off; a troubleshooting toggle
+// — INFO carries the context (tried host:port, request URLs, …) that a
+// bare WARN/ERROR omits. Floods the 32-entry ring, so meant to be turned
+// on, reproduced, read, and turned off again.
+bool        config_log_info(void);
+
 // Whether the web UI requires "Login with PhoneBlock" before
 // showing call data or accepting setting changes. Default off —
 // during initial provisioning the LAN-local UI must be reachable
@@ -183,6 +190,9 @@ typedef struct {
     // "1" = log known/internal calls, "0" = skip them, NULL = leave
     // unchanged. Default when the key is unset is "log them".
     const char *log_known_calls;
+    // "1" = also capture INFO log lines, "0" = only WARN/ERROR. NULL =
+    // leave unchanged. Default when unset is "off".
+    const char *log_info;
     // "1" = require "Login with PhoneBlock" before serving the UI,
     // "0" = open access. NULL = leave unchanged. Default when the
     // key is unset is "open access" (setup phase).

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -161,7 +161,12 @@ esp_err_t   config_set_last_failed_ota(const char *version);
 // commit succeeds; on failure the cache is unchanged.
 typedef struct {
     const char *sip_host;
-    int         sip_port;           // 0 = keep current
+    // Uses an explicit has_sip_port flag rather than the 0-sentinel
+    // pattern because 0 is a real value here (= "auto": let DNS-SRV /
+    // the transport default pick the port). A provider switch must be
+    // able to clear a previously pinned port back to auto.
+    bool        has_sip_port;
+    int         sip_port;
     const char *sip_user;
     const char *sip_pass;
     int         sip_expires;        // 0 = keep current

--- a/phoneblock-dongle/firmware/main/crashreport.c
+++ b/phoneblock-dongle/firmware/main/crashreport.c
@@ -78,6 +78,12 @@ static void crashreport_task(void *arg)
         return;
     }
 
+    // A stored dump means the previous run panicked. Surface that as a
+    // WARNING regardless of what happens to the dump next (erase / keep /
+    // upload) so a field crash is visible on the web UI's log panel even
+    // when reporting is off or the dongle isn't paired yet.
+    ESP_LOGW(TAG, "core dump from a previous crash detected (%zu bytes)", size);
+
     if (!config_crash_report_enabled()) {
         // User opted out from the web UI. Erase the dump locally so
         // it doesn't sit in flash forever — and so a later re-enable
@@ -131,7 +137,7 @@ static void crashreport_task(void *arg)
     // above the observed handshake peak.
     size_t free_heap = esp_get_free_heap_size();
     if (free_heap < CRASHREPORT_MIN_FREE_HEAP) {
-        ESP_LOGI(TAG, "heap %zu B below %d B — deferring upload to next boot",
+        ESP_LOGW(TAG, "heap %zu B below %d B — deferring upload to next boot",
                  free_heap, CRASHREPORT_MIN_FREE_HEAP);
         vTaskDelete(NULL);
         return;

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -209,7 +209,10 @@ static void reboot_task(void *arg)
 
 void firmware_schedule_reboot(void)
 {
-    xTaskCreate(reboot_task, "fw_reboot", 2048, NULL, 5, NULL);
+    // 2.5 KB: this task logs a WARN line (→ capture path + the log hook's
+    // frame) right before esp_restart(); 2 KB left too little headroom for
+    // the hook. See the stack-sizing note in log_capture.c.
+    xTaskCreate(reboot_task, "fw_reboot", 2560, NULL, 5, NULL);
 }
 
 // Fetch the JSON manifest into the caller-provided buffer. Returns

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -93,6 +93,25 @@ char log_capture_parse(const char *line,
 // Previous (console) sink, so the serial log stays fully intact.
 static vprintf_like_t s_console;
 
+// Format the captured line and push it to the stats ring. Kept in a
+// SEPARATE, never-inlined function on purpose: its ~350 B of line/tag/
+// msg buffers then land on the stack only while a WARN/ERROR line is
+// actually being captured, not on every log call. Folded into log_hook
+// (inlined), those buffers would inflate the frame of *every* logging
+// task — a 2 KB task such as status_led overflowed on a plain INFO line
+// because the hook reserved them unconditionally.
+static void __attribute__((noinline))
+capture_line(int level, const char *fmt, va_list ap)
+{
+    char line[192];
+    vsnprintf(line, sizeof(line), fmt, ap);
+    char tag[STATS_ERROR_TAG_LEN];
+    char msg[STATS_ERROR_MSG_LEN];
+    if (log_capture_parse(line, tag, sizeof(tag), msg, sizeof(msg))) {
+        stats_record_error(level, tag, msg);
+    }
+}
+
 static int log_hook(const char *fmt, va_list ap)
 {
     va_list copy;
@@ -102,19 +121,13 @@ static int log_hook(const char *fmt, va_list ap)
     // at the cost of the serial log.
     int ret = s_console ? s_console(fmt, ap) : vprintf(fmt, ap);
 
-    // The level letter is a literal in the format string, so we can
-    // skip the expensive vsnprintf for the common INFO/DEBUG lines.
+    // The level letter is a literal in the format string, so we decide
+    // here, with no buffers on the stack: INFO/DEBUG lines (the vast
+    // majority) leave log_hook's frame tiny. Only WARN/ERROR descends
+    // into capture_line(), which owns the buffers.
     char lvl = log_capture_level(fmt);
     if (lvl == 'E' || lvl == 'W') {
-        char line[192];
-        vsnprintf(line, sizeof(line), fmt, copy);
-        char tag[STATS_ERROR_TAG_LEN];
-        char msg[STATS_ERROR_MSG_LEN];
-        char got = log_capture_parse(line, tag, sizeof(tag), msg, sizeof(msg));
-        if (got == 'E' || got == 'W') {
-            stats_record_error(got == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN,
-                               tag, msg);
-        }
+        capture_line(lvl == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN, fmt, copy);
     }
 
     va_end(copy);

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -1,0 +1,132 @@
+#include "log_capture.h"
+
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// Host-testable parsing. No ESP-IDF dependencies so test/test_log_capture.c
+// can exercise it on the host.
+//
+// ESP-IDF's LOG_FORMAT macro expands to
+//   LOG_COLOR_<L> "<L> (%lu) %s: " format LOG_RESET_COLOR "\n"
+// i.e. an optional ANSI colour escape, the level letter, the timestamp
+// in parentheses, then "<tag>: <message>". The colour escape is present
+// because the build has CONFIG_LOG_COLORS=y, but we tolerate its absence
+// too.
+// ---------------------------------------------------------------------------
+
+// Skip an optional leading ANSI colour escape ("ESC[...m").
+static const char *skip_ansi(const char *p)
+{
+    if (*p == '\033') {
+        while (*p && *p != 'm') p++;
+        if (*p == 'm') p++;
+    }
+    return p;
+}
+
+static int is_level(char c)
+{
+    return c == 'E' || c == 'W' || c == 'I' || c == 'D' || c == 'V';
+}
+
+char log_capture_level(const char *line)
+{
+    if (!line) return '\0';
+    char c = *skip_ansi(line);
+    return is_level(c) ? c : '\0';
+}
+
+char log_capture_parse(const char *line,
+                       char *tag, size_t tag_cap,
+                       char *msg, size_t msg_cap)
+{
+    if (tag_cap) tag[0] = '\0';
+    if (msg_cap) msg[0] = '\0';
+    if (!line) return '\0';
+
+    const char *p = skip_ansi(line);
+    char level = *p;
+    if (!is_level(level)) return '\0';
+
+    // Skip past the timestamp: "<L> (<ts>) " ends at the first ") ".
+    const char *after_ts = strstr(p, ") ");
+    if (!after_ts) return '\0';
+    p = after_ts + 2;
+
+    // "<tag>: <message>"
+    const char *colon = strstr(p, ": ");
+    if (!colon) return '\0';
+
+    if (tag_cap) {
+        size_t tlen = (size_t)(colon - p);
+        if (tlen >= tag_cap) tlen = tag_cap - 1;
+        memcpy(tag, p, tlen);
+        tag[tlen] = '\0';
+    }
+
+    if (msg_cap) {
+        // Message runs to the trailing ANSI reset / newline, if any.
+        const char *m = colon + 2;
+        const char *end = m;
+        while (*end && *end != '\n' && *end != '\033') end++;
+        size_t mlen = (size_t)(end - m);
+        if (mlen >= msg_cap) mlen = msg_cap - 1;
+        memcpy(msg, m, mlen);
+        msg[mlen] = '\0';
+    }
+
+    return level;
+}
+
+// ---------------------------------------------------------------------------
+// ESP-IDF log hook. Compiled out on the host.
+// ---------------------------------------------------------------------------
+#ifdef ESP_PLATFORM
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "esp_log.h"
+
+#include "stats.h"
+
+// Previous (console) sink, so the serial log stays fully intact.
+static vprintf_like_t s_console;
+
+static int log_hook(const char *fmt, va_list ap)
+{
+    va_list copy;
+    va_copy(copy, ap);
+
+    // Console first, unchanged — diagnosis on the web UI must never come
+    // at the cost of the serial log.
+    int ret = s_console ? s_console(fmt, ap) : vprintf(fmt, ap);
+
+    // The level letter is a literal in the format string, so we can
+    // skip the expensive vsnprintf for the common INFO/DEBUG lines.
+    char lvl = log_capture_level(fmt);
+    if (lvl == 'E' || lvl == 'W') {
+        char line[192];
+        vsnprintf(line, sizeof(line), fmt, copy);
+        char tag[STATS_ERROR_TAG_LEN];
+        char msg[STATS_ERROR_MSG_LEN];
+        char got = log_capture_parse(line, tag, sizeof(tag), msg, sizeof(msg));
+        if (got == 'E' || got == 'W') {
+            stats_record_error(got == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN,
+                               tag, msg);
+        }
+    }
+
+    va_end(copy);
+    return ret;
+}
+
+void log_capture_start(void)
+{
+    // esp_log_set_vprintf returns the previous sink; chain to it so the
+    // console keeps working. No recursion guard is needed: nothing in
+    // the capture path (vsnprintf, the parser, stats_record_error) logs.
+    s_console = esp_log_set_vprintf(&log_hook);
+}
+
+#endif // ESP_PLATFORM

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -122,35 +122,48 @@ static void capture_line(int level, const char *fmt, va_list ap)
     xSemaphoreGive(s_lock);
 }
 
+// STACK SIZING — important. This hook runs on the stack of whatever task
+// emits the log line, and a global esp_log_set_vprintf hook unavoidably
+// adds a frame there: on Xtensa GCC does NOT tail-call the console
+// hand-off below (windowed ABI — verified in the disassembly: callx8 +
+// retw.n), so log_hook keeps a ~64 B frame on EVERY log call, INFO
+// included; WARN/ERROR adds capture_line's small frame on top (the ~340 B
+// of format scratch is file-static above, not on the stack, so it is not
+// doubled with the console's vprintf). Consequence: every task that logs
+// must carry that headroom. Most do; the few deliberately small ones that
+// log are sized up explicitly (status_led, fw_reboot). The esp_event task
+// (CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE, 2304 B) warns from wifi.c and
+// is the next candidate if a wifi warning ever overflows it.
 static int log_hook(const char *fmt, va_list ap)
 {
-    va_list copy;
-    va_copy(copy, ap);
+    // Level detection inlined (no call) to keep this frame minimal. The
+    // level letter is a literal in the format string; skip an optional
+    // leading ANSI colour escape first.
+    const char *p = fmt;
+    if (*p == '\033') { while (*p && *p != 'm') p++; if (*p) p++; }
+    char lvl = *p;
 
-    // Console first, unchanged — diagnosis on the web UI must never come
-    // at the cost of the serial log.
-    int ret = s_console ? s_console(fmt, ap) : vprintf(fmt, ap);
-
-    // The level letter is a literal in the format string, so we decide
-    // here, with no buffers on the stack: INFO/DEBUG lines (the vast
-    // majority) skip capture entirely.
-    char lvl = log_capture_level(fmt);
+    // Only WARN/ERROR pays for capture (a va_copy + the formatting in
+    // capture_line). INFO/DEBUG — the overwhelming majority, including
+    // deep driver lines like the GPIO dump — fall straight through.
     if (lvl == 'E' || lvl == 'W') {
+        va_list copy;
+        va_copy(copy, ap);
         capture_line(lvl == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN, fmt, copy);
+        va_end(copy);
     }
 
-    va_end(copy);
-    return ret;
+    return s_console(fmt, ap);
 }
 
 void log_capture_start(void)
 {
     s_lock = xSemaphoreCreateMutex();
     // esp_log_set_vprintf returns the previous sink; chain to it so the
-    // console keeps working. No recursion guard is needed beyond the
-    // try-lock: nothing in the capture path (vsnprintf, the parser,
-    // stats_record_error) logs.
+    // console keeps working. Guarantee it is non-NULL so log_hook can
+    // call it unconditionally (an `?:` there would block the tail-call).
     s_console = esp_log_set_vprintf(&log_hook);
+    if (!s_console) s_console = &vprintf;
 }
 
 #endif // ESP_PLATFORM

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -86,6 +86,9 @@ char log_capture_parse(const char *line,
 #include <stdio.h>
 #include <stdarg.h>
 
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
 #include "esp_log.h"
 
 #include "stats.h"
@@ -93,23 +96,30 @@ char log_capture_parse(const char *line,
 // Previous (console) sink, so the serial log stays fully intact.
 static vprintf_like_t s_console;
 
-// Format the captured line and push it to the stats ring. Kept in a
-// SEPARATE, never-inlined function on purpose: its ~350 B of line/tag/
-// msg buffers then land on the stack only while a WARN/ERROR line is
-// actually being captured, not on every log call. Folded into log_hook
-// (inlined), those buffers would inflate the frame of *every* logging
-// task — a 2 KB task such as status_led overflowed on a plain INFO line
-// because the hook reserved them unconditionally.
-static void __attribute__((noinline))
-capture_line(int level, const char *fmt, va_list ap)
+// The hook runs on the stack of whatever task logs the line, and the
+// formatting scratch dominates that cost. Keeping line/tag/msg here as
+// file-static (rather than on capture_line's stack) is what makes a
+// WARN/ERROR cost essentially the same stack as the vprintf the console
+// does anyway: ~340 B of buffers off the stack instead of in the frame.
+// That matters because some warnings are logged from small-stack tasks
+// — wifi.c warns from the 2304-byte esp_event task — where an extra
+// ~380 B frame would overflow. A FreeRTOS mutex guards the shared
+// scratch; a non-blocking take means a concurrent or re-entrant capture
+// simply skips the ring entry (the line is already on the console)
+// rather than blocking the logging task.
+static SemaphoreHandle_t s_lock;
+static char s_line[192];
+static char s_tag[STATS_ERROR_TAG_LEN];
+static char s_msg[STATS_ERROR_MSG_LEN];
+
+static void capture_line(int level, const char *fmt, va_list ap)
 {
-    char line[192];
-    vsnprintf(line, sizeof(line), fmt, ap);
-    char tag[STATS_ERROR_TAG_LEN];
-    char msg[STATS_ERROR_MSG_LEN];
-    if (log_capture_parse(line, tag, sizeof(tag), msg, sizeof(msg))) {
-        stats_record_error(level, tag, msg);
+    if (!s_lock || xSemaphoreTake(s_lock, 0) != pdTRUE) return;
+    vsnprintf(s_line, sizeof(s_line), fmt, ap);
+    if (log_capture_parse(s_line, s_tag, sizeof(s_tag), s_msg, sizeof(s_msg))) {
+        stats_record_error(level, s_tag, s_msg);
     }
+    xSemaphoreGive(s_lock);
 }
 
 static int log_hook(const char *fmt, va_list ap)
@@ -123,8 +133,7 @@ static int log_hook(const char *fmt, va_list ap)
 
     // The level letter is a literal in the format string, so we decide
     // here, with no buffers on the stack: INFO/DEBUG lines (the vast
-    // majority) leave log_hook's frame tiny. Only WARN/ERROR descends
-    // into capture_line(), which owns the buffers.
+    // majority) skip capture entirely.
     char lvl = log_capture_level(fmt);
     if (lvl == 'E' || lvl == 'W') {
         capture_line(lvl == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN, fmt, copy);
@@ -136,9 +145,11 @@ static int log_hook(const char *fmt, va_list ap)
 
 void log_capture_start(void)
 {
+    s_lock = xSemaphoreCreateMutex();
     // esp_log_set_vprintf returns the previous sink; chain to it so the
-    // console keeps working. No recursion guard is needed: nothing in
-    // the capture path (vsnprintf, the parser, stats_record_error) logs.
+    // console keeps working. No recursion guard is needed beyond the
+    // try-lock: nothing in the capture path (vsnprintf, the parser,
+    // stats_record_error) logs.
     s_console = esp_log_set_vprintf(&log_hook);
 }
 

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -91,6 +91,7 @@ char log_capture_parse(const char *line,
 
 #include "esp_log.h"
 
+#include "config.h"
 #include "stats.h"
 
 // Previous (console) sink, so the serial log stays fully intact.
@@ -143,13 +144,19 @@ static int log_hook(const char *fmt, va_list ap)
     if (*p == '\033') { while (*p && *p != 'm') p++; if (*p) p++; }
     char lvl = *p;
 
-    // Only WARN/ERROR pays for capture (a va_copy + the formatting in
-    // capture_line). INFO/DEBUG — the overwhelming majority, including
-    // deep driver lines like the GPIO dump — fall straight through.
-    if (lvl == 'E' || lvl == 'W') {
+    // WARN/ERROR are always captured. INFO only when the user enabled it
+    // for troubleshooting (config_log_info) — checked after the W/E test
+    // so the common path pays nothing extra. Either way capture_line's
+    // ~48 B frame is the only added stack (the format scratch is static),
+    // which the small-stack tasks have margin for.
+    int level = 0;
+    if      (lvl == 'E') level = ESP_LOG_ERROR;
+    else if (lvl == 'W') level = ESP_LOG_WARN;
+    else if (lvl == 'I' && config_log_info()) level = ESP_LOG_INFO;
+    if (level) {
         va_list copy;
         va_copy(copy, ap);
-        capture_line(lvl == 'E' ? ESP_LOG_ERROR : ESP_LOG_WARN, fmt, copy);
+        capture_line(level, fmt, copy);
         va_end(copy);
     }
 

--- a/phoneblock-dongle/firmware/main/log_capture.h
+++ b/phoneblock-dongle/firmware/main/log_capture.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <stddef.h>
+
+// Global log capture: mirrors every WARN/ERROR line the firmware emits
+// — our own modules and the ESP-IDF libraries alike — into the stats
+// error ring, which the web UI shows as the "Protokoll" (log) panel.
+// This is what makes field diagnosis possible: a customer (or we) can
+// read the actual warnings/errors off the dongle's web page instead of
+// needing a serial console.
+//
+// The mechanism is a single esp_log_set_vprintf() hook, so there is
+// nothing to remember at individual call sites: anything logged at
+// WARN/ERROR shows up automatically. To surface a new unusual condition,
+// log it at the right level — no extra plumbing.
+
+// Install the log hook. Call once, after stats_setup(). ESP-only.
+void log_capture_start(void);
+
+// --- Host-testable log-line parsing (no ESP-IDF dependencies) -------
+// Split out so test/test_log_capture.c can pin the fragile parsing on
+// the host without an ESP-IDF build.
+
+// Severity letter of an ESP-IDF formatted log line ('E','W','I','D','V'),
+// skipping an optional leading ANSI colour escape, or '\0' if the first
+// non-escape character is not a known level. Cheap: looks only at the
+// head, used as the pre-filter before the expensive vsnprintf.
+char log_capture_level(const char *line);
+
+// Parse a fully formatted ESP-IDF log line of the shape
+//   [ESC[..m]<L> (<timestamp>) <tag>: <message>[ESC[0m][\n]
+// into `tag` and `message` (NUL-terminated; trailing ANSI reset and
+// newline stripped). Returns the level letter, or '\0' if the line is
+// not parseable. The caller decides which levels to keep.
+char log_capture_parse(const char *line,
+                       char *tag, size_t tag_cap,
+                       char *msg, size_t msg_cap);

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -233,10 +233,23 @@ void app_main(void)
         const char *failed = config_last_failed_ota();
         const esp_app_desc_t *app = esp_app_get_description();
         const char *current = app ? app->version : "";
-        if (failed[0] != '\0' && strcmp(failed, current) == 0) {
-            ESP_LOGI(TAG, "running version %s matches last_failed_ota — "
-                          "marker cleared (boot survived)", current);
-            config_set_last_failed_ota(NULL);
+        if (failed[0] != '\0') {
+            if (strcmp(failed, current) == 0) {
+                ESP_LOGI(TAG, "running version %s matches last_failed_ota — "
+                              "marker cleared (boot survived)", current);
+                config_set_last_failed_ota(NULL);
+            } else {
+                // The marker names a version we are NOT running: the OTA
+                // to it installed, booted badly, and the bootloader
+                // rolled us back. The marker is set only after a complete
+                // install (every download/verify failure clears it), so
+                // this reliably means "a firmware update failed to boot".
+                // Surface it as a WARNING (→ web UI log) and leave the
+                // marker so the updater skips the same broken bits.
+                // Recurs once per boot until a newer build supersedes it.
+                ESP_LOGW(TAG, "firmware update to %s failed to boot — "
+                              "rolled back to %s", failed, current);
+            }
         }
     }
 

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "crashreport.h"
 #include "firmware_update.h"
+#include "log_capture.h"
 #include "report_queue.h"
 #include "selftest.h"
 #include "sip_register.h"
@@ -182,6 +183,11 @@ void app_main(void)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
 
     stats_setup();
+    // Install the log hook right after the stats ring exists: from here
+    // on, every WARN/ERROR line (ours and the libraries') is mirrored to
+    // the web UI's log panel. Earlier boot lines (nvs/netif init) predate
+    // it, which is fine — those are pre-config and visible on serial.
+    log_capture_start();
     config_load();
     announcement_init();
     // Start the LED early so the user sees "CONNECTING" (or

--- a/phoneblock-dongle/firmware/main/report_queue.c
+++ b/phoneblock-dongle/firmware/main/report_queue.c
@@ -38,8 +38,8 @@ static void report_worker_task(void *arg)
         report_entry_t e;
         if (xQueueReceive(s_queue, &e, portMAX_DELAY) != pdTRUE) continue;
         ESP_LOGI(TAG, "report-call %s", e.phone);
-        // Errors get recorded by phoneblock_report_call itself via
-        // stats_record_error — nothing to do here on failure.
+        // phoneblock_report_call logs its own failures (ERROR), which the
+        // log hook mirrors to the web UI — nothing to do here on failure.
         phoneblock_report_call(e.phone);
     }
 }

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1466,9 +1466,13 @@ static void sip_task(void *arg)
 
 void sip_register_start(void)
 {
+    // Host + user are mandatory; an empty password is a valid credential
+    // (digest HA1 = MD5(user:realm:"")) — some providers register an
+    // anonymous account (e.g. Telekom's anonymous@t-online.de) with no
+    // password. Don't refuse locally: attempt the REGISTER and let the
+    // registrar's response surface in the status UI.
     if (strlen(config_sip_host()) == 0 ||
-        strlen(config_sip_user()) == 0 ||
-        strlen(config_sip_pass()) == 0) {
+        strlen(config_sip_user()) == 0) {
         ESP_LOGW(TAG, "SIP config incomplete, skipping registration");
         return;
     }

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -88,8 +88,9 @@ static TaskHandle_t s_sip_task = NULL;
 // granted/2, so a single missed refresh leaves ~granted/2 of valid
 // binding before the FB drops us. Within that window, transient
 // failures retry silently — only when the binding actually lapses
-// without recovery is a stats_record_error emitted. 0 = no valid
-// binding (boot, after factory reset, after a definitive failure).
+// without recovery is an ERROR logged (and thereby surfaced on the web
+// UI via the log hook). 0 = no valid binding (boot, after factory
+// reset, after a definitive failure).
 static int64_t s_binding_expires_at_us = 0;
 // Most recent transient-failure reason, stashed so that if the binding
 // does eventually expire without a successful refresh we can surface
@@ -455,10 +456,11 @@ typedef enum {
 // REGISTER_TRANSIENT (network/timeout — caller may want to retry
 // silently while a still-valid binding gives us cover) or
 // REGISTER_DEFINITIVE (registrar said "no" or the protocol is broken
-// in a way that retries can't fix). Does NOT call stats_record_error
-// itself — the policy of when to surface a failure to the dashboard
-// belongs at the caller, which knows whether it's an initial register,
-// a periodic refresh, or a defensive re-register after a TCP reconnect.
+// in a way that retries can't fix). Does NOT log the failure itself —
+// the policy of when to surface it (and thus mirror it to the web UI via
+// the log hook) belongs at the caller, which knows whether it's an
+// initial register, a periodic refresh, or a defensive re-register
+// after a TCP reconnect.
 static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
                                       char *err, size_t err_cap)
 {
@@ -1181,7 +1183,6 @@ static void sip_task(void *arg)
                  "transport open failed (%s %.40s:%d) — check host/port",
                  config_sip_transport(), dial_host, dial_port);
         ESP_LOGE(TAG, "%s — aborting SIP task", msg);
-        stats_record_error("sip", msg);
         s_sip_task = NULL;
         vTaskDelete(NULL);
         return;
@@ -1206,7 +1207,6 @@ static void sip_task(void *arg)
                  "transport %.8s ignored — firmware implements UDP/TCP/TLS only",
                  tr);
         ESP_LOGW(TAG, "%s", msg);
-        stats_record_error("sip", msg);
     }
     // TLS protects only the signaling. Without SRTP (Phase 5) the audio
     // path is still RTP/AVP cleartext on UDP/RTP. Surface that visibly
@@ -1215,7 +1215,6 @@ static void sip_task(void *arg)
         const char *msg =
             "TLS active but RTP is still plaintext (SRTP arrives in Phase 5)";
         ESP_LOGW(TAG, "%s", msg);
-        stats_record_error("sip", msg);
     }
     if (strcmp(config_sip_srtp(), "off") != 0
         && strcmp(config_sip_srtp(), "") != 0) {
@@ -1224,7 +1223,6 @@ static void sip_task(void *arg)
                  "SRTP %.12s ignored — firmware only does plain RTP",
                  config_sip_srtp());
         ESP_LOGW(TAG, "%s", msg);
-        stats_record_error("sip", msg);
     }
     const int retry_delay_s = 30;
     char *rx = NULL;
@@ -1257,7 +1255,6 @@ static void sip_task(void *arg)
         s_pending_error[0] = '\0';
         refresh_at_us = esp_timer_get_time() + (int64_t)(granted_expires / 2) * 1000000LL;
     } else {
-        if (err[0]) stats_record_error("sip", err);
         ESP_LOGE(TAG, "initial registration failed (%s), retry in %d s",
                  err[0] ? err : "no detail", retry_delay_s);
         s_binding_expires_at_us = 0;
@@ -1268,7 +1265,6 @@ static void sip_task(void *arg)
     rx = malloc(SIP_RX_BUF_SIZE);
     if (!rx) {
         ESP_LOGE(TAG, "malloc rx buffer failed — aborting SIP task");
-        stats_record_error("sip", "out of memory in SIP task");
         s_sip_task = NULL;
         vTaskDelete(NULL);
         return;
@@ -1324,7 +1320,6 @@ static void sip_task(void *arg)
                 s_pending_error[0] = '\0';
                 refresh_at_us = esp_timer_get_time() + (int64_t)(granted_expires / 2) * 1000000LL;
             } else {
-                if (err[0]) stats_record_error("sip", err);
                 ESP_LOGE(TAG, "REGISTER with new config failed (%s), retry in %d s",
                          err[0] ? err : "no detail", retry_delay_s);
                 s_binding_expires_at_us = 0;
@@ -1339,12 +1334,10 @@ static void sip_task(void *arg)
         // extension, rather than waiting out the (expires/2) refresh
         // window during which incoming INVITEs would be lost.
         if (sip_transport_consume_reconnect(ctx.transport)) {
-            ESP_LOGI(TAG, "transport reconnected → re-REGISTER");
-            // Informational marker so the operator can correlate a
-            // transport flap with whatever else they are seeing in
-            // the dashboard. Kept regardless of the do_register
-            // outcome below.
-            stats_record_error("sip", "TCP reconnect → re-REGISTER");
+            // A dropped TCP/TLS connection is worth surfacing: WARN so the
+            // log hook records it, letting the operator correlate a
+            // transport flap with whatever else they see in the log.
+            ESP_LOGW(TAG, "transport reconnected → re-REGISTER");
             err[0] = '\0';
             r = do_register(&ctx, &granted_expires, err, sizeof(err));
             ok = (r == REGISTER_OK);
@@ -1356,7 +1349,8 @@ static void sip_task(void *arg)
                 s_pending_error[0] = '\0';
                 refresh_at_us = esp_timer_get_time() + (int64_t)(granted_expires / 2) * 1000000LL;
             } else {
-                if (err[0]) stats_record_error("sip", err);
+                ESP_LOGE(TAG, "re-REGISTER after reconnect failed (%s), retry in %d s",
+                         err[0] ? err : "no detail", retry_delay_s);
                 s_binding_expires_at_us = 0;
                 s_pending_error[0] = '\0';
                 refresh_at_us = esp_timer_get_time() + (int64_t)retry_delay_s * 1000000LL;
@@ -1448,7 +1442,6 @@ static void sip_task(void *arg)
                     snprintf(msg, sizeof(msg), "%.127s",
                              err[0] ? err : "REGISTER failed");
                 }
-                stats_record_error("sip", msg);
                 ESP_LOGE(TAG, "re-REGISTER failed: %s — retry in %d s",
                          msg, retry_delay_s);
                 s_binding_expires_at_us = 0;

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -236,11 +236,18 @@ static int parse_host_port(const char *spec, char *host_out, int cap)
 //      bare domain, so SRV is the only working path.
 //   3. Direct A-record lookup on config_sip_host() with the configured
 //      (or transport-default) port.
+// Transport's default SIP port when none is configured/discovered.
+static int default_sip_port(void)
+{
+    return (strcmp(config_sip_transport(), "tls") == 0) ? 5061 : 5060;
+}
+
 static void dial_destination(char *host_out, int cap, int *port_out)
 {
     const char *outbound = config_sip_outbound();
     if (outbound && outbound[0]) {
-        *port_out = parse_host_port(outbound, host_out, cap);
+        int p = parse_host_port(outbound, host_out, cap);
+        *port_out = p > 0 ? p : default_sip_port();
         return;
     }
 
@@ -265,7 +272,13 @@ static void dial_destination(char *host_out, int cap, int *port_out)
 
     strncpy(host_out, config_sip_host(), cap - 1);
     host_out[cap - 1] = '\0';
-    *port_out = config_sip_port();
+    // No explicit port and no SRV record (e.g. fritz.box): substitute the
+    // transport default HERE, not only in sip_transport_open(). The reload
+    // path (config change → sip_transport_resolve()) does not default a 0
+    // port; it would resolve host:0 and send UDP to port 0 — the cause of
+    // "Fritz!Box + empty port stops registering after a settings save".
+    int port = config_sip_port();
+    *port_out = port > 0 ? port : default_sip_port();
 }
 
 // ---------------------------------------------------------------------------

--- a/phoneblock-dongle/firmware/main/sip_srv.c
+++ b/phoneblock-dongle/firmware/main/sip_srv.c
@@ -202,7 +202,7 @@ bool sip_srv_lookup(const char *service, const char *proto,
     // Resolver must be configured (DHCP usually fills this in).
     const ip_addr_t *dns_ip = dns_getserver(0);
     if (!dns_ip || ip_addr_isany(dns_ip)) {
-        ESP_LOGD(TAG, "no DNS server configured; skipping SRV");
+        ESP_LOGW(TAG, "no DNS server configured; skipping SRV");
         return false;
     }
 

--- a/phoneblock-dongle/firmware/main/stats.c
+++ b/phoneblock-dongle/firmware/main/stats.c
@@ -111,12 +111,13 @@ void stats_record_call_counters_only(verdict_t verdict)
     unlock();
 }
 
-void stats_record_error(const char *tag, const char *message)
+void stats_record_error(int level, const char *tag, const char *message)
 {
     lock();
 
     stats_error_t *slot = &s_errors[s_errors_head];
     slot->at_us = esp_timer_get_time();
+    slot->level = level;
     copy_trim(slot->tag,     sizeof(slot->tag),     tag);
     copy_trim(slot->message, sizeof(slot->message), message);
 

--- a/phoneblock-dongle/firmware/main/stats.h
+++ b/phoneblock-dongle/firmware/main/stats.h
@@ -12,7 +12,12 @@
 // held only briefly.
 
 #define STATS_MAX_CALLS      10
-#define STATS_MAX_ERRORS     10
+// Sized generously: the ring is now fed by a global log hook
+// (log_capture.c) that mirrors every WARN/ERROR line — our own and the
+// ESP-IDF libraries' — so a single failing operation can emit several
+// related entries. A deeper ring keeps the root cause from scrolling
+// off before the user looks.
+#define STATS_MAX_ERRORS     32
 #define STATS_NUMBER_LEN     48
 #define STATS_DISPLAY_LEN    32
 #define STATS_LABEL_LEN      32
@@ -38,6 +43,7 @@ typedef struct {
 
 typedef struct {
     int64_t at_us;
+    int     level;                             // ESP_LOG_WARN | ESP_LOG_ERROR
     char    tag[STATS_ERROR_TAG_LEN];          // e.g. "sip", "api", "tr064"
     char    message[STATS_ERROR_MSG_LEN];
 } stats_error_t;
@@ -75,7 +81,11 @@ void stats_record_call_checked(const char *number, const char *display,
 // codes) but still wants the dashboard counters (total/legitimate)
 // to reflect that a call happened.
 void stats_record_call_counters_only(verdict_t verdict);
-void stats_record_error(const char *tag, const char *message);
+// Append a WARN/ERROR entry to the displayed log ring. `level` is an
+// esp_log_level_t (ESP_LOG_WARN / ESP_LOG_ERROR). Normally called only
+// by the global log hook in log_capture.c, which mirrors every WARN /
+// ERROR line into this ring.
+void stats_record_error(int level, const char *tag, const char *message);
 void stats_record_sip_state(bool registered);
 
 // Records the latency breakdown of the last API call (total + phases).

--- a/phoneblock-dongle/firmware/main/status_led.c
+++ b/phoneblock-dongle/firmware/main/status_led.c
@@ -149,6 +149,14 @@ static void led_task(void *arg)
     };
     gpio_config(&cfg);
 
+    // Diagnostic: report the smallest free stack seen so far — i.e. right
+    // after gpio_config(), this task's deepest logging call. This is the
+    // hard number behind the stack sizing (was a 2 KB stack overflowing
+    // here once the log hook was added); keep an eye on it staying well
+    // clear of 0.
+    ESP_LOGI(TAG, "stack high-water mark: %u bytes free",
+             (unsigned)uxTaskGetStackHighWaterMark(NULL));
+
     led_state_t last_state = (led_state_t)-1;
     pattern_t   pat        = pattern_for(ST_CONNECTING);
     uint8_t     tick       = 0;
@@ -177,6 +185,11 @@ void status_led_start(void)
         ESP_LOGI(TAG, "LED task disabled (CONFIG_STATUS_LED_GPIO=-1)");
         return;
     }
-    xTaskCreate(led_task, "status_led", 2048,
+    // 2.5 KB, not 2 KB: the global log hook (log_capture.c) adds a ~64 B
+    // frame to *every* log call — including the deep multi-arg INFO line
+    // gpio_config() emits — and this task's old 2 KB left less than that
+    // in reserve. The headroom covers the hook plus margin for future log
+    // formats; see the note on stack sizing in log_capture.c.
+    xTaskCreate(led_task, "status_led", 2560,
                 (void *)LED_ARG_PACK(gpio, active_low), 1, NULL);
 }

--- a/phoneblock-dongle/firmware/main/sync.c
+++ b/phoneblock-dongle/firmware/main/sync.c
@@ -209,7 +209,6 @@ static void run_once(void)
         snprintf(msg, sizeof(msg), "list: %.60s",
                  detail[0] ? detail : "network");
         set_status_result(false, 0, 0, msg);
-        stats_record_error("sync", msg);
         return;
     }
 

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -453,6 +453,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char sip_outbound[80] = "";
     char sip_realm[64]    = "";
     char sip_srtp[16]     = "";
+    char sip_anon_s[4]    = "";
     char sync_en_s[4]     = "";
     char log_known_s[4]   = "";
     char auto_update_s[4] = "";
@@ -469,6 +470,9 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_sip_out   = form_get(body, "sip_outbound",  sip_outbound, sizeof(sip_outbound));
     bool have_sip_realm = form_get(body, "sip_realm",     sip_realm,    sizeof(sip_realm));
     bool have_sip_srtp  = form_get(body, "sip_srtp",      sip_srtp,     sizeof(sip_srtp));
+    // Present only when the manual form's "anonymous" box is ticked. Its
+    // presence (not its value) is the signal to clear a stored password.
+    bool have_sip_anon  = form_get(body, "sip_anon",      sip_anon_s,   sizeof(sip_anon_s));
     bool have_sync_en   = form_get(body, "sync_enabled",  sync_en_s,    sizeof(sync_en_s));
     bool have_log_known = form_get(body, "log_known_calls", log_known_s, sizeof(log_known_s));
     bool have_auto_upd  = form_get(body, "auto_update",   auto_update_s, sizeof(auto_update_s));
@@ -497,9 +501,16 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .has_sip_port = have_sip_port && sip_port_s[0],
         .sip_port     = have_sip_port && sip_port_s[0] ? atoi(sip_port_s) : 0,
         .sip_user   = have_sip_user && sip_user[0]  ? sip_user  : NULL,
-        // Empty password submitted = keep existing (so user doesn't have to
-        // re-type it when editing other fields).
-        .sip_pass   = have_sip_pass && sip_pass[0]  ? sip_pass  : NULL,
+        // Password resolution, in order:
+        //   - "anonymous" box ticked → "" : explicitly clear the stored
+        //     password (the only way to reach a passwordless account like
+        //     anonymous@t-online.de once a password was ever saved).
+        //   - non-empty field         → use it.
+        //   - empty field, no box     → NULL : keep existing, so the user
+        //     need not retype it when editing other fields.
+        .sip_pass   = have_sip_anon                 ? ""
+                    : have_sip_pass && sip_pass[0]  ? sip_pass
+                    : NULL,
         .sip_expires = have_sip_exp && sip_exp_s[0] ? atoi(sip_exp_s) : 0,
         .sip_internal_number = clear_int_num,
         // Extended SIP parameters: explicit empty string clears, missing

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -1036,6 +1036,7 @@ static esp_err_t handle_errors(httpd_req_t *req)
     for (int i = 0; i < n; i++) {
         cJSON *o = cJSON_CreateObject();
         cJSON_AddNumberToObject(o, "age_s",   (double)((now_us - errs[i].at_us) / 1000000));
+        cJSON_AddStringToObject(o, "level",   errs[i].level == ESP_LOG_ERROR ? "E" : "W");
         cJSON_AddStringToObject(o, "tag",     errs[i].tag);
         cJSON_AddStringToObject(o, "message", errs[i].message);
         cJSON_AddItemToArray(arr, o);

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -324,6 +324,9 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON *cl = cJSON_AddObjectToObject(root, "calls");
     cJSON_AddBoolToObject  (cl,   "log_known",   config_log_known_calls());
 
+    cJSON *lg = cJSON_AddObjectToObject(root, "log");
+    cJSON_AddBoolToObject  (lg,   "capture_info", config_log_info());
+
     cJSON *au = cJSON_AddObjectToObject(root, "auth");
     cJSON_AddBoolToObject  (au,   "enabled",     config_auth_enabled());
     cJSON_AddBoolToObject  (au,   "logged_in",   web_auth_is_logged_in(req));
@@ -456,6 +459,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char sip_anon_s[4]    = "";
     char sync_en_s[4]     = "";
     char log_known_s[4]   = "";
+    char log_info_s[4]    = "";
     char auto_update_s[4] = "";
     char crash_rep_s[4]   = "";
     char test_calls_s[4]  = "";
@@ -475,6 +479,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_sip_anon  = form_get(body, "sip_anon",      sip_anon_s,   sizeof(sip_anon_s));
     bool have_sync_en   = form_get(body, "sync_enabled",  sync_en_s,    sizeof(sync_en_s));
     bool have_log_known = form_get(body, "log_known_calls", log_known_s, sizeof(log_known_s));
+    bool have_log_info  = form_get(body, "log_info", log_info_s, sizeof(log_info_s));
     bool have_auto_upd  = form_get(body, "auto_update",   auto_update_s, sizeof(auto_update_s));
     bool have_crash_rep = form_get(body, "crash_report",  crash_rep_s,   sizeof(crash_rep_s));
     bool have_test_call = form_get(body, "accept_test_calls", test_calls_s, sizeof(test_calls_s));
@@ -526,6 +531,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .sip_srtp      = have_sip_srtp  ? sip_srtp     : NULL,
         .sync_enabled    = have_sync_en   ? sync_en_s    : NULL,
         .log_known_calls = have_log_known ? log_known_s  : NULL,
+        .log_info        = have_log_info  ? log_info_s   : NULL,
         .auto_update     = have_auto_upd  ? auto_update_s : NULL,
         .crash_report    = have_crash_rep ? crash_rep_s   : NULL,
         .accept_test_calls = have_test_call ? test_calls_s : NULL,
@@ -1036,7 +1042,9 @@ static esp_err_t handle_errors(httpd_req_t *req)
     for (int i = 0; i < n; i++) {
         cJSON *o = cJSON_CreateObject();
         cJSON_AddNumberToObject(o, "age_s",   (double)((now_us - errs[i].at_us) / 1000000));
-        cJSON_AddStringToObject(o, "level",   errs[i].level == ESP_LOG_ERROR ? "E" : "W");
+        cJSON_AddStringToObject(o, "level",
+            errs[i].level == ESP_LOG_ERROR ? "E" :
+            errs[i].level == ESP_LOG_WARN  ? "W" : "I");
         cJSON_AddStringToObject(o, "tag",     errs[i].tag);
         cJSON_AddStringToObject(o, "message", errs[i].message);
         cJSON_AddItemToArray(arr, o);

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -567,6 +567,80 @@ static void send_fail(httpd_req_t *req, const char *message)
     send_json(req, root);
 }
 
+// Common tail for both Fritz!Box provisioning paths (direct setup and
+// the post-2FA retry): register the dongle's TR-064 app instance (best
+// effort, see below), persist the freshly provisioned SIP profile, kick
+// off a re-register, and emit the success JSON. `res` must come from a
+// successful tr064_provision_sip_client(); `auth_token` is the 2FA token
+// when one is in play, NULL otherwise.
+static esp_err_t finish_fritzbox_setup(httpd_req_t *req,
+        const char *fritz_host, const char *fritz_user,
+        const char *fritz_pass, const char *auth_token,
+        const tr064_sip_result_t *res)
+{
+    // Best-effort dedicated app instance on the box: gives the sync task
+    // its own Phone-rights-only credentials so we don't have to persist
+    // the admin password. Failure (older Fritz!OS without AppSetup, a
+    // rate-limit, …) is logged but non-fatal — SIP still works, only the
+    // sync feature stays disabled.
+    char app_user[32] = "";
+    char app_pass[40] = "";
+    int  app_err_code = 0;
+    char app_err_msg[128] = "";
+    esp_err_t app_err = tr064_register_dongle_app(
+        fritz_host, 49000, fritz_user, fritz_pass, auth_token,
+        app_user, sizeof(app_user),
+        app_pass, sizeof(app_pass),
+        &app_err_code, app_err_msg, sizeof(app_err_msg));
+    if (app_err != ESP_OK) {
+        ESP_LOGW(TAG,
+            "RegisterApp failed (code %d, %s) — sync feature disabled",
+            app_err_code, app_err_msg);
+        app_user[0] = '\0';
+        app_pass[0] = '\0';
+    }
+
+    // Persist as a *complete* new SIP profile: reset the expert
+    // parameters to the Fritz!Box happy-path defaults so stale
+    // transport/realm/srtp/port from an earlier manual or provider setup
+    // can't survive config_update()'s merge and break the new UDP/5060
+    // registration (#363).
+    config_update_t u = {
+        .sip_host = fritz_host,
+        .has_sip_port = true,
+        .sip_port = 5060,
+        .sip_user = res->sip_user,
+        .sip_pass = res->sip_pass,
+        .sip_internal_number = res->internal_number,
+        .sip_transport = "udp",
+        .sip_auth_user = "",
+        .sip_outbound  = "",
+        .sip_realm     = "",
+        .sip_srtp      = "off",
+        .fritzbox_app_user = app_user,
+        .fritzbox_app_pass = app_pass,
+    };
+    if (config_update(&u) != ESP_OK) {
+        send_fail(req, "NVS write failed.");
+        return ESP_OK;
+    }
+    // TR-064 just provisioned a new extension on the Fritz!Box — give the
+    // box 1.5 s to make it live before the first REGISTER, otherwise it
+    // hits a not-yet-active slot and falls into 30 s retry.
+    sip_register_request_reload(true);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject  (root, "ok", true);
+    cJSON_AddStringToObject(root, "message",
+        "Extension created. The dongle is registering now — "
+        "see the status bar above for the current state.");
+    cJSON_AddStringToObject(root, "sip_user", res->sip_user);
+    cJSON_AddStringToObject(root, "internal_number", res->internal_number);
+    cJSON_AddBoolToObject  (root, "app_registered", app_user[0] != '\0');
+    send_json(req, root);
+    return ESP_OK;
+}
+
 // POST /api/fritzbox-setup
 // Body (URL-encoded): fritz_host=…&fritz_user=…&fritz_pass=…&phone_name=…
 // Runs tr064_provision_sip_client; on success, stores the generated
@@ -704,69 +778,10 @@ static esp_err_t handle_fritzbox_setup(httpd_req_t *req)
         return ESP_OK;
     }
 
-    // Best-effort register a dedicated app instance on the box. Gives
-    // the sync task its own Phone-rights-only credentials so we don't
-    // have to persist the admin password. Failure (e.g. older Fritz!OS
-    // without AppSetup, or rate-limit) is logged but does not fail the
-    // whole setup — SIP still works without it, the sync feature just
-    // stays disabled.
-    char app_user[32] = "";
-    char app_pass[40] = "";
-    int  app_err_code = 0;
-    char app_err_msg[128] = "";
-    esp_err_t app_err = tr064_register_dongle_app(
-        fritz_host, 49000, fritz_user, fritz_pass, NULL,
-        app_user, sizeof(app_user),
-        app_pass, sizeof(app_pass),
-        &app_err_code, app_err_msg, sizeof(app_err_msg));
-    if (app_err != ESP_OK) {
-        ESP_LOGW(TAG,
-            "RegisterApp failed (code %d, %s) — sync feature disabled",
-            app_err_code, app_err_msg);
-        app_user[0] = '\0';
-        app_pass[0] = '\0';
-    }
-
-    // Commit generated SIP credentials + registrar + (optional) app
-    // credentials to NVS. This establishes a *complete* new SIP profile,
-    // so the expert parameters from any earlier manual/provider setup
-    // (e.g. transport=tls + port 5061 for Telekom) must be reset to the
-    // Fritz!Box happy-path defaults — otherwise they survive the merge in
-    // config_update() and sabotage the new UDP/5060 registration (#363).
-    config_update_t u = {
-        .sip_host = fritz_host,
-        .has_sip_port = true,
-        .sip_port = 5060,
-        .sip_user = res.sip_user,
-        .sip_pass = res.sip_pass,
-        .sip_internal_number = res.internal_number,
-        .sip_transport = "udp",
-        .sip_auth_user = "",
-        .sip_outbound  = "",
-        .sip_realm     = "",
-        .sip_srtp      = "off",
-        .fritzbox_app_user = app_user,
-        .fritzbox_app_pass = app_pass,
-    };
-    if (config_update(&u) != ESP_OK) {
-        send_fail(req, "NVS write failed.");
-        return ESP_OK;
-    }
-    // TR-064 just provisioned a new extension on the Fritz!Box — give
-    // the box 1.5 s to make it live before the first REGISTER, otherwise
-    // the REGISTER hits a not-yet-active slot and falls into 30 s retry.
-    sip_register_request_reload(true);
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject(root, "ok", true);
-    cJSON_AddStringToObject(root, "message",
-        "Extension created. The dongle is registering now — "
-        "see the status bar above for the current state.");
-    cJSON_AddStringToObject(root, "sip_user", res.sip_user);
-    cJSON_AddStringToObject(root, "internal_number", res.internal_number);
-    cJSON_AddBoolToObject  (root, "app_registered", app_user[0] != '\0');
-    send_json(req, root);
-    return ESP_OK;
+    // Provisioning succeeded — register the app instance, persist the
+    // profile, re-register and answer (token=NULL: no 2FA was needed).
+    return finish_fritzbox_setup(req, fritz_host, fritz_user, fritz_pass,
+                                 NULL, &res);
 }
 
 // Percent-encode the unsafe characters in `in` into `out`. RFC 3986
@@ -971,36 +986,11 @@ static esp_err_t handle_fritzbox_2fa_status(httpd_req_t *req)
         s_2fa.fritz_user, s_2fa.fritz_pass, s_2fa.phone_name,
         s_2fa.token, &res);
 
-    // Register the dongle app instance using the same 2FA token (still
-    // valid for the whole auth session). Best effort — see the direct
-    // setup path for why a failure here is non-fatal.
-    char app_user[32] = "";
-    char app_pass[40] = "";
-    if (err == ESP_OK) {
-        int  app_err_code = 0;
-        char app_err_msg[128] = "";
-        esp_err_t app_err = tr064_register_dongle_app(
-            s_2fa.fritz_host, 49000,
-            s_2fa.fritz_user, s_2fa.fritz_pass, s_2fa.token,
-            app_user, sizeof(app_user),
-            app_pass, sizeof(app_pass),
-            &app_err_code, app_err_msg, sizeof(app_err_msg));
-        if (app_err != ESP_OK) {
-            ESP_LOGW(TAG,
-                "RegisterApp after 2FA failed (code %d, %s) — "
-                "sync feature disabled",
-                app_err_code, app_err_msg);
-            app_user[0] = '\0';
-            app_pass[0] = '\0';
-        }
-    }
-
-    // Whatever the outcome, the 2FA round-trip is over; wipe the
-    // cached admin password ASAP.
-    memset(s_2fa.fritz_pass, 0, sizeof(s_2fa.fritz_pass));
-    s_2fa.active = false;
-
     if (err != ESP_OK) {
+        // Wipe the cached admin password before bailing — the round-trip
+        // is over either way.
+        memset(s_2fa.fritz_pass, 0, sizeof(s_2fa.fritz_pass));
+        s_2fa.active = false;
         char msg[200];
         snprintf(msg, sizeof(msg),
             "Still failing after 2FA — error %d: %s",
@@ -1010,43 +1000,14 @@ static esp_err_t handle_fritzbox_2fa_status(httpd_req_t *req)
         return ESP_OK;
     }
 
-    // Commit SIP credentials, re-register. Reset the expert SIP
-    // parameters to the Fritz!Box defaults for the same reason as the
-    // non-2FA path above: a complete new profile must not inherit stale
-    // transport/realm/srtp values from an earlier manual setup (#363).
-    config_update_t u = {
-        .sip_host = s_2fa.fritz_host,
-        .has_sip_port = true,
-        .sip_port = 5060,
-        .sip_user = res.sip_user,
-        .sip_pass = res.sip_pass,
-        .sip_internal_number = res.internal_number,
-        .sip_transport = "udp",
-        .sip_auth_user = "",
-        .sip_outbound  = "",
-        .sip_realm     = "",
-        .sip_srtp      = "off",
-        .fritzbox_app_user = app_user,
-        .fritzbox_app_pass = app_pass,
-    };
-    if (config_update(&u) != ESP_OK) {
-        send_fail(req, "NVS write failed.");
-        return ESP_OK;
-    }
-    // TR-064 just provisioned a new extension on the Fritz!Box — give
-    // the box 1.5 s to make it live before the first REGISTER, otherwise
-    // the REGISTER hits a not-yet-active slot and falls into 30 s retry.
-    sip_register_request_reload(true);
-
-    cJSON *root = cJSON_CreateObject();
-    cJSON_AddBoolToObject  (root, "ok",              true);
-    cJSON_AddStringToObject(root, "message",
-        "Extension created. The dongle is registering now — "
-        "see the status bar above for the current state.");
-    cJSON_AddStringToObject(root, "sip_user",        res.sip_user);
-    cJSON_AddStringToObject(root, "internal_number", res.internal_number);
-    send_json(req, root);
-    return ESP_OK;
+    // Provisioning succeeded — same tail as the direct path, passing the
+    // 2FA token so the app instance registers within the auth session.
+    esp_err_t rc = finish_fritzbox_setup(req, s_2fa.fritz_host,
+        s_2fa.fritz_user, s_2fa.fritz_pass, s_2fa.token, &res);
+    // The 2FA round-trip is over; wipe the cached admin password.
+    memset(s_2fa.fritz_pass, 0, sizeof(s_2fa.fritz_pass));
+    s_2fa.active = false;
+    return rc;
 }
 
 static esp_err_t handle_errors(httpd_req_t *req)

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -491,7 +491,11 @@ static esp_err_t handle_config_post(httpd_req_t *req)
 
     config_update_t u = {
         .sip_host   = new_host,
-        .sip_port   = have_sip_port && sip_port_s[0] ? atoi(sip_port_s) : 0,
+        // Port present in the form (even "0" = auto) writes through;
+        // absent leaves the stored value alone. 0 must be storable so a
+        // provider switch can clear a stale pinned port back to auto/SRV.
+        .has_sip_port = have_sip_port && sip_port_s[0],
+        .sip_port     = have_sip_port && sip_port_s[0] ? atoi(sip_port_s) : 0,
         .sip_user   = have_sip_user && sip_user[0]  ? sip_user  : NULL,
         // Empty password submitted = keep existing (so user doesn't have to
         // re-type it when editing other fields).
@@ -724,13 +728,23 @@ static esp_err_t handle_fritzbox_setup(httpd_req_t *req)
     }
 
     // Commit generated SIP credentials + registrar + (optional) app
-    // credentials to NVS.
+    // credentials to NVS. This establishes a *complete* new SIP profile,
+    // so the expert parameters from any earlier manual/provider setup
+    // (e.g. transport=tls + port 5061 for Telekom) must be reset to the
+    // Fritz!Box happy-path defaults — otherwise they survive the merge in
+    // config_update() and sabotage the new UDP/5060 registration (#363).
     config_update_t u = {
         .sip_host = fritz_host,
+        .has_sip_port = true,
         .sip_port = 5060,
         .sip_user = res.sip_user,
         .sip_pass = res.sip_pass,
         .sip_internal_number = res.internal_number,
+        .sip_transport = "udp",
+        .sip_auth_user = "",
+        .sip_outbound  = "",
+        .sip_realm     = "",
+        .sip_srtp      = "off",
         .fritzbox_app_user = app_user,
         .fritzbox_app_pass = app_pass,
     };
@@ -996,13 +1010,22 @@ static esp_err_t handle_fritzbox_2fa_status(httpd_req_t *req)
         return ESP_OK;
     }
 
-    // Commit SIP credentials, re-register.
+    // Commit SIP credentials, re-register. Reset the expert SIP
+    // parameters to the Fritz!Box defaults for the same reason as the
+    // non-2FA path above: a complete new profile must not inherit stale
+    // transport/realm/srtp values from an earlier manual setup (#363).
     config_update_t u = {
         .sip_host = s_2fa.fritz_host,
+        .has_sip_port = true,
         .sip_port = 5060,
         .sip_user = res.sip_user,
         .sip_pass = res.sip_pass,
         .sip_internal_number = res.internal_number,
+        .sip_transport = "udp",
+        .sip_auth_user = "",
+        .sip_outbound  = "",
+        .sip_realm     = "",
+        .sip_srtp      = "off",
         .fritzbox_app_user = app_user,
         .fritzbox_app_pass = app_pass,
     };

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -495,10 +495,13 @@ static esp_err_t handle_config_post(httpd_req_t *req)
 
     config_update_t u = {
         .sip_host   = new_host,
-        // Port present in the form (even "0" = auto) writes through;
-        // absent leaves the stored value alone. 0 must be storable so a
-        // provider switch can clear a stale pinned port back to auto/SRV.
-        .has_sip_port = have_sip_port && sip_port_s[0],
+        // Port present in the form writes through; absent (a partial
+        // update such as a settings toggle) leaves the stored value
+        // alone. An empty *or* "0" field both mean "auto" (0 → DNS-SRV /
+        // transport default): this matches the prefill, which renders a
+        // stored 0 as an empty field, and lets a provider switch clear a
+        // stale pinned port back to auto.
+        .has_sip_port = have_sip_port,
         .sip_port     = have_sip_port && sip_port_s[0] ? atoi(sip_port_s) : 0,
         .sip_user   = have_sip_user && sip_user[0]  ? sip_user  : NULL,
         // Password resolution, in order:

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -964,17 +964,24 @@ async function postForm(url, form){
 
 // --- provider presets (top 5, PROVIDERS.md) -------------------------
 
+// `port: 0` means "auto" — the firmware resolves the endpoint via
+// DNS-SRV and uses the port the SRV record advertises. Telekom only
+// publishes an SRV record (_sips._tcp.tel.t-online.de) and no A record
+// on the bare domain, so a hard-coded port would skip SRV and the
+// direct A lookup would fail (#363); it also requires TLS transport.
 const PROVIDERS = {
   telekom: {
     name: 'Telekom MagentaZuhause',
     host: 'tel.t-online.de',
-    port: 5060,
+    port: 0,
+    transport: 'tls',
     userHint: 'Format: +49… (E.164). Benutzer = E-Mail des T-Online-Kontos, Passwort = T-Online-Webpasswort.',
   },
   vodafone: {
     name: 'Vodafone (DSL/Kabel)',
     hostTemplate: '{vorwahl}.sip.arcor.de',
     port: 5060,
+    transport: 'udp',
     needsVorwahl: true,
     userHint: 'Rufnummer ohne führende 0. Passwort aus „MeinVodafone" → separates SIP-Passwort.',
   },
@@ -982,18 +989,21 @@ const PROVIDERS = {
     name: '1&1',
     host: 'sip.1und1.de',
     port: 5060,
+    transport: 'udp',
     userHint: 'Format: 49…, ohne „+" und ohne führende 0. Passwort = „Telefoniepasswort" aus dem 1&1-Control-Center.',
   },
   sipgate: {
     name: 'sipgate',
     host: 'sipgate.de',
     port: 5060,
+    transport: 'udp',
     userHint: 'SIP-ID aus dem sipgate-Webportal. Passwort = separates SIP-Passwort.',
   },
   easybell: {
     name: 'easybell',
     host: 'voip.easybell.de',
     port: 5060,
+    transport: 'udp',
     userHint: 'SIP-Benutzer und -Passwort aus dem easybell-Kundenportal.',
   },
 };
@@ -2358,11 +2368,20 @@ async function onProviderSubmit(e){
   btn.disabled = true;
   msg.textContent = t('sip.fb.working');
   msg.style.color = '#888';
+  // A preset defines a *complete* SIP profile. Send every expert field
+  // — including explicit resets for the ones the preset doesn't use —
+  // so a prior manual/other-provider setup can't leave stale values
+  // behind that survive the merge and break the new registration (#363).
   const body = new URLSearchParams();
   body.append('sip_host', host);
   body.append('sip_port', String(p.port));
   body.append('sip_user', e.target.sip_user.value);
   body.append('sip_pass', e.target.sip_pass.value);
+  body.append('sip_transport', p.transport || 'udp');
+  body.append('sip_auth_user', '');
+  body.append('sip_outbound', '');
+  body.append('sip_realm', '');
+  body.append('sip_srtp', 'off');
   try {
     const r = await fetch('/api/config', {
       method: 'POST',

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -157,6 +157,8 @@ const I18N = {
     'status.errors.empty': 'keine Einträge',
     'status.errors.ago': 'vor {age}',
     'status.errors.clear': 'Protokoll leeren',
+    'status.errors.capture_info': 'Auch Infos protokollieren',
+    'status.errors.capture_info.hint': 'Für die Fehlersuche: zeigt zusätzlich Info-Meldungen (z. B. versuchter Server:Port). Füllt das Protokoll schnell — danach wieder ausschalten.',
     'status.auth.title': 'Zugangsschutz',
     'status.auth.intro': 'Schützt die Konfigurationsoberfläche im laufenden Betrieb. Aktivierst Du den Schutz, fragt diese Seite ab dann nach einer Anmeldung über Deinen PhoneBlock-Account, bevor sie Anrufdaten zeigt oder Einstellungen entgegennimmt.',
     'status.auth.disabled': 'Zugangsschutz aus — jeder im LAN erreicht das Dashboard ohne Anmeldung.',
@@ -364,6 +366,8 @@ const I18N = {
     'status.errors.empty': 'no entries',
     'status.errors.ago': '{age} ago',
     'status.errors.clear': 'Clear log',
+    'status.errors.capture_info': 'Also log info messages',
+    'status.errors.capture_info.hint': 'For troubleshooting: also shows info messages (e.g. the server:port tried). Fills the log quickly — switch off again afterwards.',
     'status.auth.title': 'Access protection',
     'status.auth.intro': 'Protects the configuration UI in everyday operation. When you turn this on, the page asks for a "Login with PhoneBlock" before it shows call data or accepts setting changes.',
     'status.auth.disabled': 'Access protection off — anyone on the LAN can reach the dashboard without logging in.',
@@ -559,6 +563,8 @@ const I18N = {
     'status.errors.empty': 'aucune entrée',
     'status.errors.ago': 'il y a {age}',
     'status.errors.clear': 'Vider le journal',
+    'status.errors.capture_info': 'Journaliser aussi les infos',
+    'status.errors.capture_info.hint': "Pour le dépannage : affiche aussi les messages d'info (par ex. le serveur:port essayé). Remplit vite le journal — à désactiver ensuite.",
     'status.auth.title': 'Protection d’accès',
     'status.auth.intro': 'Protège l’interface de configuration en exploitation. Une fois activée, la page demande une « Connexion avec PhoneBlock » avant d’afficher les appels ou d’accepter des modifications.',
     'status.auth.disabled': 'Protection d’accès désactivée — n’importe qui sur le LAN peut atteindre le tableau de bord sans se connecter.',
@@ -754,6 +760,8 @@ const I18N = {
     'status.errors.empty': 'sin entradas',
     'status.errors.ago': 'hace {age}',
     'status.errors.clear': 'Vaciar registro',
+    'status.errors.capture_info': 'Registrar también los mensajes info',
+    'status.errors.capture_info.hint': 'Para diagnóstico: muestra también mensajes info (p. ej. el servidor:puerto intentado). Llena el registro rápido; desactívalo después.',
     'status.auth.title': 'Protección de acceso',
     'status.auth.intro': 'Protege la interfaz de configuración durante el uso diario. Si la activas, la página pedirá un «Inicio de sesión con PhoneBlock» antes de mostrar llamadas o aceptar cambios.',
     'status.auth.disabled': 'Protección de acceso desactivada — cualquiera en la LAN puede llegar al panel sin iniciar sesión.',
@@ -1146,6 +1154,11 @@ function renderStatus(){
     +    esc(t('status.errors.clear')) + '</button>'
     + '</h2>'
     + '<div id="errorsList"></div>'
+    + '<label style="display:flex;align-items:center;gap:.4rem;font-weight:normal;margin-top:.7rem;font-size:.85rem">'
+    +   '<input type="checkbox" id="logInfoChk" style="width:auto">'
+    +   '<span>' + esc(t('status.errors.capture_info')) + '</span></label>'
+    + '<p class="muted" style="font-size:.72rem;margin:.2rem 0 0">'
+    +   esc(t('status.errors.capture_info.hint')) + '</p>'
     + '</section>'
     + '<section id="annSection" style="display:none">'
     + '<h2>' + esc(t('status.ann.title')) + '</h2>'
@@ -1858,8 +1871,9 @@ async function refreshAll(){
   const hasErrs = errs && errs.errors.length;
   if (hasErrs){
     list.innerHTML = errs.errors.map(e => {
-      // Severity colour on the tag: errors red, warnings amber.
-      const sev = e.level === 'E' ? 'color:#d93025' : 'color:#e8830c';
+      // Severity colour on the tag: errors red, warnings amber, info grey.
+      const sev = e.level === 'E' ? 'color:#d93025'
+                : e.level === 'W' ? 'color:#e8830c' : 'color:#888';
       return '<div class="error-row"><strong style="' + sev + '">['
         + esc(e.tag) + ']</strong> ' + esc(e.message)
         + ' <span class="muted">'
@@ -1876,6 +1890,25 @@ async function refreshAll(){
       catch (_){ /* next poll will reflect whatever state we end up in */ }
       await refreshAll();
       clearBtn.disabled = false;
+    };
+  }
+
+  // "Also log INFO" troubleshooting toggle. Reflect the stored state on
+  // every poll; persist via /api/config on change.
+  const logChk = $('logInfoChk');
+  if (logChk){
+    logChk.checked = !!(s.log && s.log.capture_info);
+    logChk.onchange = async () => {
+      const body = new URLSearchParams();
+      body.append('log_info', logChk.checked ? '1' : '0');
+      try {
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: body.toString(),
+        });
+      } catch (_){ /* next poll reconciles */ }
+      refreshAll();
     };
   }
 

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -153,10 +153,10 @@ const I18N = {
     'status.thresholds.range.help': 'Stimmen gegen Nachbarn im selben 10er- oder 100er-Block. Default 10. Wert 0 schaltet Range-Block ab — dann zählen nur Direkt-Treffer.',
     'status.thresholds.saved': 'Gespeichert.',
     'status.thresholds.invalid': 'Ungültiger Wert.',
-    'status.errors.title': 'Fehler',
-    'status.errors.empty': 'keine Fehler',
+    'status.errors.title': 'Protokoll',
+    'status.errors.empty': 'keine Einträge',
     'status.errors.ago': 'vor {age}',
-    'status.errors.clear': 'Log leeren',
+    'status.errors.clear': 'Protokoll leeren',
     'status.auth.title': 'Zugangsschutz',
     'status.auth.intro': 'Schützt die Konfigurationsoberfläche im laufenden Betrieb. Aktivierst Du den Schutz, fragt diese Seite ab dann nach einer Anmeldung über Deinen PhoneBlock-Account, bevor sie Anrufdaten zeigt oder Einstellungen entgegennimmt.',
     'status.auth.disabled': 'Zugangsschutz aus — jeder im LAN erreicht das Dashboard ohne Anmeldung.',
@@ -360,8 +360,8 @@ const I18N = {
     'status.thresholds.range.help': 'Votes against neighbors in the same 10/100-block. Default 10. Set to 0 to disable range-based blocking — only direct hits count then.',
     'status.thresholds.saved': 'Saved.',
     'status.thresholds.invalid': 'Invalid value.',
-    'status.errors.title': 'Errors',
-    'status.errors.empty': 'no errors',
+    'status.errors.title': 'Log',
+    'status.errors.empty': 'no entries',
     'status.errors.ago': '{age} ago',
     'status.errors.clear': 'Clear log',
     'status.auth.title': 'Access protection',
@@ -555,8 +555,8 @@ const I18N = {
     'status.calls.clear': 'Vider la liste',
     'status.calls.log_known': 'Journaliser les appels connus',
     'status.calls.log_known.help': 'Si désactivé, les appels provenant de numéros du carnet d’adresses et les codes internes (**, *…) n’apparaissent pas dans la liste — les compteurs ci-dessus restent mis à jour.',
-    'status.errors.title': 'Erreurs',
-    'status.errors.empty': 'aucune erreur',
+    'status.errors.title': 'Journal',
+    'status.errors.empty': 'aucune entrée',
     'status.errors.ago': 'il y a {age}',
     'status.errors.clear': 'Vider le journal',
     'status.auth.title': 'Protection d’accès',
@@ -750,8 +750,8 @@ const I18N = {
     'status.calls.clear': 'Vaciar lista',
     'status.calls.log_known': 'Registrar llamadas conocidas',
     'status.calls.log_known.help': 'Si está desactivado, las llamadas de números de la agenda y los códigos internos (**, *…) no aparecen en la lista — los contadores de arriba se siguen actualizando.',
-    'status.errors.title': 'Errores',
-    'status.errors.empty': 'sin errores',
+    'status.errors.title': 'Registro',
+    'status.errors.empty': 'sin entradas',
     'status.errors.ago': 'hace {age}',
     'status.errors.clear': 'Vaciar registro',
     'status.auth.title': 'Protección de acceso',
@@ -1857,11 +1857,14 @@ async function refreshAll(){
   const clearBtn = $('errorsClear');
   const hasErrs = errs && errs.errors.length;
   if (hasErrs){
-    list.innerHTML = errs.errors.map(e =>
-      '<div class="error-row"><strong>[' + esc(e.tag) + ']</strong> '
-      + esc(e.message) + ' <span class="muted">'
-      + esc(t('status.errors.ago', {age: fmtSec(e.age_s)})) + '</span></div>'
-    ).join('');
+    list.innerHTML = errs.errors.map(e => {
+      // Severity colour on the tag: errors red, warnings amber.
+      const sev = e.level === 'E' ? 'color:#d93025' : 'color:#e8830c';
+      return '<div class="error-row"><strong style="' + sev + '">['
+        + esc(e.tag) + ']</strong> ' + esc(e.message)
+        + ' <span class="muted">'
+        + esc(t('status.errors.ago', {age: fmtSec(e.age_s)})) + '</span></div>';
+    }).join('');
   } else {
     list.innerHTML = '<p class="muted">' + esc(t('status.errors.empty')) + '</p>';
   }

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -285,6 +285,9 @@ const I18N = {
     'sip.manual.port.hint': 'Leer lassen = automatisch via DNS-SRV bzw. Transport-Default (5060 UDP/TCP, 5061 TLS).',
     'sip.manual.user': 'SIP-Benutzer',
     'sip.manual.pass': 'SIP-Passwort',
+    'sip.manual.pass.hint': 'Leer lassen = gespeichertes Passwort behalten.',
+    'sip.manual.anon': 'Ohne Passwort anmelden (anonym)',
+    'sip.manual.anon.hint': 'Entfernt ein gespeichertes Passwort und meldet sich ohne an — z. B. anonymous@t-online.de bei der Telekom.',
     'sip.manual.submit': 'Speichern',
     'sip.manual.done': 'Gespeichert.',
     'sip.manual.error': 'Fehler: {msg}',
@@ -489,6 +492,9 @@ const I18N = {
     'sip.manual.port.hint': 'Leave empty for auto via DNS-SRV or the transport default (5060 UDP/TCP, 5061 TLS).',
     'sip.manual.user': 'SIP user',
     'sip.manual.pass': 'SIP password',
+    'sip.manual.pass.hint': 'Leave empty = keep the stored password.',
+    'sip.manual.anon': 'Register without a password (anonymous)',
+    'sip.manual.anon.hint': 'Clears any stored password and registers without one — e.g. anonymous@t-online.de on Telekom.',
     'sip.manual.submit': 'Save',
     'sip.manual.done': 'Saved.',
     'sip.manual.error': 'Error: {msg}',
@@ -681,6 +687,9 @@ const I18N = {
     'sip.manual.port.hint': 'Vide = automatique via DNS-SRV ou la valeur par défaut du transport (5060 UDP/TCP, 5061 TLS).',
     'sip.manual.user': 'Utilisateur SIP',
     'sip.manual.pass': 'Mot de passe SIP',
+    'sip.manual.pass.hint': 'Laisser vide = conserver le mot de passe enregistré.',
+    'sip.manual.anon': "S'enregistrer sans mot de passe (anonyme)",
+    'sip.manual.anon.hint': "Supprime un mot de passe enregistré et s'enregistre sans — par ex. anonymous@t-online.de chez Telekom.",
     'sip.manual.submit': 'Enregistrer',
     'sip.manual.done': 'Enregistré.',
     'sip.manual.error': 'Erreur : {msg}',
@@ -873,6 +882,9 @@ const I18N = {
     'sip.manual.port.hint': 'Déjelo en blanco para usar DNS-SRV o el valor predeterminado del transporte (5060 UDP/TCP, 5061 TLS).',
     'sip.manual.user': 'Usuario SIP',
     'sip.manual.pass': 'Contraseña SIP',
+    'sip.manual.pass.hint': 'Dejar en blanco = conservar la contraseña guardada.',
+    'sip.manual.anon': 'Registrarse sin contraseña (anónimo)',
+    'sip.manual.anon.hint': 'Elimina cualquier contraseña guardada y se registra sin ella, p. ej. anonymous@t-online.de en Telekom.',
     'sip.manual.submit': 'Guardar',
     'sip.manual.done': 'Guardado.',
     'sip.manual.error': 'Error: {msg}',
@@ -2437,7 +2449,14 @@ async function renderSipManual(){
     + '<label>' + esc(t('sip.manual.user'))
     + '<input type="text"   name="sip_user" value="' + esc(user) + '"></label>'
     + '<label>' + esc(t('sip.manual.pass'))
-    + '<input type="password" name="sip_pass" autocomplete="off"></label>'
+    + '<input type="password" name="sip_pass" id="sipPass" autocomplete="off"></label>'
+    + '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
+    +   esc(t('sip.manual.pass.hint')) + '</p>'
+    + '<label style="display:flex;align-items:center;gap:.4rem;font-weight:normal">'
+    +   '<input type="checkbox" name="sip_anon" id="sipAnon" style="width:auto">'
+    +   '<span>' + esc(t('sip.manual.anon')) + '</span></label>'
+    + '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
+    +   esc(t('sip.manual.anon.hint')) + '</p>'
     + '<details style="margin:1rem 0">'
     +   '<summary style="cursor:pointer;color:#008f7a;font-size:.9rem">'
     +     esc(t('sip.manual.advanced')) + '</summary>'
@@ -2472,6 +2491,14 @@ async function renderSipManual(){
     + '<button type="submit" class="btn-primary">' + esc(t('sip.manual.submit')) + '</button>'
     + '<span id="manMsg" class="muted" style="margin-left:.6rem"></span>'
     + '</p></form></section>';
+  // "Anonymous" disables the password field: a disabled field is left
+  // out of the form body, so the backend sees the explicit sip_anon
+  // marker (clear password) rather than an empty sip_pass (keep current).
+  const anon = $('sipAnon'), pass = $('sipPass');
+  anon.addEventListener('change', () => {
+    pass.disabled = anon.checked;
+    if (anon.checked) pass.value = '';
+  });
   $('manForm').addEventListener('submit', onManualSubmit);
 }
 

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -55,6 +55,14 @@ CONFIG_MBEDTLS_SSL_PROTO_TLS1_3=n
 # Main task stack: 8 KB is enough for cJSON + TLS + example helpers.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 
+# esp_event task stack: 2.75 KB, up from the 2304 B default. wifi.c runs
+# its event handlers here and logs WARN lines from them (failsafe / WPS),
+# which since the log-capture hook (log_capture.c) cost an extra ~110 B of
+# frame. The default left too little headroom for that on a deep handler
+# (schedule_failsafe even spawns a task inline). 2.75 KB clears it with
+# margin. The only IDF-owned task into which our own code logs warnings.
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=2816
+
 # HTTP server: browsers return from the phoneblock.net OAuth flow with
 # sizeable referrer + cookie + security headers (Chrome easily hits 1.5 kB
 # on a single request). The default 512-byte buffer rejects those with

--- a/phoneblock-dongle/firmware/test/.gitignore
+++ b/phoneblock-dongle/firmware/test/.gitignore
@@ -4,4 +4,5 @@ test_sip_srv
 test_sip_auth
 test_tr064_parse
 test_api_scan
+test_log_capture
 cjson.o

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -25,6 +25,9 @@ test_sip_auth: test_sip_auth.c ../main/sip_auth.c ../main/sip_auth.h
 
 test_tr064_parse: test_tr064_parse.c ../main/tr064_parse.c ../main/tr064_parse.h
 	$(CC) $(CFLAGS) test_tr064_parse.c ../main/tr064_parse.c -o $@
+
+test_log_capture: test_log_capture.c ../main/log_capture.c ../main/log_capture.h
+	$(CC) $(CFLAGS) test_log_capture.c ../main/log_capture.c -o $@
 
 cjson.o: $(CJSON_DIR)/cJSON.c $(CJSON_DIR)/cJSON.h
 	$(CC) -O0 -g -I$(CJSON_DIR) -c $< -o $@

--- a/phoneblock-dongle/firmware/test/test_log_capture.c
+++ b/phoneblock-dongle/firmware/test/test_log_capture.c
@@ -1,0 +1,116 @@
+// Host-side unit tests for main/log_capture.{c,h} parsing.
+//
+// The log hook decides what reaches the web UI's log panel by parsing
+// ESP-IDF's formatted log lines (level letter + tag + message), so the
+// parsing has to survive the colour escapes, the timestamp variants and
+// messages that themselves contain ": ". Pin all of that here, without
+// an ESP-IDF build.
+
+#include <stdio.h>
+#include <string.h>
+
+#include "log_capture.h"
+
+static int g_tests = 0;
+static int g_failures = 0;
+
+#define CHECK_CHAR(name, expected, got) do {                         \
+    g_tests++;                                                       \
+    if ((char)(expected) != (char)(got)) {                          \
+        fprintf(stderr, "FAIL %s: expected '%c'(%d) got '%c'(%d)\n", \
+                name, (expected) ? (expected) : '0', (int)(expected),\
+                (got) ? (got) : '0', (int)(got));                    \
+        g_failures++;                                                \
+    }                                                                \
+} while (0)
+
+#define CHECK_STR(name, expected, got) do {                          \
+    g_tests++;                                                       \
+    if (strcmp((expected), (got)) != 0) {                            \
+        fprintf(stderr, "FAIL %s: expected <<<%s>>> got <<<%s>>>\n", \
+                name, (expected), (got));                            \
+        g_failures++;                                                \
+    }                                                                \
+} while (0)
+
+// Convenience: run the parser and check level+tag+message in one go.
+static void expect(const char *name, const char *line,
+                   char want_level, const char *want_tag, const char *want_msg)
+{
+    char tag[16] = "?";
+    char msg[128] = "?";
+    char lvl = log_capture_parse(line, tag, sizeof(tag), msg, sizeof(msg));
+    char nbuf[128];
+    snprintf(nbuf, sizeof(nbuf), "%s/level", name);
+    CHECK_CHAR(nbuf, want_level, lvl);
+    if (want_level) {
+        snprintf(nbuf, sizeof(nbuf), "%s/tag", name);
+        CHECK_STR(nbuf, want_tag, tag);
+        snprintf(nbuf, sizeof(nbuf), "%s/msg", name);
+        CHECK_STR(nbuf, want_msg, msg);
+    }
+}
+
+// ESP-IDF colour prefixes (CONFIG_LOG_COLORS=y).
+#define RED    "\033[0;31m"
+#define YELLOW "\033[0;33m"
+#define GREEN  "\033[0;32m"
+#define RESET  "\033[0m"
+
+int main(void)
+{
+    // --- log_capture_level: cheap pre-filter on the format head -------
+    CHECK_CHAR("level/E-colour", 'E', log_capture_level(RED "E (1) t: m" RESET "\n"));
+    CHECK_CHAR("level/W-colour", 'W', log_capture_level(YELLOW "W (1) t: m" RESET "\n"));
+    CHECK_CHAR("level/I-colour", 'I', log_capture_level(GREEN "I (1) t: m" RESET "\n"));
+    CHECK_CHAR("level/E-plain",  'E', log_capture_level("E (1) t: m\n"));
+    CHECK_CHAR("level/garbage",  '\0', log_capture_level("not a log line"));
+    CHECK_CHAR("level/null",     '\0', log_capture_level(NULL));
+
+    // --- typical error / warning lines --------------------------------
+    expect("err-colour", RED "E (12345) sip: REGISTER failed" RESET "\n",
+           'E', "sip", "REGISTER failed");
+    expect("warn-colour", YELLOW "W (678) wifi: weak signal" RESET "\n",
+           'W', "wifi", "weak signal");
+
+    // Info still parses (the hook just won't act on it).
+    expect("info-colour", GREEN "I (1) main: booting" RESET "\n",
+           'I', "main", "booting");
+
+    // No colour escape (e.g. CONFIG_LOG_COLORS off).
+    expect("err-plain", "E (5) api: HTTP 500\n",
+           'E', "api", "HTTP 500");
+
+    // Library tags are kept too — no allowlist filtering: the esp-tls /
+    // mbedtls detail is exactly what we want on the panel.
+    expect("lib-tag", RED "E (9) esp-tls: handshake failed -0x2700" RESET "\n",
+           'E', "esp-tls", "handshake failed -0x2700");
+
+    // Message that itself contains ": " — split on the FIRST one, so the
+    // tag is just the tag and the colon stays in the message.
+    expect("colon-in-msg", RED "E (9) sip: connect to host: refused" RESET "\n",
+           'E', "sip", "connect to host: refused");
+
+    // Alternative timestamp format (CONFIG_LOG_TIMESTAMP_SOURCE_SYSTEM)
+    // still ends the prefix at ") ".
+    expect("ts-clock", "W (00:00:01.234) tr064: GetState slow\n",
+           'W', "tr064", "GetState slow");
+
+    // Unparseable lines (no "tag: msg" shape) yield no level.
+    expect("no-colon", "E (5) just a banner line\n", '\0', "", "");
+    expect("garbage", "random text without structure", '\0', "", "");
+
+    // --- truncation: must never overflow caller buffers ---------------
+    {
+        char tag[4] = "?";   // room for 3 chars + NUL
+        char msg[5] = "?";   // room for 4 chars + NUL
+        char lvl = log_capture_parse(RED "E (1) longtag: longmessage" RESET "\n",
+                                     tag, sizeof(tag), msg, sizeof(msg));
+        CHECK_CHAR("trunc/level", 'E', lvl);
+        CHECK_STR ("trunc/tag", "lon", tag);
+        CHECK_STR ("trunc/msg", "long", msg);
+    }
+
+    printf("log_capture: %d tests, %d failures\n", g_tests, g_failures);
+    return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
Behebt die in #363 gemeldeten Dongle-Setup-Probleme und macht – als direkte Folge der Diskussion – **alle** Warnungen/Fehler auf der Dongle-Oberfläche sichtbar, damit Fehleranalyse beim Kunden überhaupt möglich ist.

## 1. Telekom-/Provider-Setup (#363)

- **Leeres Passwort wird akzeptiert.** Der Registrierungs-Gate verlangte ein nicht-leeres Passwort und übersprang sonst die Anmeldung (`SIP config incomplete, skipping registration`). Ein leeres Passwort ist ein gültiges Digest-Credential (anonyme Konten wie `anonymous@t-online.de`); jetzt sind nur Host + Benutzer Pflicht.
- **Telekom-Preset funktioniert.** Das Preset war auf Port 5060/UDP verdrahtet. Telekom publiziert nur einen SRV-Record (`_sips._tcp.tel.t-online.de`) und keinen A-Record auf der nackten Domain und braucht TLS. Preset jetzt `transport=tls`, `port=0` ("auto") → der vorhandene SRV-Resolver baut die richtige Query und übernimmt Host + Port.
- **Profilwechsel erbt keine Altwerte mehr.** `config_update()` mergt nur Nicht-NULL-Felder, sodass ein früheres manuelles TLS/Realm/Port-Setup eine spätere Fritz\!Box-/Preset-Anmeldung sabotierte. Die vollständigen-Profil-Pfade setzen die Expert-Parameter jetzt explizit zurück. Port-Reset brauchte ein `has_sip_port`-Flag, weil `0` ("auto") vorher nicht von "unverändert" unterscheidbar war.
- **Leeres Passwort lässt sich setzen.** Ein einmal gespeichertes Passwort war über das Formular nie mehr leerbar (leeres Feld = "behalten"). Neue "anonym"-Checkbox als explizite Geste zum Löschen.
- **Leeres Port-Feld = auto.** Das Verhalten passt jetzt zum vorhandenen Hinweistext und ist symmetrisch zur Vorbefüllung (gespeicherte 0 → leeres Feld).

Plus eine Refaktorierung: der duplizierte Fritz\!Box-Provisionierungs-Abschluss (direkter Pfad + Post-2FA) liegt jetzt in einer gemeinsamen `finish_fritzbox_setup()`.

## 2. Diagnose: alle Warnungen/Fehler auf der Web-UI

Bisher speisten nur 23 von ~270 `WARN`/`ERROR`-Stellen den Fehler-Ring; ganze Module und sämtliche ESP-IDF-Bibliotheksfehler (esp-tls-Handshake, DNS, HTTP) erreichten die UI nie.

- **Zentraler Log-Hook** (`log_capture.c`, via `esp_log_set_vprintf`): spiegelt jede `WARN`/`ERROR`-Zeile – eigene und Bibliothek – in den Stats-Ring. Mit dem richtigen Level loggen genügt; UI-Anzeige passiert automatisch.
- Box "Fehler" → "**Protokoll**" (4 Sprachen), Severity-Färbung (Fehler rot, Warnung orange), Ring 10 → 32. Die 23 expliziten `stats_record_error`-Calls entfernt.
- **Aggressiver Level-Audit:** echte Lücken hochgestuft (Core-Dump erkannt = vorheriger Absturz, Heap-Druck, fehlender DNS-Server, Transport-Reconnect). Wiederkehrende/erwartbare Zeilen bewusst auf INFO belassen (WLAN-Failsafe-Ticks, normales Anrufende, fehlende SRV-Records), um Ring-Flut zu vermeiden.

## Tests
- `idf.py build` grün.
- Neuer Host-Unit-Test `test/test_log_capture.c` (32 Fälle) deckt das Parsing ab (ANSI-Farben, Timestamp-Varianten, `": "` in der Message, Bibliotheks-Tags, Truncation).
- **Offen:** Laufzeit-Test gegen echte Telekom-Infrastruktur bzw. provozierte Fehler auf Hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)