### PR TITLE
Denormalize published rating into BLOCKLIST to drop the per-row NUMBERS join

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -1749,9 +1749,10 @@ public class DB {
 			// Invalid number in DB, filter out.
 			return null;
 		}
-		Rating rating = e.getVotes() <= 0
-			? Rating.A_LEGITIMATE
-			: dominantCategory(e.getFraud(), e.getGamble(), e.getAdvertising(), e.getPoll(), e.getPing());
+		// Category is the dominant rating, frozen at publication and read
+		// straight from BLOCKLIST (migration 43). Tombstones (votes <= 0) carry
+		// no meaningful category and are reported as A_LEGITIMATE.
+		Rating rating = e.getVotes() <= 0 ? Rating.A_LEGITIMATE : e.getCategory();
 		return BlockListEntry.create()
 				.setPhone(number.getPlus())
 				.setVotes(e.getVotes())

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBBlocklistEntry.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DBBlocklistEntry.java
@@ -3,6 +3,8 @@
  */
 package de.haumacher.phoneblock.db;
 
+import de.haumacher.phoneblock.app.api.model.Rating;
+
 /**
  * One row of the published BLOCKLIST table (#342).
  *
@@ -11,10 +13,11 @@ package de.haumacher.phoneblock.db;
  * {@link #getHeat()} the log4 class of the activity EMA, both frozen at
  * publication time — independent of the read moment, unlike the decay-exposed
  * EMA columns on NUMBERS. {@code votes = 0} marks a tombstone: the removal
- * signal served to incremental-sync clients. The last activity and the
- * category counters are joined live from NUMBERS (zero for tombstones whose
- * NUMBERS row is gone); they are informational only — lastActivity for
- * display, the counters for the entry's rating.
+ * signal served to incremental-sync clients. {@link #getCategory()} (the
+ * dominant rating) and {@link #getLastPing()} (last activity) are likewise
+ * frozen at publication and denormalized onto BLOCKLIST (migration 43), so the
+ * sync reads need no live NUMBERS join; they are informational only — the
+ * rating colors the entry, lastActivity is for display.
  * </p>
  */
 public class DBBlocklistEntry {
@@ -27,39 +30,22 @@ public class DBBlocklistEntry {
 
 	private final long _lastPing;
 
-	private final int _legitimate;
+	private final Rating _category;
 
-	private final int _ping;
-
-	private final int _poll;
-
-	private final int _advertising;
-
-	private final int _gamble;
-
-	private final int _fraud;
-
-	private DBBlocklistEntry(String phone, int votes, int heat, long lastPing,
-			int legitimate, int ping, int poll, int advertising, int gamble, int fraud) {
+	private DBBlocklistEntry(String phone, int votes, int heat, long lastPing, Rating category) {
 		_phone = phone;
 		_votes = votes;
 		_heat = heat;
 		_lastPing = lastPing;
-		_legitimate = legitimate;
-		_ping = ping;
-		_poll = poll;
-		_advertising = advertising;
-		_gamble = gamble;
-		_fraud = fraud;
+		_category = category;
 	}
 
 	/**
-	 * Creates a {@link DBBlocklistEntry} for the API download: live last
-	 * activity and category counters, no Heat class.
+	 * Creates a {@link DBBlocklistEntry} for the API download: published last
+	 * activity and dominant category, no Heat class.
 	 */
-	public DBBlocklistEntry(String phone, int votes, long lastPing,
-			int legitimate, int ping, int poll, int advertising, int gamble, int fraud) {
-		this(phone, votes, 0, lastPing, legitimate, ping, poll, advertising, gamble, fraud);
+	public DBBlocklistEntry(String phone, int votes, long lastPing, Rating category) {
+		this(phone, votes, 0, lastPing, category);
 	}
 
 	/**
@@ -67,7 +53,7 @@ public class DBBlocklistEntry {
 	 * votes bucket and Heat class — nothing else is rendered.
 	 */
 	public DBBlocklistEntry(String phone, int votes, int heat) {
-		this(phone, votes, heat, 0, 0, 0, 0, 0, 0, 0);
+		this(phone, votes, heat, 0, null);
 	}
 
 	/** The number in PhoneBlock ID format (see NumberAnalyzer). */
@@ -85,39 +71,17 @@ public class DBBlocklistEntry {
 		return _heat;
 	}
 
-	/** Live last activity timestamp of the number. */
+	/** Published last activity timestamp of the number. */
 	public long getLastPing() {
 		return _lastPing;
 	}
 
-	/** Live {@code A_LEGITIMATE} rating count. */
-	public int getLegitimate() {
-		return _legitimate;
-	}
-
-	/** Live {@code C_PING} rating count. */
-	public int getPing() {
-		return _ping;
-	}
-
-	/** Live {@code D_POLL} rating count. */
-	public int getPoll() {
-		return _poll;
-	}
-
-	/** Live {@code E_ADVERTISING} rating count. */
-	public int getAdvertising() {
-		return _advertising;
-	}
-
-	/** Live {@code F_GAMBLE} rating count. */
-	public int getGamble() {
-		return _gamble;
-	}
-
-	/** Live {@code G_FRAUD} rating count. */
-	public int getFraud() {
-		return _fraud;
+	/**
+	 * The published dominant rating category, or {@code null} on the CardDAV
+	 * path (which does not render a category).
+	 */
+	public Rating getCategory() {
+		return _category;
 	}
 
 }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
@@ -387,22 +387,14 @@ public interface SpamReports {
 
 	/**
 	 * Full blocklist for {@code /api/blocklist} (#342): the published state
-	 * — bucket votes frozen at publication — filtered by the server-side
-	 * visibility threshold. The block decision data is stable between
-	 * sweeps; only the informational lastActivity and rating columns are
-	 * joined live (the API makes no caching promise).
+	 * — bucket votes, dominant category and last activity all frozen at
+	 * publication — filtered by the server-side visibility threshold. Reads
+	 * only BLOCKLIST; the category/activity snapshot is denormalized (migration
+	 * 43) so no per-row NUMBERS join is needed.
 	 */
 	@Select("""
-			select b.PHONE, b.VOTES,
-			       coalesce(s.LASTPING, 0) as LASTPING,
-			       coalesce(s.LEGITIMATE, 0) as LEGITIMATE,
-			       coalesce(s.PING, 0) as PING,
-			       coalesce(s.POLL, 0) as POLL,
-			       coalesce(s.ADVERTISING, 0) as ADVERTISING,
-			       coalesce(s.GAMBLE, 0) as GAMBLE,
-			       coalesce(s.FRAUD, 0) as FRAUD
+			select b.PHONE, b.VOTES, b.LASTPING, b.CATEGORY
 			from BLOCKLIST b
-			left join NUMBERS s on s.PHONE = b.PHONE
 			where b.VOTES >= #{minVotes}
 			order by b.PHONE
 			""")
@@ -827,14 +819,25 @@ public interface SpamReports {
 				     WHEN s.SPAM_EVIDENCE - s.LEGIT_EVIDENCE >= #{t20} THEN 20
 				     WHEN s.SPAM_EVIDENCE - s.LEGIT_EVIDENCE >= #{t10} THEN 10
 				     WHEN s.SPAM_EVIDENCE - s.LEGIT_EVIDENCE >= #{t4} THEN 4
-				     ELSE 2 END as VOTES
+				     ELSE 2 END as VOTES,
+				-- Dominant category, frozen here so the sync reads need no live
+				-- NUMBERS join. Mirrors DB.dominantCategory: argmax with tie
+				-- priority FRAUD > GAMBLE > ADVERTISING > POLL > PING, B_MISSED
+				-- when all counters are zero (the all-zero guard must be first).
+				CASE WHEN s.FRAUD = 0 AND s.GAMBLE = 0 AND s.ADVERTISING = 0 AND s.POLL = 0 AND s.PING = 0 THEN 'B_MISSED'
+				     WHEN s.FRAUD       >= s.GAMBLE AND s.FRAUD >= s.ADVERTISING AND s.FRAUD >= s.POLL AND s.FRAUD >= s.PING THEN 'G_FRAUD'
+				     WHEN s.GAMBLE      >= s.ADVERTISING AND s.GAMBLE >= s.POLL AND s.GAMBLE >= s.PING THEN 'F_GAMBLE'
+				     WHEN s.ADVERTISING >= s.POLL AND s.ADVERTISING >= s.PING THEN 'E_ADVERTISING'
+				     WHEN s.POLL        >= s.PING THEN 'D_POLL'
+				     ELSE 'C_PING' END as CATEGORY,
+				s.LASTPING as LASTPING
 			from NUMBERS s
 			where s.SPAM_EVIDENCE >= #{t2} and s.SPAM_EVIDENCE - s.LEGIT_EVIDENCE >= #{t2}
 		) n on b.PHONE = n.PHONE
 		when matched and b.VOTES <> n.VOTES then update set
-			VOTES = n.VOTES, VERSION = #{version}
-		when not matched then insert (PHONE, VOTES, VERSION)
-			values (n.PHONE, n.VOTES, #{version})
+			VOTES = n.VOTES, VERSION = #{version}, CATEGORY = n.CATEGORY, LASTPING = n.LASTPING
+		when not matched then insert (PHONE, VOTES, VERSION, CATEGORY, LASTPING)
+			values (n.PHONE, n.VOTES, #{version}, n.CATEGORY, n.LASTPING)
 		""")
 	int publishBlocklistUpdates(long version,
 		double t2, double t4, double t10, double t20, double t50, double t100);
@@ -912,23 +915,17 @@ public interface SpamReports {
 	/**
 	 * Gets all blocklist changes since the given version (#342).
 	 *
-	 * <p>Returns the frozen published state: bucket votes and the activity
-	 * timestamp as of publication. Tombstones ({@code votes = 0}) signal
-	 * removals. Category counters are joined live from NUMBERS — they only
-	 * color the entry's rating; the left join keeps tombstones alive after a
-	 * hard delete of the NUMBERS row (#341).</p>
+	 * <p>Returns the frozen published state: bucket votes, dominant category and
+	 * the activity timestamp as of publication. Tombstones ({@code votes = 0})
+	 * signal removals. Reads only BLOCKLIST — the category and activity are
+	 * denormalized columns (migration 43), so this hot incremental-sync path no
+	 * longer joins the wide NUMBERS table once per row. The category is frozen
+	 * at publication (refreshed on the next vote-bucket flip), consistent with
+	 * the already-frozen votes; it only colors the entry's rating.</p>
 	 */
 	@Select("""
-		select b.PHONE, b.VOTES,
-		       coalesce(s.LASTPING, 0) as LASTPING,
-		       coalesce(s.LEGITIMATE, 0) as LEGITIMATE,
-		       coalesce(s.PING, 0) as PING,
-		       coalesce(s.POLL, 0) as POLL,
-		       coalesce(s.ADVERTISING, 0) as ADVERTISING,
-		       coalesce(s.GAMBLE, 0) as GAMBLE,
-		       coalesce(s.FRAUD, 0) as FRAUD
+		select b.PHONE, b.VOTES, b.LASTPING, b.CATEGORY
 		from BLOCKLIST b
-		left join NUMBERS s on s.PHONE = b.PHONE
 		where b.VERSION > #{sinceVersion}
 		order by b.VERSION, b.PHONE
 		""")

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/db-migration-43.sql
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/db-migration-43.sql
@@ -1,0 +1,26 @@
+-- Denormalize the published rating into BLOCKLIST so the incremental-sync and
+-- full-sync reads (getBlocklistChangesSince / getBlocklist) no longer LEFT JOIN
+-- the wide NUMBERS table once per row. A blocklist API entry carries only a
+-- single rating (the dominant category) plus the last-activity timestamp, so we
+-- store exactly those two columns -- not the seven raw category counters. Both
+-- are frozen at publication time (written by the publication sweep), matching
+-- the already-frozen VOTES bucket.
+ALTER TABLE BLOCKLIST ADD CATEGORY CHARACTER VARYING(15) DEFAULT 'B_MISSED' NOT NULL;
+ALTER TABLE BLOCKLIST ADD LASTPING BIGINT DEFAULT 0 NOT NULL;
+
+-- One-time backfill from NUMBERS, reproducing DB.dominantCategory: the argmax
+-- over the category counters with tie priority FRAUD > GAMBLE > ADVERTISING >
+-- POLL > PING, falling back to B_MISSED when every counter is zero. The all-zero
+-- guard must come first -- otherwise FRAUD >= every-other-zero would wrongly win
+-- 'G_FRAUD'. Tombstones (no NUMBERS row) keep the column defaults.
+UPDATE BLOCKLIST b SET
+  LASTPING = COALESCE((select s.LASTPING from NUMBERS s where s.PHONE = b.PHONE), 0),
+  CATEGORY = COALESCE((select
+      CASE WHEN s.FRAUD = 0 AND s.GAMBLE = 0 AND s.ADVERTISING = 0 AND s.POLL = 0 AND s.PING = 0 THEN 'B_MISSED'
+           WHEN s.FRAUD       >= s.GAMBLE AND s.FRAUD >= s.ADVERTISING AND s.FRAUD >= s.POLL AND s.FRAUD >= s.PING THEN 'G_FRAUD'
+           WHEN s.GAMBLE      >= s.ADVERTISING AND s.GAMBLE >= s.POLL AND s.GAMBLE >= s.PING THEN 'F_GAMBLE'
+           WHEN s.ADVERTISING >= s.POLL AND s.ADVERTISING >= s.PING THEN 'E_ADVERTISING'
+           WHEN s.POLL        >= s.PING THEN 'D_POLL'
+           ELSE 'C_PING' END
+      from NUMBERS s where s.PHONE = b.PHONE), 'B_MISSED')
+where exists (select 1 from NUMBERS s where s.PHONE = b.PHONE);

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/db-schema.sql
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/db-schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE PROPERTIES (
 	CONSTRAINT PROPERTIES_PK PRIMARY KEY (NAME)
 );
 
-INSERT INTO PROPERTIES (NAME, VAL) VALUES('db.version', '42');
+INSERT INTO PROPERTIES (NAME, VAL) VALUES('db.version', '43');
 INSERT INTO PROPERTIES (NAME, VAL) VALUES('blocklist.version', '1');
 
 
@@ -66,6 +66,12 @@ CREATE TABLE BLOCKLIST (
 	PHONE CHARACTER VARYING(100) NOT NULL,
 	VOTES INTEGER NOT NULL,
 	VERSION BIGINT NOT NULL,
+	-- Published rating snapshot (frozen at publication, like VOTES): the
+	-- dominant category as a Rating enum name (e.g. 'G_FRAUD'), and the last
+	-- activity timestamp. Denormalized so the sync reads need no live NUMBERS
+	-- join per row; a blocklist API entry exposes only this single rating.
+	CATEGORY CHARACTER VARYING(15) DEFAULT 'B_MISSED' NOT NULL,
+	LASTPING BIGINT DEFAULT 0 NOT NULL,
 	CONSTRAINT BLOCKLIST_PK PRIMARY KEY (PHONE)
 );
 


### PR DESCRIPTION
## Problem

The blocklist sync reads (`getBlocklistChangesSince`, `getBlocklist`) `LEFT JOIN`ed the wide `NUMBERS` table **once per result row** to fetch seven category counters plus the last-activity timestamp, then collapsed the counters to a single dominant rating (`DB.dominantCategory`). For a large delta (e.g. an old `?since=`), this is N random `getRow`s into the ~20-column `NUMBERS` rows scattered across the 1.5 GB store — CPU-bound page deserialization that dominates the query cost. Thread dumps of the live server showed exactly this: `http-nio` workers RUNNABLE in `MVPrimaryIndex.getRow` → `RowDataType.read` while serving `/api/blocklist?since=`.

## Change

A blocklist API entry only ever exposes **one** rating plus `lastActivity`. So instead of carrying the seven raw counters, store exactly those two as **frozen snapshot columns** on `BLOCKLIST`:

- `CATEGORY VARCHAR(15)` — the dominant rating as a `Rating` enum name (`'G_FRAUD'`, …), matching the existing `COMMENTS.RATING` / `FTC_SUBJECTS.RATING` convention (default MyBatis enum mapping, no custom handler).
- `LASTPING BIGINT` — last activity.

The publication sweep (`publishBlocklistUpdates`) computes the dominant category in SQL — a `CASE` mirroring `DB.dominantCategory` (argmax with tie priority `FRAUD > GAMBLE > ADVERTISING > POLL > PING`, `B_MISSED` when all counters are zero) — and writes it alongside `VOTES`. The sync reads become a pure `BLOCKLIST` scan over `BLOCKLIST_VERSION_IDX` with **no `NUMBERS` access**.

`dominantCategory` stays — it is still used for the `DBNumberInfo` (`/api/check`) path.

## Trade-off

The category is now **frozen at publication** (refreshed on the next vote-bucket flip) rather than joined live, consistent with the already-frozen `VOTES`. It only colors the entry's rating, so the slight staleness is acceptable.

## Migration

`db-migration-43.sql` adds the two columns and backfills them from `NUMBERS` using the same `CASE`; `db.version` → 43.

## Verification

- Build green.
- 68 tests pass, incl. `TestIncrementalBlocklist` (9) — validates the full publish→sync round-trip including the category and the MyBatis constructor mapping to `Rating`, against the fresh schema. The publish `CASE` (identical to the backfill `CASE`) is therefore exercised.
- **Not covered by tests:** the upgrade path itself (migration 43 against an existing v42 DB). The backfill `UPDATE` is standard H2 and the `CASE` is validated via the MERGE tests, but recommend running it once against a DB copy before production; the backfill is a one-time full pass over `BLOCKLIST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)