### PR TITLE
mobile: sync personal wildcards in the background, match from SQLite

### DIFF
--- a/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
+++ b/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/CallChecker.java
@@ -86,7 +86,6 @@ public class CallChecker extends CallScreeningService {
         int minVotes = prefs.getInt("min_votes", 4);
         boolean blockRanges = prefs.getBoolean("block_ranges", true);
         int minRangeVotes = prefs.getInt("min_range_votes", 10);
-        String wildcardPrefixesJson = prefs.getString("wildcard_prefixes", "[]");
 
         if (authToken == null) {
             Log.d(CallChecker.class.getName(), "onScreenCall: No PhoneBlock authorization, cannot screen call.");
@@ -147,10 +146,11 @@ public class CallChecker extends CallScreeningService {
                 if (timeoutFuture[0] != null) {
                     timeoutFuture[0].cancel(false);
                 }
+                final java.util.List<String> wildcardPrefixes = loadLocalWildcardPrefixes();
                 Handler.createAsync(Looper.getMainLooper()).post(() ->
                     decideAndRespond(callDetails, rawNumber, number,
                         fVotes, fVotesWildcard, fArchived, fRating, fLabel, fLocation, fBlackListed,
-                        minVotes, blockRanges, minRangeVotes, wildcardPrefixesJson));
+                        minVotes, blockRanges, minRangeVotes, wildcardPrefixes));
             }
         }, 0, TimeUnit.MILLISECONDS);
 
@@ -159,11 +159,12 @@ public class CallChecker extends CallScreeningService {
             if (responded.compareAndSet(false, true)) {
                 queryFuture.cancel(true);
                 int localVotes = Math.max(0, lookupLocalBlocklist(number));
+                final java.util.List<String> wildcardPrefixes = loadLocalWildcardPrefixes();
 
                 Handler.createAsync(Looper.getMainLooper()).post(() ->
                     decideAndRespond(callDetails, rawNumber, number,
                         localVotes, 0, false, null, null, null, false,
-                        minVotes, blockRanges, minRangeVotes, wildcardPrefixesJson));
+                        minVotes, blockRanges, minRangeVotes, wildcardPrefixes));
             }
         }, 4500, TimeUnit.MILLISECONDS);
     }
