### PR TITLE
dongle: fix selftest task stack overflow corrupting the heap

### DIFF
--- a/phoneblock-dongle/firmware/main/selftest.c
+++ b/phoneblock-dongle/firmware/main/selftest.c
@@ -47,5 +47,10 @@ static void selftest_task(void *arg)
 void selftest_start(void)
 {
     if (s_task) return;
-    xTaskCreate(selftest_task, "selftest", 4096, NULL, 3, &s_task);
+    // TLS handshake + getaddrinfo in phoneblock_selftest() blow past
+    // 4 KB and smash the adjacent heap block, corrupting the TLSF
+    // free-list (crashes show up as heap asserts in random other tasks:
+    // tiT, wifi, mdns, ...). The same selftest runs fine synchronously
+    // on the 8 KB main task at boot, so match that proven size here.
+    xTaskCreate(selftest_task, "selftest", 8192, NULL, 3, &s_task);
 }


### PR DESCRIPTION
## Problem

Analysis of **36 field coredumps** (firmware 1.3.1 + 1.3.2) uploaded by dongles after panics shows a single root cause.

The crashes are scattered across unrelated victim tasks — `tiT` (lwIP), `wifi`, `mdns`, `sip_register`, `esp_timer`, `IDLE1`, `selftest` — and almost all abort inside the TLSF heap allocator with asserts like:

```
assert failed: block_locate_free tlsf.c:566 (block_size(block) >= size)
```

That is the classic **heap-corruption** signature: one task writes past a buffer and smashes the TLSF free-list metadata, then the *next arbitrary* task to call `malloc`/`free` crashes. The victim is never the culprit.

Five dumps caught the culprit directly via the FreeRTOS stack canary:

```
***ERROR*** A stack overflow in task selftest has been detected.
```

## Root cause

`selftest_task` runs `phoneblock_selftest()` (an HTTPS `GET /api/test`, full mbedTLS handshake + `getaddrinfo`) plus `logreport_flush()` (another TLS upload) on a **4 KB stack**. That is not enough for a TLS handshake — it overflows and corrupts the adjacent heap block.

Proof from the firmware's own numbers:

| Path | same TLS work | stack | status |
|---|---|---|---|
| Boot selftest (synchronous, main task) | ✅ | **8192** | stable |
| `sync` task (HTTPS API) | ✅ | 6144 | stable |
| **`selftest` task** | ✅ | **4096** | **crashes** |

The identical selftest runs fine synchronously on the 8 KB main task at boot.

## Fix

Bump the `selftest` task stack to 8192 to match the proven boot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)