### PR TITLE
mobile: stop blocklist-sync retry storm — don't retry on failure

### DIFF
--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -557,7 +557,16 @@ void callbackDispatcher() {
       if (task == 'blocklistSync') {
         final packageInfo = await PackageInfo.fromPlatform();
         appVersion = packageInfo.version;
-        return await BlocklistSyncService.instance.sync();
+        // Fire-and-forget: a failed sync must NOT cause WorkManager to retry.
+        // Returning sync()'s `false` maps to Result.retry, which re-issues the
+        // same `?since=<version>` request within minutes. A sync that keeps
+        // failing (e.g. a slow or truncated response that never advances the
+        // stored version) then becomes a tight retry loop hammering the
+        // server's expensive blocklist-delta query. There is nothing to gain
+        // from an immediate retry: the next periodic run tries again, and once
+        // the server responds normally the sync recovers on its own.
+        await BlocklistSyncService.instance.sync();
+        return true;
       }
       return Future.value(true);
     } catch (e, s) {


### PR DESCRIPTION
## Problem

A device stuck at an old blocklist version was observed hammering `GET /api/blocklist?since=56` ~350×/hour (every ~10 s), each forcing an expensive server-side delta scan. Server-side app logs identified it as a single mobile client (`PhoneBlockMobile/1.3.1`).

Root cause in the app: the WorkManager callback returned `sync()`'s `false` on failure, which the `workmanager` plugin maps to `Result.retry` → WorkManager re-issues the same `?since=<version>` request within minutes. Because the stored version is only advanced inside the success-path SQLite transaction (which also increments `syncCount`), any failure leaves both frozen — so the "full resync every 40 syncs" safety net never fires either, and the device retries the same `since` forever. Combined with a slow/large response, this is a self-reinforcing (metastable) retry storm.

## Change

Return success from the WorkManager callback regardless of the sync outcome, so a failed sync simply waits for the next periodic (24 h) run instead of retrying immediately. From ~350/h per device down to ~1/day; once the server responds normally the sync recovers on its own.

Per the discussion: an immediate retry buys nothing — an old `since` is not cheaper than a full sync (`since=0` is a strict superset of `since=N`), so retrying just repeats the same heavy query.

## Scope

This only helps **future** app versions; devices already on 1.3.1 in the field keep retrying until they update. Server-side protection for the `/api/blocklist?since=` endpoint (caching + rate limit) is still needed for the existing fleet and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)