@@ -174,7 +175,7 @@ public class CallChecker extends CallScreeningService {
      */
     private void decideAndRespond(@NonNull Call.Details callDetails, String rawNumber, String number,
             int votes, int votesWildcard, boolean archived, String rating, String label, String location, boolean blackListed,
-            int minVotes, boolean blockRanges, int minRangeVotes, String wildcardPrefixesJson) {
+            int minVotes, boolean blockRanges, int minRangeVotes, java.util.List<String> wildcardPrefixes) {
 
         boolean block = false;
         String matchedPrefix = null;
@@ -186,7 +187,7 @@ public class CallChecker extends CallScreeningService {
         } else if (blockRanges && votesWildcard >= minRangeVotes) {
             block = true;
         } else {
-            matchedPrefix = findWildcardMatch(number, wildcardPrefixesJson);
+            matchedPrefix = findWildcardMatch(number, wildcardPrefixes);
             if (matchedPrefix != null) {
                 block = true;
             }
@@ -221,17 +222,11 @@ public class CallChecker extends CallScreeningService {
     }
 
     /** Finds the first wildcard prefix that matches the given number, or null. */
-    private static String findWildcardMatch(String number, String wildcardPrefixesJson) {
-        try {
-            org.json.JSONArray prefixes = new org.json.JSONArray(wildcardPrefixesJson);
-            for (int i = 0; i < prefixes.length(); i++) {
-                String prefix = prefixes.getString(i);
-                if (number.startsWith(prefix)) {
-                    return prefix;
-                }
+    private static String findWildcardMatch(String number, java.util.List<String> wildcardPrefixes) {
+        for (String prefix : wildcardPrefixes) {
+            if (number.startsWith(prefix)) {
+                return prefix;
             }
-        } catch (org.json.JSONException e) {
-            Log.w(CallChecker.class.getName(), "Failed to parse wildcard prefixes", e);
         }
         return null;
     }
@@ -324,6 +319,43 @@ public class CallChecker extends CallScreeningService {
             Log.w(CallChecker.class.getName(), "Error looking up local blocklist", e);
             return -1;
         }
+    }
+
+    /**
+     * Loads the user's personal wildcard prefixes from the local SQLite store.
+     *
+     * <p>Read directly from the {@code wildcard_blocks} table (the same database the Flutter side
+     * reconciles with the server) rather than from SharedPreferences, so that prefixes synced by
+     * the background worker take effect without a foreground round-trip through the MethodChannel.</p>
+     *
+     * @return The list of international-format prefixes, empty if none are stored or on error.
+     */
+    private java.util.List<String> loadLocalWildcardPrefixes() {
+        java.util.List<String> prefixes = new java.util.ArrayList<>();
+        try {
+            java.io.File dbFile = getDatabasePath("screened_calls.db");
+            if (!dbFile.exists()) {
+                return prefixes;
+            }
+
+            SQLiteDatabase db = SQLiteDatabase.openDatabase(
+                dbFile.getPath(), null, SQLiteDatabase.OPEN_READONLY);
+            try {
+                Cursor cursor = db.rawQuery("SELECT prefix FROM wildcard_blocks", null);
+                try {
+                    while (cursor.moveToNext()) {
+                        prefixes.add(cursor.getString(0));
+                    }
+                } finally {
+                    cursor.close();
+                }
+            } finally {
+                db.close();
+            }
+        } catch (Exception e) {
+            Log.w(CallChecker.class.getName(), "Error loading local wildcard prefixes", e);
+        }
+        return prefixes;
     }
 
 }

--- a/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/MainActivity.java
+++ b/phoneblock_mobile/android/app/src/main/java/de/haumacher/phoneblock_mobile/MainActivity.java
@@ -396,17 +396,6 @@ public class MainActivity extends FlutterActivity {
                 String normalized = PhoneNumberUtils.normalizeToInternationalFormat(rawNumber, countryCode);
                 result.success(normalized);
                 break;
-
-            case "setWildcardPrefixes": {
-                java.util.List<String> prefixes = methodCall.argument("prefixes");
-                setWildcardPrefixes(prefixes);
-                result.success(null);
-                break;
-            }
-            case "getWildcardPrefixes": {
-                result.success(getWildcardPrefixes());
-                break;
-            }
         }
     }
 
@@ -646,33 +635,6 @@ public class MainActivity extends FlutterActivity {
         SharedPreferences prefs = getPreferences(context);
         int current = prefs.getInt("suspicious_calls_count", 0);
         prefs.edit().putInt("suspicious_calls_count", current + 1).apply();
-    }
-
-    /**
-     * Stores wildcard prefixes in SharedPreferences for CallChecker access.
-     */
-    private void setWildcardPrefixes(java.util.List<String> prefixes) {
-        SharedPreferences prefs = getPreferences(this);
-        JSONArray jsonArray = new JSONArray(prefixes);
-        prefs.edit().putString("wildcard_prefixes", jsonArray.toString()).apply();
-    }
-
-    /**
-     * Retrieves wildcard prefixes from SharedPreferences.
-     */
-    private java.util.List<String> getWildcardPrefixes() {
-        SharedPreferences prefs = getPreferences(this);
-        String json = prefs.getString("wildcard_prefixes", "[]");
-        try {
-            JSONArray jsonArray = new JSONArray(json);
-            java.util.List<String> result = new java.util.ArrayList<>();
-            for (int i = 0; i < jsonArray.length(); i++) {
-                result.add(jsonArray.getString(i));
-            }
-            return result;
-        } catch (JSONException e) {
-            return new java.util.ArrayList<>();
-        }
     }
 
     public static SharedPreferences getPreferences(Context context) {

--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -518,6 +518,67 @@ Future<bool> addWildcardToServer(String prefix, String authToken) async {
   }
 }
 
+/// Reconciles the local `wildcard_blocks` store with the server's wildcard set (#377).
+///
+/// The server is the source of truth; the local store exists only so the native
+/// [CallChecker] can match prefixes during call screening. The app's pre-existing local-only
+/// wildcards are lifted to the server once (migration); afterwards the local set mirrors the
+/// server, so wildcards added or removed on any of the user's devices propagate here.
+///
+/// Context-free (takes [authToken] explicitly) so it runs both from the UI and from the
+/// WorkManager background isolate. [serverWildcards] is the wildcard subset of the user's
+/// blacklist as returned by the API.
+Future<void> reconcileWildcards(List<api.PersonalizedNumber> serverWildcards, String authToken) async {
+  final db = ScreenedCallsDatabase.instance;
+  final prefs = await SharedPreferences.getInstance();
+
+  // One-time migration of the app's existing local-only wildcards to the server.
+  if (!(prefs.getBool('wildcards_migrated') ?? false)) {
+    final onServer = serverWildcards.map((w) => w.phone).toSet();
+    for (final local in await db.getAllWildcardBlocks()) {
+      if (!onServer.contains(local.prefix) && await addWildcardToServer(local.prefix, authToken)) {
+        serverWildcards.add(api.PersonalizedNumber(
+            phone: local.prefix, wildcard: true, created: local.created.millisecondsSinceEpoch));
+      }
+    }
+    await prefs.setBool('wildcards_migrated', true);
+  }
+
+  // Mirror the server set into the local store: add server-only, drop local-only.
+  final serverPrefixes = serverWildcards.map((w) => w.phone).toSet();
+  final local = await db.getAllWildcardBlocks();
+  final localPrefixes = local.map((w) => w.prefix).toSet();
+
+  for (final sw in serverWildcards) {
+    if (!localPrefixes.contains(sw.phone)) {
+      await db.insertWildcardBlock(WildcardBlock(
+        prefix: sw.phone,
+        comment: null,
+        created: sw.created > 0 ? DateTime.fromMillisecondsSinceEpoch(sw.created) : DateTime.now(),
+      ));
+    }
+  }
+  for (final lw in local) {
+    if (!serverPrefixes.contains(lw.prefix)) {
+      await db.deleteWildcardBlock(lw.id!);
+    }
+  }
+}
+
+/// Fetches the user's blacklist and reconciles its wildcard prefixes with the local store (#377).
+///
+/// Safe to call from the WorkManager background isolate (no [BuildContext], no MethodChannel).
+/// Returns false if the server could not be reached.
+Future<bool> syncPersonalWildcards(String authToken) async {
+  final numberList = await fetchBlacklist(authToken);
+  if (numberList == null) {
+    return false;
+  }
+  final serverWildcards = numberList.numbers.where((n) => n.wildcard).toList();
+  await reconcileWildcards(serverWildcards, authToken);
+  return true;
+}
+
 /// Removes a personal wildcard-prefix block from the server (#377).
 ///
 /// Returns true on success (HTTP 204). Requires authentication via [authToken].
@@ -557,7 +618,14 @@ void callbackDispatcher() {
       if (task == 'blocklistSync') {
         final packageInfo = await PackageInfo.fromPlatform();
         appVersion = packageInfo.version;
-        return await BlocklistSyncService.instance.sync();
+        final ok = await BlocklistSyncService.instance.sync();
+        // Also reconcile the user's personal wildcards (#377) so prefixes added on the
+        // website or another device take effect even if the blacklist page is never opened.
+        final authToken = await getAuthToken();
+        if (authToken != null && authToken.isNotEmpty) {
+          await syncPersonalWildcards(authToken);
+        }
+        return ok;
       }
       return Future.value(true);
     } catch (e, s) {
@@ -2888,12 +2956,6 @@ Future<void> registerBlocklistSync() async {
   );
 }
 
-/// Syncs wildcard prefixes from SQLite to SharedPreferences for CallChecker access.
-Future<void> syncWildcardPrefixesToNative() async {
-  final prefixes = await ScreenedCallsDatabase.instance.getWildcardPrefixes();
-  await platform.invokeMethod('setWildcardPrefixes', {'prefixes': prefixes});
-}
-
 Future<bool> checkPermission() async {
   try {
     return await platform.invokeMethod("checkPermission");
@@ -3955,7 +4017,7 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
 
         List<WildcardBlock> wildcards = [];
         if (_isBlacklist) {
-          await _syncWildcards(serverWildcards);
+          await reconcileWildcards(serverWildcards, widget.authToken);
           wildcards = await ScreenedCallsDatabase.instance.getAllWildcardBlocks();
         }
 
@@ -3977,51 +4039,6 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
         _isLoading = false;
       });
     }
-  }
-
-  /// Reconciles local wildcard blocks with the server (#377).
-  ///
-  /// The server is the source of truth; the local copy exists only so the native
-  /// CallScreeningService can block offline. The app's pre-existing local-only wildcards are
-  /// lifted to the server once (migration); afterwards the local set mirrors the server, so
-  /// wildcards added or removed on any of the user's devices propagate here.
-  Future<void> _syncWildcards(List<api.PersonalizedNumber> serverWildcards) async {
-    final db = ScreenedCallsDatabase.instance;
-    final prefs = await SharedPreferences.getInstance();
-
-    // One-time migration of the app's existing local-only wildcards to the server.
-    if (!(prefs.getBool('wildcards_migrated') ?? false)) {
-      final onServer = serverWildcards.map((w) => w.phone).toSet();
-      for (final local in await db.getAllWildcardBlocks()) {
-        if (!onServer.contains(local.prefix) && await addWildcardToServer(local.prefix, widget.authToken)) {
-          serverWildcards.add(api.PersonalizedNumber(
-              phone: local.prefix, wildcard: true, created: local.created.millisecondsSinceEpoch));
-        }
-      }
-      await prefs.setBool('wildcards_migrated', true);
-    }
-
-    // Mirror the server set into the local store: add server-only, drop local-only.
-    final serverPrefixes = serverWildcards.map((w) => w.phone).toSet();
-    final local = await db.getAllWildcardBlocks();
-    final localPrefixes = local.map((w) => w.prefix).toSet();
-
-    for (final sw in serverWildcards) {
-      if (!localPrefixes.contains(sw.phone)) {
-        await db.insertWildcardBlock(WildcardBlock(
-          prefix: sw.phone,
-          comment: null,
-          created: sw.created > 0 ? DateTime.fromMillisecondsSinceEpoch(sw.created) : DateTime.now(),
-        ));
-      }
-    }
-    for (final lw in local) {
-      if (!serverPrefixes.contains(lw.prefix)) {
-        await db.deleteWildcardBlock(lw.id!);
-      }
-    }
-
-    await syncWildcardPrefixesToNative();
   }
 
   /// Edit the comment for a number in the list.
@@ -4263,7 +4280,6 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
     );
 
     await ScreenedCallsDatabase.instance.insertWildcardBlock(block);
