### PR TITLE
feat(dongle): Opt-in OTA beta channel for test builds (#366)

### DIFF
--- a/phoneblock-dongle/firmware/main/Kconfig.projbuild
+++ b/phoneblock-dongle/firmware/main/Kconfig.projbuild
@@ -16,14 +16,21 @@ menu "PhoneBlock Dongle"
             the test instance only work there, and vice versa. The token
             prefix (pbt_) is the same in both cases.
 
-    config PHONEBLOCK_OTA_MANIFEST_URL
-        string "OTA update manifest URL"
-        default "https://cdn.phoneblock.net/dongle/firmware/stable/manifest.json"
+    config PHONEBLOCK_OTA_BASE_URL
+        string "OTA update base URL"
+        default "https://cdn.phoneblock.net/dongle/firmware"
         help
-            HTTPS URL the dongle polls for OTA updates. This is the
-            same esp-web-tools manifest that the browser-based
-            installer uses, so there is exactly one source of truth
-            per release. Expected shape (as written by release.sh):
+            HTTPS base URL the dongle polls for OTA updates. The
+            firmware appends "/<channel>/manifest.json", where the
+            channel ("stable" by default, "beta" for opt-in testers)
+            is selected at runtime in the web UI and persisted in NVS.
+            Releases publish to both channels so beta is always at
+            least as new as stable (see scripts/release.sh).
+
+            The polled file is the same esp-web-tools manifest that the
+            browser-based installer uses, so there is exactly one
+            source of truth per release. Expected shape (as written by
+            release.sh):
 
               {"name": "PhoneBlock Dongle",
                "version": "1.0.3",

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -31,6 +31,7 @@ static const char *NS   = "phoneblock";
 #define K_AUTH_USER     "auth_user"
 #define K_AUTH_PERSIST  "auth_persist"
 #define K_AUTO_UPDATE   "auto_update"
+#define K_OTA_CHANNEL   "ota_channel"
 #define K_CRASH_REPORT  "crash_report"
 #define K_ACCEPT_TEST   "accept_test"
 #define K_CONTACT_HOST  "contact_host"
@@ -77,6 +78,7 @@ typedef struct {
     char auth_user[64];      // pinned PhoneBlock user-name; empty = no pin
     char auth_persist[33];   // 32 hex chars + NUL; empty = nobody is "remembered"
     char auto_update[4];     // "1" | "0" (or empty = default on)
+    char ota_channel[8];     // "stable" | "beta" (empty = default stable)
     char crash_report[4];    // "1" | "0" (or empty = default on)
     char accept_test[4];     // "1" | "0" (empty = use Kconfig default)
     char contact_host[64];
@@ -145,6 +147,7 @@ void config_load(void)
         s_config.auth_user[0]     = '\0';
         s_config.auth_persist[0]  = '\0';
         s_config.auto_update[0]   = '\0';
+        s_config.ota_channel[0]   = '\0';
         s_config.crash_report[0]  = '\0';
         s_config.accept_test[0]   = '\0';
         copy_default(s_config.contact_host, sizeof(s_config.contact_host), CONFIG_SIP_CONTACT_HOST_OVERRIDE);
@@ -197,6 +200,8 @@ void config_load(void)
              s_config.auth_persist, sizeof(s_config.auth_persist));
     load_str(h, K_AUTO_UPDATE, "",
              s_config.auto_update, sizeof(s_config.auto_update));
+    load_str(h, K_OTA_CHANNEL, "",
+             s_config.ota_channel, sizeof(s_config.ota_channel));
     load_str(h, K_CRASH_REPORT, "",
              s_config.crash_report, sizeof(s_config.crash_report));
     load_str(h, K_ACCEPT_TEST, "",
@@ -261,6 +266,14 @@ bool        config_auto_update_enabled(void)
     // tracks the released stream. Only an explicit "0" freezes it,
     // typically after a manual firmware upload from the web UI.
     return s_config.auto_update[0] != '0';
+}
+const char *config_ota_channel(void)
+{
+    // Allowlist: anything that isn't exactly "beta" maps to the
+    // default "stable". The result is spliced straight into the OTA
+    // poll URL path, so clamping here means a corrupt or unexpected
+    // NVS value can never redirect the dongle to an arbitrary host.
+    return strcmp(s_config.ota_channel, "beta") == 0 ? "beta" : "stable";
 }
 bool        config_crash_report_enabled(void)
 {
@@ -414,6 +427,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.auth_persist, sizeof(s_config.auth_persist));
     if (err == ESP_OK) err = set_str_if(h, K_AUTO_UPDATE, u->auto_update,
                                         s_config.auto_update, sizeof(s_config.auto_update));
+    if (err == ESP_OK) err = set_str_if(h, K_OTA_CHANNEL, u->ota_channel,
+                                        s_config.ota_channel, sizeof(s_config.ota_channel));
     if (err == ESP_OK) err = set_str_if(h, K_CRASH_REPORT, u->crash_report,
                                         s_config.crash_report, sizeof(s_config.crash_report));
     if (err == ESP_OK) err = set_str_if(h, K_ACCEPT_TEST, u->accept_test_calls,

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -103,6 +103,17 @@ const char *config_auth_persist(void);
 // when ready to follow the released stream again.
 bool        config_auto_update_enabled(void);
 
+// OTA update channel the daily self-update and the manual "check"
+// button poll. The manifest URL is built as
+// <CONFIG_PHONEBLOCK_OTA_BASE_URL>/<channel>/manifest.json, so the
+// channel is the path segment that selects the released stream.
+// Always returns one of the two known-safe literals "stable" (default)
+// or "beta": any other / corrupt NVS value maps to "stable", which
+// keeps the result safe to splice straight into the poll URL. "beta"
+// is opt-in for users testing pre-release builds; releases publish to
+// both channels so beta is always >= stable (see scripts/release.sh).
+const char *config_ota_channel(void);
+
 // Whether crashreport.c is allowed to upload a stored core dump to
 // the PhoneBlock backend on the boot following a panic. Default on
 // — the dump is otherwise dead weight in flash and the operator's
@@ -193,6 +204,11 @@ typedef struct {
     // "0" = freeze on the current build. NULL = leave unchanged.
     // Default when unset is "1" (auto-update on).
     const char *auto_update;
+    // OTA update channel: "stable" | "beta". NULL = leave unchanged.
+    // The caller is expected to pass only these two literals; any
+    // other value is persisted verbatim but read back as "stable" by
+    // config_ota_channel().
+    const char *ota_channel;
     // "1" = upload core dumps to the PhoneBlock backend after a
     // panic-and-reboot, "0" = erase them locally without sending.
     // NULL = leave unchanged. Default when unset is "1".

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -219,7 +219,13 @@ void firmware_schedule_reboot(void)
 static esp_err_t fetch_manifest(char *body, size_t cap,
                                 char *err, size_t err_cap)
 {
-    const char *url = CONFIG_PHONEBLOCK_OTA_MANIFEST_URL;
+    // Manifest URL = <base>/<channel>/manifest.json. The channel is a
+    // client-side opt-in (NVS, web UI toggle); config_ota_channel()
+    // clamps it to the known-safe literals "stable"/"beta" so it is
+    // safe to splice into the path here.
+    char url[256];
+    snprintf(url, sizeof(url), "%s/%s/manifest.json",
+             CONFIG_PHONEBLOCK_OTA_BASE_URL, config_ota_channel());
     esp_http_client_config_t cfg = {
         .url = url,
         .crt_bundle_attach = esp_crt_bundle_attach,

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -331,6 +331,7 @@ static esp_err_t handle_status(httpd_req_t *req)
 
     cJSON *fw = cJSON_AddObjectToObject(root, "firmware");
     cJSON_AddBoolToObject  (fw,   "auto_update",  config_auto_update_enabled());
+    cJSON_AddStringToObject(fw,   "channel",      config_ota_channel());
     cJSON_AddBoolToObject  (fw,   "crash_report", config_crash_report_enabled());
 
     send_json(req, root);
@@ -456,6 +457,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char sync_en_s[4]     = "";
     char log_known_s[4]   = "";
     char auto_update_s[4] = "";
+    char channel_s[8]     = "";
     char crash_rep_s[4]   = "";
     char test_calls_s[4]  = "";
 
@@ -472,6 +474,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_sync_en   = form_get(body, "sync_enabled",  sync_en_s,    sizeof(sync_en_s));
     bool have_log_known = form_get(body, "log_known_calls", log_known_s, sizeof(log_known_s));
     bool have_auto_upd  = form_get(body, "auto_update",   auto_update_s, sizeof(auto_update_s));
+    bool have_channel   = form_get(body, "channel",       channel_s,     sizeof(channel_s));
     bool have_crash_rep = form_get(body, "crash_report",  crash_rep_s,   sizeof(crash_rep_s));
     bool have_test_call = form_get(body, "accept_test_calls", test_calls_s, sizeof(test_calls_s));
     bool have_pb_url     = form_get(body, "pb_url",    pb_url,    sizeof(pb_url));
@@ -487,6 +490,16 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     const char *clear_int_num = NULL;
     if (new_host && strcmp(new_host, config_sip_host()) != 0) {
         clear_int_num = "";
+    }
+
+    // OTA channel: only the two known channels are accepted. An
+    // unrecognised value is ignored (left unchanged) rather than
+    // persisted, so a malformed POST can never write a string the
+    // manifest-URL builder would have to defend against.
+    const char *channel = NULL;
+    if (have_channel && (strcmp(channel_s, "stable") == 0 ||
+                         strcmp(channel_s, "beta")   == 0)) {
+        channel = channel_s;
     }
 
     config_update_t u = {
@@ -509,6 +522,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .sync_enabled    = have_sync_en   ? sync_en_s    : NULL,
         .log_known_calls = have_log_known ? log_known_s  : NULL,
         .auto_update     = have_auto_upd  ? auto_update_s : NULL,
+        .ota_channel     = channel,
         .crash_report    = have_crash_rep ? crash_rep_s   : NULL,
         .accept_test_calls = have_test_call ? test_calls_s : NULL,
         .phoneblock_base_url = have_pb_url   && pb_url[0]   ? pb_url   : NULL,

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -203,6 +203,10 @@ const I18N = {
     'status.fw.failed': 'Letztes Update auf Version {version} hat den Boot nicht überstanden — automatisch zurückgerollt. Auto-Update überspringt diese Version. Klick auf „Auf Aktualisierung prüfen", um es erneut zu versuchen.',
     'status.fw.auto_update': 'Tägliche Auto-Aktualisierung',
     'status.fw.auto_update.help': 'Wenn aktiv, prüft der Dongle einmal pro Tag, ob auf der PhoneBlock-CDN eine neuere Version liegt, und installiert sie automatisch. Beim manuellen Hochladen einer Firmware wird diese Option automatisch ausgeschaltet, damit der Daily-Check Deinen handgewählten Build nicht überschreibt — schalte sie hier wieder ein, wenn Du dem Release-Strom folgen willst.',
+    'status.fw.channel': 'Update-Kanal',
+    'status.fw.channel.help': 'Wähle „Beta", wenn Du Testversionen vorab erhalten möchtest — etwa um einen gemeldeten Fehler gegenzuprüfen. „Stabil" liefert nur freigegebene Versionen. Sobald eine getestete Version final freigegeben wird, wechselst Du automatisch wieder auf diese.',
+    'status.fw.channel.stable': 'Stabil',
+    'status.fw.channel.beta': 'Beta (Testversionen)',
     'status.fw.crash_report': 'Fehlerberichte an phoneblock.net senden',
     'status.fw.crash_report.help': 'Wenn der Dongle wegen eines Programmfehlers neu startet, wird ein Speicherauszug auf einer dafür reservierten Flash-Partition abgelegt. Ist diese Option aktiv, lädt der Dongle den Auszug beim nächsten Start an phoneblock.net hoch — das hilft uns, Felddefekte zu finden und zu fixen. Schalte die Option aus, wenn der Dongle solche Berichte nicht senden soll; gespeicherte Auszüge werden dann lokal gelöscht statt verschickt.',
     'status.sync.title': 'Sperrlisten-Sync',
@@ -407,6 +411,10 @@ const I18N = {
     'status.fw.failed': 'Last update to version {version} did not survive the boot — automatically rolled back. Auto-update will skip this version. Click "Check for update" to retry.',
     'status.fw.auto_update': 'Daily auto-update',
     'status.fw.auto_update.help': 'When on, the dongle checks the PhoneBlock CDN once a day for a newer version and installs it automatically. Manually uploading a firmware turns this off so the daily check does not overwrite your hand-picked build — turn it back on here once you want to follow the released stream again.',
+    'status.fw.channel': 'Update channel',
+    'status.fw.channel.help': 'Choose "Beta" to receive test builds early — for example to verify a bug you reported. "Stable" only delivers released versions. Once a tested version is finally released, you switch back to it automatically.',
+    'status.fw.channel.stable': 'Stable',
+    'status.fw.channel.beta': 'Beta (test builds)',
     'status.fw.crash_report': 'Send crash reports to phoneblock.net',
     'status.fw.crash_report.help': 'When the dongle reboots after a software panic, a memory snapshot is written to a reserved flash partition. With this option on, the dongle uploads the snapshot to phoneblock.net on the next boot — that helps us find and fix field bugs. Switch it off to suppress reports; stored snapshots are then erased locally instead of sent.',
     'status.sync.title': 'Blocklist sync',
@@ -599,6 +607,10 @@ const I18N = {
     'status.fw.failed': 'La dernière mise à jour vers la version {version} n’a pas survécu au démarrage — restauration automatique. La mise à jour automatique ignore cette version. Cliquez sur « Vérifier les mises à jour » pour réessayer.',
     'status.fw.auto_update': 'Mise à jour automatique quotidienne',
     'status.fw.auto_update.help': 'Si activée, le dongle vérifie une fois par jour la présence d’une version plus récente sur le CDN PhoneBlock et l’installe automatiquement. Téléverser un firmware manuellement désactive cette option pour que la vérification quotidienne n’écrase pas ta version choisie — réactive-la ici quand tu veux suivre le flux des versions publiées.',
+    'status.fw.channel': 'Canal de mise à jour',
+    'status.fw.channel.help': 'Choisis « Bêta » pour recevoir les versions de test en avance — par exemple pour vérifier un bug que tu as signalé. « Stable » ne fournit que les versions publiées. Dès qu’une version testée est publiée définitivement, tu y reviens automatiquement.',
+    'status.fw.channel.stable': 'Stable',
+    'status.fw.channel.beta': 'Bêta (versions de test)',
     'status.fw.crash_report': 'Envoyer les rapports d’erreur à phoneblock.net',
     'status.fw.crash_report.help': 'Si le dongle redémarre après une erreur logicielle, un instantané mémoire est écrit dans une partition flash réservée. Si cette option est activée, le dongle envoie l’instantané à phoneblock.net au prochain démarrage — cela nous aide à identifier et corriger les bugs en production. Désactive-la pour empêcher l’envoi ; les instantanés stockés sont alors effacés localement au lieu d’être transmis.',
     'status.sync.title': 'Synchro liste de blocage',
@@ -791,6 +803,10 @@ const I18N = {
     'status.fw.failed': 'La última actualización a la versión {version} no superó el arranque — se revirtió automáticamente. La actualización automática omitirá esta versión. Pulsa «Buscar actualizaciones» para volver a intentarlo.',
     'status.fw.auto_update': 'Actualización automática diaria',
     'status.fw.auto_update.help': 'Si está activada, el dongle comprueba una vez al día si hay una versión más nueva en la CDN de PhoneBlock y la instala automáticamente. Subir un firmware manualmente desactiva esta opción para que la comprobación diaria no sobrescriba tu compilación elegida — vuelve a activarla aquí cuando quieras seguir el flujo de versiones publicadas.',
+    'status.fw.channel': 'Canal de actualización',
+    'status.fw.channel.help': 'Elige «Beta» para recibir versiones de prueba con antelación — por ejemplo para verificar un error que has reportado. «Estable» solo entrega versiones publicadas. En cuanto una versión probada se publica definitivamente, vuelves a ella automáticamente.',
+    'status.fw.channel.stable': 'Estable',
+    'status.fw.channel.beta': 'Beta (versiones de prueba)',
     'status.fw.crash_report': 'Enviar informes de error a phoneblock.net',
     'status.fw.crash_report.help': 'Cuando el dongle reinicia tras un fallo de software, se escribe una instantánea de memoria en una partición flash reservada. Con esta opción activada, el dongle sube la instantánea a phoneblock.net en el próximo arranque — esto nos ayuda a localizar y corregir errores en campo. Desactívala para suprimir los envíos; las instantáneas guardadas se borran localmente en lugar de enviarse.',
     'status.sync.title': 'Sincronización de lista de bloqueo',
@@ -1188,6 +1204,16 @@ function renderStatus(){
     +    'style="display:flex;align-items:center;gap:.4rem;font-weight:400;color:#444;margin:0">'
     + '    <input id="fwAutoUpdate" type="checkbox" style="width:auto;margin:0">'
     + '    <span>' + esc(t('status.fw.auto_update')) + '</span>'
+    + '  </label>'
+    + '</p>'
+    + '<p style="margin-top:.4rem;font-size:.85rem">'
+    + '  <label title="' + esc(t('status.fw.channel.help')) + '" '
+    +    'style="display:flex;align-items:center;gap:.4rem;font-weight:400;color:#444;margin:0">'
+    + '    <span>' + esc(t('status.fw.channel')) + '</span>'
+    + '    <select id="fwChannel" style="width:auto;margin:0">'
+    + '      <option value="stable">' + esc(t('status.fw.channel.stable')) + '</option>'
+    + '      <option value="beta">' + esc(t('status.fw.channel.beta')) + '</option>'
+    + '    </select>'
     + '  </label>'
     + '</p>'
     + '<p style="margin-top:.4rem;font-size:.85rem">'
@@ -2038,6 +2064,32 @@ async function refreshAll(){
           });
         } catch (_){ /* next poll will reconcile */ }
         fwAutoUpdate.disabled = false;
+        refreshAll();
+      };
+    }
+  }
+
+  const fwChannel = $('fwChannel');
+  // s.firmware.channel is the persisted device channel ("stable" |
+  // "beta"). Default "stable" when missing (older firmware that didn't
+  // expose the field).
+  if (fwChannel){
+    fwChannel.value = (s && s.firmware && s.firmware.channel === 'beta')
+      ? 'beta' : 'stable';
+    if (!fwChannel.onchange){
+      fwChannel.onchange = async () => {
+        const want = fwChannel.value;
+        fwChannel.disabled = true;
+        const body = new URLSearchParams();
+        body.append('channel', want);
+        try {
+          await fetch('/api/config', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: body.toString(),
+          });
+        } catch (_){ /* next poll will reconcile */ }
+        fwChannel.disabled = false;
         refreshAll();
       };
     }

--- a/phoneblock-dongle/firmware/scripts/release.sh
+++ b/phoneblock-dongle/firmware/scripts/release.sh
@@ -2,13 +2,19 @@
 #
 # Build, package, and upload a PhoneBlock-Dongle firmware release.
 #
-#   ./scripts/release.sh             # full flow: build, stage, upload, flip stable
+#   ./scripts/release.sh             # full flow: build, stage, upload, flip channel(s)
 #   ./scripts/release.sh --stage     # build + stage to release/<version>/, no upload
 #   ./scripts/release.sh --dry-run   # all of the above + print scp/ssh commands
 #
 # Version comes from `git describe --tags --match "dongle-v*"`. The working tree
 # must be clean and HEAD must sit exactly on a tag — between-tag builds (e.g.
 # 1.4.2-3-gabcdef) are rejected to keep the CDN to released versions only.
+#
+# The target channel is derived from the tag: a pre-release suffix
+# (dongle-v1.6.0-rc1) publishes to the "beta" channel only; a clean
+# release (dongle-v1.6.0) publishes to "stable" *and* "beta". That
+# keeps beta always >= stable, so a beta tester lands on the final
+# build once it ships and never sees a downgrade.
 
 set -euo pipefail
 
@@ -80,6 +86,19 @@ fi
 VERSION="${DESCRIBE#dongle-v}"
 echo "Releasing version: $VERSION"
 
+# Derive the target channel(s) from the tag. A pre-release suffix
+# (anything after a '-', e.g. 1.6.0-rc1) ships to beta only; a clean
+# release ships to stable *and* beta so beta never lags behind stable.
+# The dongle's semver compare treats "1.6.0-rc2" < "1.6.0", so a beta
+# device upgrades onto the final build automatically once it lands.
+if [[ "$VERSION" == *-* ]]; then
+    CHANNELS=(beta)
+    echo "Pre-release tag → channel: beta"
+else
+    CHANNELS=(stable beta)
+    echo "Release tag → channels: stable + beta"
+fi
+
 # ---------------------------------------------------------------------------
 # 2. Build firmware. ESP-IDF reads version from version.txt next to CMakeLists,
 #    which lands in esp_app_desc_t.version and the /api/status payload.
@@ -137,9 +156,12 @@ idf.py -C "$FIRMWARE_DIR" build
 # 3. Stage release artifacts into release/<version>/.
 # ---------------------------------------------------------------------------
 STAGE_VERSION="${RELEASE_ROOT}/${VERSION}"
-STAGE_STABLE="${RELEASE_ROOT}/stable"
-rm -rf "$STAGE_VERSION" "$STAGE_STABLE"
-mkdir -p "$STAGE_VERSION" "$STAGE_STABLE"
+# Channel manifest: absolute URLs into the version dir. Identical for
+# every channel (stable/beta), so it's built once and uploaded to each
+# target channel in step 4.
+STAGE_CHAN="${RELEASE_ROOT}/channel"
+rm -rf "$STAGE_VERSION" "$STAGE_CHAN"
+mkdir -p "$STAGE_VERSION" "$STAGE_CHAN"
 
 cp "${BUILD_DIR}/bootloader/bootloader.bin"           "${STAGE_VERSION}/"
 cp "${BUILD_DIR}/partition_table/partition-table.bin" "${STAGE_VERSION}/"
@@ -176,32 +198,32 @@ sed -e "s/@VERSION@/${VERSION}/g" \
     "${SCRIPT_DIR}/manifest.json.tmpl" \
     > "${STAGE_VERSION}/manifest.json"
 
-# Stable manifest: absolute URLs into the version directory. The install page
-# pins to https://cdn.phoneblock.net/dongle/firmware/stable/manifest.json so
-# the URL never changes; only this single file flips at release time.
+# Channel manifest: absolute URLs into the version directory. The install
+# page and the dongle pin to .../dongle/firmware/<channel>/manifest.json so
+# the URL never changes; only this single file flips per channel at release
+# time.
 BASE_URL="https://cdn.phoneblock.net/dongle/firmware/${VERSION}"
 sed -e "s/@VERSION@/${VERSION}/g" \
     -e "s/@APP_SHA256@/${APP_SHA256}/g" \
     -e "s|@SIGNATURE@|${APP_SIG}|g" \
     -e "s|\"path\": \"|\"path\": \"${BASE_URL}/|g" \
     "${SCRIPT_DIR}/manifest.json.tmpl" \
-    > "${STAGE_STABLE}/manifest.json"
+    > "${STAGE_CHAN}/manifest.json"
 
 # Plain pointer file for tooling that wants just the version string.
-printf '{ "version": "%s" }\n' "$VERSION" > "${STAGE_STABLE}/version.json"
+printf '{ "version": "%s" }\n' "$VERSION" > "${STAGE_CHAN}/version.json"
 
 echo "Staged: $STAGE_VERSION"
-echo "Staged: $STAGE_STABLE"
+echo "Staged: $STAGE_CHAN → channels: ${CHANNELS[*]}"
 
 if [[ "$MODE" == "stage" ]]; then
     exit 0
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Upload version directory, then atomically flip stable/.
+# 4. Upload version directory, then atomically flip each target channel.
 # ---------------------------------------------------------------------------
 REMOTE_VERSION="${CDN_FIRMWARE}/${VERSION}"
-REMOTE_STABLE="${CDN_FIRMWARE}/stable"
 
 # The CDN host accepts sftp/scp only — no shell access. Parent dirs are
 # created via sftp (-mkdir ignores "already exists"). The version dir is
@@ -213,28 +235,34 @@ sftp_batch <<SFTP
 -mkdir ${CDN_BASE}
 -mkdir ${CDN_FIRMWARE}
 -mkdir ${REMOTE_VERSION}
--mkdir ${REMOTE_STABLE}
 SFTP
 
 # Local shell expands the glob; scp ships each file into REMOTE_VERSION
 # directly — no subdirectory wrapping.
 run scp "${STAGE_VERSION}"/* "${CDN_HOST}:${REMOTE_VERSION}/"
 
-# Atomic flip: upload to *.tmp, then rename over the live file. OpenSSH's sftp
-# uses posix-rename, which atomically replaces the target. The window in which
-# stable/manifest.json doesn't exist is zero (after the first release) or one
-# upload (on the very first release, where there's nothing to overwrite yet).
-sftp_batch <<SFTP
-put ${STAGE_STABLE}/manifest.json ${REMOTE_STABLE}/manifest.json.tmp
-put ${STAGE_STABLE}/version.json  ${REMOTE_STABLE}/version.json.tmp
-rename ${REMOTE_STABLE}/manifest.json.tmp ${REMOTE_STABLE}/manifest.json
-rename ${REMOTE_STABLE}/version.json.tmp  ${REMOTE_STABLE}/version.json
+# Atomic flip per channel: upload to *.tmp, then rename over the live file.
+# OpenSSH's sftp uses posix-rename, which atomically replaces the target. The
+# window in which <channel>/manifest.json doesn't exist is zero (after the
+# first release) or one upload (the very first release of that channel, where
+# there's nothing to overwrite yet).
+for CH in "${CHANNELS[@]}"; do
+    REMOTE_CH="${CDN_FIRMWARE}/${CH}"
+    sftp_batch <<SFTP
+-mkdir ${REMOTE_CH}
+put ${STAGE_CHAN}/manifest.json ${REMOTE_CH}/manifest.json.tmp
+put ${STAGE_CHAN}/version.json  ${REMOTE_CH}/version.json.tmp
+rename ${REMOTE_CH}/manifest.json.tmp ${REMOTE_CH}/manifest.json
+rename ${REMOTE_CH}/version.json.tmp  ${REMOTE_CH}/version.json
 SFTP
+done
 
 echo
 echo "Released ${VERSION}."
 echo "  Pinned: https://cdn.phoneblock.net/dongle/firmware/${VERSION}/manifest.json"
-echo "  Stable: https://cdn.phoneblock.net/dongle/firmware/stable/manifest.json"
+for CH in "${CHANNELS[@]}"; do
+    echo "  ${CH}: https://cdn.phoneblock.net/dongle/firmware/${CH}/manifest.json"
+done
 
 # Push the tag now that the CDN has accepted the upload. Pushing
 # only after a successful release means a failed run (build error,

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -140,10 +140,12 @@ CONFIG_SPIFFS_PAGE_SIZE=1024
 # /api/... and /mobile/... themselves.
 CONFIG_PHONEBLOCK_BASE_URL="https://phoneblock.net/phoneblock"
 
-# OTA manifest: same esp-web-tools manifest the browser-based
-# installer reads, so there is exactly one source of truth per
-# release. Override in .local to point at a staging CDN bucket.
-CONFIG_PHONEBLOCK_OTA_MANIFEST_URL="https://cdn.phoneblock.net/dongle/firmware/stable/manifest.json"
+# OTA base URL: the firmware appends "/<channel>/manifest.json" (the
+# channel is a runtime web-UI toggle, "stable" by default). The polled
+# file is the same esp-web-tools manifest the browser-based installer
+# reads, so there is one source of truth per release. Override in
+# .local to point at a staging CDN bucket.
+CONFIG_PHONEBLOCK_OTA_BASE_URL="https://cdn.phoneblock.net/dongle/firmware"
 
 # SIP. Registrar/username/password are written to NVS by the web
 # setup wizard. SIP_EXPIRES is the *requested* upper bound for the


### PR DESCRIPTION
Closes #366.

## Warum

Um Testversionen der Dongle-Firmware gezielt an Bug-Melder auszuspielen, fehlte ein „Beta-Kanal". Server-seitiges Targeting einzelner Geräte ist mit der Architektur unmöglich: Der OTA-Poll ist anonym (kein Geräte-ID/Token/MAC), es gibt keinen Per-Client-State (~1e6 Geräte), und das CDN ist statisch (nur sftp/scp). Die einzige tragfähige Stelle für die Entscheidung „bin ich Beta-Tester?" ist daher das Gerät selbst — als **Opt-in** im lokalen Web-UI.

## Was

- **config** (`config.{h,c}`): neuer NVS-Schlüssel `ota_channel` (Default `stable`). `config_ota_channel()` klemmt auf die Allowlist `{stable, beta}` — ein korrupter/unerwarteter NVS-Wert kann die Poll-URL nicht umleiten.
- **firmware_update.c**: Manifest-URL wird zur Laufzeit als `<base>/<channel>/manifest.json` gebaut. Kconfig-Option `PHONEBLOCK_OTA_MANIFEST_URL` → `PHONEBLOCK_OTA_BASE_URL` umbenannt (+ `sdkconfig.defaults`).
- **web.c**: `firmware.channel` in `/api/status`; `channel`-Feld in `/api/config` wird validiert (nur `stable`/`beta`, sonst ignoriert).
- **web UI** (`index.html`): Kanal-Dropdown in der Firmware-Sektion, i18n für de/en/fr/es.
- **release.sh**: Zielkanal aus dem Git-Tag abgeleitet:
  - Pre-Release (`dongle-v1.6.0-rc1`) → nur `beta/` umschwenken.
  - Finales Release (`dongle-v1.6.0`) → `stable/` **und** `beta/` umschwenken.

  Invariante `beta >= stable`: Ein Beta-Tester landet nach Testabschluss automatisch auf der finalen Version (vorhandene Semver-Pre-Release-Logik: `1.6.0` > `1.6.0-rc2`) und sieht nie einen Downgrade.

## Lebenszyklus

1. `dongle-v1.6.0-rc1` taggen → `release.sh` schwenkt nur `beta/`.
2. Bug-Melder stellt im UI auf „Beta" → Gerät zieht `rc1`.
3. Fix → `rc2` auf `beta`; Gerät aktualisiert automatisch.
4. `dongle-v1.6.0` (final) → `stable/` **und** `beta/`; Beta-Gerät zieht auf das Final nach.

## Test

- `idf.py build` erfolgreich (nach Reconfigure wegen der Kconfig-Umbenennung).
- Signatur-, Semver- und Downgrade-Schutz-Logik unverändert; gleicher ECDSA-Key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)