### PR TITLE
Avoid history-snapshot runaway: correlated EXISTS instead of PHONE IN

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
@@ -755,6 +755,24 @@ public interface SpamReports {
 			""")
 	String nextHistoryBatchBound(long lastSnapshot, String fromPhone, int batchSize);
 
+	/**
+	 * Closes the currently open history generation ({@code RMAX = 0x7fffffff}) of every active number
+	 * in the batch, so {@link #createHistorySnapshot} can open a fresh generation for them.
+	 *
+	 * <p>
+	 * The "is active" criterion lives in {@code NUMBERS}, so the update on {@code NUMBERS_HISTORY}
+	 * must correlate to that table. This is expressed as a correlated {@code EXISTS} rather than
+	 * {@code PHONE IN (subquery)} on purpose: the {@code IN} form let H2's cost-based optimizer flip
+	 * to a full {@code NUMBERS_HISTORY} scan once the table had grown large enough, turning a
+	 * batch-sized update into a multi-hour, CPU-bound statement that pinned old MVStore page versions.
+	 * The {@code EXISTS} correlation pins {@code s.PHONE} to the row at hand, so H2 probes the
+	 * {@code NUMBERS} primary key per matched history row instead of materializing the whole active
+	 * set. The outer {@code PHONE} range still bounds the scan to the batch; no inner range is needed
+	 * because the correlation already points at a single number. The outer {@code PHONE} must be
+	 * fully qualified — an unqualified reference would bind to {@code NUMBERS.PHONE} inside the
+	 * subquery and make the predicate trivially true.
+	 * </p>
+	 */
 	@Update("""
 			update NUMBERS_HISTORY
 			set
@@ -762,8 +780,8 @@ public interface SpamReports {
 			where
 				RMAX = 0x7fffffff and
 				PHONE > #{fromPhone} and PHONE <= #{toPhone} and
-				PHONE in (select s.PHONE from NUMBERS s
-					where s.LASTPING > #{lastSnapshot} and s.PHONE > #{fromPhone} and s.PHONE <= #{toPhone})
+				exists (select 1 from NUMBERS s
+					where s.PHONE = NUMBERS_HISTORY.PHONE and s.LASTPING > #{lastSnapshot})
 			""")
 	int outdateHistorySnapshot(int rev, long lastSnapshot, String fromPhone, String toPhone);
 


### PR DESCRIPTION
## Problem

The nightly history-snapshot job (`DB.updateHistory`, scheduled at 00:00) was observed running a single `update NUMBERS_HISTORY` statement for 8+ hours. The statement (`SpamReports.outdateHistorySnapshot`) closed the open history generation of active numbers via:

```sql
... PHONE in (select s.PHONE from NUMBERS s where s.LASTPING > ? and ...)
```

Once `NUMBERS_HISTORY` had grown large, this `IN (subquery)` form let H2 materialize the entire active set per batch instead of probing per row. A `DBHealthMonitor` snapshot showed the statement pinning old MVStore page versions (`oldestVersionToKeep` frozen far behind `currentVersion`), so dead chunks could not be reclaimed and the database file grew to ~1.8 GB at `chunksFillRate=27%`.

## Change

Rewrite the predicate as a correlated `EXISTS` pinned to `NUMBERS_HISTORY.PHONE`, so H2 probes the `NUMBERS` primary key per matched history row instead of materializing the whole active set:

```sql
... and exists (select 1 from NUMBERS s
                where s.PHONE = NUMBERS_HISTORY.PHONE and s.LASTPING > ?)
```

The inner `PHONE` range becomes redundant (the correlation points at a single number) and is dropped; the outer `PHONE` range still bounds the batch. The outer `PHONE` is fully qualified so it cannot bind to `NUMBERS.PHONE` inside the subquery.

`createHistorySnapshot` is left unchanged — it already selects directly from `NUMBERS` over the `PHONE` index and never scans `NUMBERS_HISTORY`.

## Measurement

On real data (`EXPLAIN ANALYZE` of the equivalent count), the `IN` form read **~1,005,768 rows** (847k of them a materialized `NUMBERS` set per evaluation); the `EXISTS` form read **~104,959** (a single PK point-lookup per matched row) and completed markedly faster. More importantly, `EXISTS` cost is bounded by the batch's outer rows, not by the active-set size — so it cannot blow up on a night with a stale watermark.

## Caveat

With the current data + literal parameters, even the old `IN` plan used the PK; the runaway plan could not be reproduced post-recovery. The fix is a plan-stability hardening (removes the optimizer's freedom to materialize/scan) backed by the measured read counts, not a reproduced plan flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)