-    await syncWildcardPrefixesToNative();
     // Sync the wildcard to the server (#377) so the user's other devices honor it too.
     await addWildcardToServer(prefix, widget.authToken);
     await _loadNumbers();
@@ -4741,7 +4757,6 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
         if (confirmed != true) return false;
 
         await ScreenedCallsDatabase.instance.deleteWildcardBlock(block.id!);
-        await syncWildcardPrefixesToNative();
         // Remove the wildcard on the server too (#377), so the deletion propagates.
         await removeWildcardFromServer(block.prefix, widget.authToken);
 

--- a/phoneblock_mobile/lib/storage.dart
+++ b/phoneblock_mobile/lib/storage.dart
@@ -663,13 +663,6 @@ class ScreenedCallsDatabase {
     return maps.map((m) => WildcardBlock.fromMap(m)).toList();
   }
 
-  /// Returns all wildcard prefixes as a list of strings.
-  Future<List<String>> getWildcardPrefixes() async {
-    final db = await database;
-    final maps = await db.query('wildcard_blocks', columns: ['prefix'], orderBy: 'prefix ASC');
-    return maps.map((m) => m['prefix'] as String).toList();
-  }
-
   /// Updates the comment for a wildcard blocking rule.
   Future<int> updateWildcardBlockComment(int id, String comment) async {
     final db = await database;


### PR DESCRIPTION
## Problem

Persönliche Wildcard-Blocklist-Einträge (#377, `PERSONALIZATION.WILDCARD`) wurden in der App nur dann mit dem Server abgeglichen, wenn der Nutzer die Blacklist-Ansicht öffnete. Der tägliche WorkManager-Hintergrundtask synchronisierte ausschließlich die globale Community-Blocklist. Eine auf der Website (oder einem anderen Gerät) angelegte Wildcard erreichte das Handy also nur, wenn die Blacklist-Seite zufällig geöffnet wurde.

Der Server kann persönliche Prefix-Wildcards bei der anonymisierten SHA1-Online-Abfrage prinzipbedingt nicht prüfen — das Matching muss daher bei jedem Anruf lokal erfolgen (tat es bereits über den gemeinsamen `decideAndRespond`-Pfad), und der lokale Bestand muss aktuell gehalten werden.

Blocker für einen Hintergrund-Abgleich: Das WorkManager-Isolate hat keine Activity, daher konnte der bisherige Weg SQLite → SharedPreferences (`setWildcardPrefixes` via MethodChannel) → CallChecker dort nicht abschließen.

## Lösung

- **CallChecker liest Wildcard-Prefixe jetzt direkt aus der SQLite-Tabelle `wildcard_blocks`** (analog zum bestehenden `lookupLocalBlocklist`). SQLite ist damit die einzige Quelle und der MethodChannel-Umweg entfällt.
- **Der tägliche WorkManager-Task gleicht die persönlichen Wildcards mit ab** — über die neue kontextfreie `syncPersonalWildcards()`/`reconcileWildcards()`, ausgelagert aus der früheren State-Methode `_syncWildcards()`.
- **Toten Code entfernt**: `syncWildcardPrefixesToNative()`, die nativen `setWildcardPrefixes`/`getWildcardPrefixes`-Handler und -Methoden sowie den ungenutzten Dart-`getWildcardPrefixes()`-DB-Helper.

## Aktualität nach dieser Änderung

1. Blacklist-Ansicht öffnen → sofortiger Abgleich (bestehend, unverändert).
2. Täglicher Hintergrund-Task → gleicht jetzt ebenfalls ab (neu).

Bewusst **kein** Push-Trigger: Es bleibt ein Restfenster von bis zu ~24 h, falls der Nutzer die Ansicht nie öffnet und in diesem Zeitraum ein passender Anruf eingeht. Bei der niedrigen Frequenz persönlicher Wildcards ist das akzeptabel.

## Verifikation

- `flutter analyze` der geänderten Dart-Dateien: keine neuen Issues.
- `./gradlew :app:compileDebugJavaWithJavac`: erfolgreich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)