### PR TITLE
Dongle: feed task watchdog during TR-064 provisioning; raise TWDT to 120 s

### DIFF
--- a/phoneblock-dongle/firmware/main/tr064.c
+++ b/phoneblock-dongle/firmware/main/tr064.c
@@ -10,6 +10,7 @@
 #include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "esp_task_wdt.h"
 #include "mbedtls/md5.h"
 
 #include "config.h"
@@ -107,6 +108,17 @@ static esp_err_t post_soap(const char *url, const char *soap_action,
 {
     esp_err_t err    = ESP_FAIL;
     int       status = 0;
+
+    // Provisioning issues one SOAP call per existing telephony client
+    // (find_client_slot loops X_AVM-DE_GetClient3), all synchronously on
+    // the httpd worker. A slow Fritz!Box can stretch that chain past the
+    // task-watchdog window, and the httpd WDT feeder (web.c) can't run
+    // while the worker is busy here — so the worker would trip the
+    // watchdog. Feed it once per SOAP call: each post_soap is bounded by
+    // the 5 s HTTP timeout, so a genuinely wedged single call is still
+    // caught, while a legitimately long multi-call sequence completes.
+    // No-op (guarded) on tasks that aren't watchdog-subscribed.
+    if (esp_task_wdt_status(NULL) == ESP_OK) esp_task_wdt_reset();
 
     // ESP_ERR_HTTP_CONNECT here often means lwip's socket pool is
     // momentarily exhausted (browser polling /api/status in parallel

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -109,10 +109,14 @@ CONFIG_ESP_COREDUMP_CHECK_BOOT=y
 # panic path, which then writes a coredump to flash (see above) and
 # reboots — exactly what we want for diagnostics.
 #
-# Timeout 20 s: the worst single-iteration cost in sip_task is one
-# phoneblock_check (10 s budget) plus one do_register (10 s TLS
-# budget) back-to-back on a reload path. 20 s leaves headroom
-# without sitting on a freeze for ages.
+# Timeout 120 s: the watchdog is a last-resort catch for a genuinely
+# wedged task, not a tight per-iteration budget. The worst legitimate
+# single-iteration cost in sip_task (one phoneblock_check + one
+# do_register, ~10 s each) and the TR-064 provisioning chain that
+# fans one SOAP call per Fritz!Box telephony client (each bounded by
+# the 5 s HTTP timeout) both sum well under this. A generous ceiling
+# keeps a slow-but-progressing operation from tripping a false panic;
+# the individual operations carry their own tighter timeouts.
 #
 # IDLE_TASK_CPU0/CPU1 keep the default IDF behaviour of watching
 # the idle tasks too, so a runaway high-priority task that starves
@@ -120,7 +124,7 @@ CONFIG_ESP_COREDUMP_CHECK_BOOT=y
 CONFIG_ESP_TASK_WDT_EN=y
 CONFIG_ESP_TASK_WDT_INIT=y
 CONFIG_ESP_TASK_WDT_PANIC=y
-CONFIG_ESP_TASK_WDT_TIMEOUT_S=20
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=120
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=y
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=y
 


### PR DESCRIPTION
## Problem

A 1.3.3 field coredump showed the `httpd` worker tripping the **task watchdog** (not a real crash — httpd stack 4848/3328 used/free is healthy). The worker was wedged synchronously in:

```
handle_fritzbox_setup            web.c:755
└ tr064_provision_sip_client     tr064.c
  └ find_client_slot                       ← loops one SOAP call per telephony client
    └ get_num_clients / GetClient3
      └ post_soap                          ← esp_http_client_perform, blocked in socket recv
```

`find_client_slot` fans **one `X_AVM-DE_GetClient3` SOAP call per existing Fritz!Box telephony client**, all synchronously on the httpd worker. On a slow Fritz!Box that chain outlasts the 20 s watchdog window, and the httpd WDT feeder (`web.c`) can't run while the worker is busy — so the deliberate wedge-detector panics.

## Fix

1. **`tr064.c`** — feed the watchdog once per SOAP call in `post_soap`, guarded with `esp_task_wdt_status(NULL) == ESP_OK` (no-op on non-subscribed tasks; same pattern as `sip_register.c:529`). Each `post_soap` is bounded by the 5 s HTTP timeout, so a genuinely wedged single call is still caught, while a legitimately long multi-call sequence completes.
2. **`sdkconfig.defaults`** — raise `CONFIG_ESP_TASK_WDT_TIMEOUT_S` 20 → 120. The watchdog is a last-resort catch for a wedged task, not a tight per-iteration budget; individual operations carry their own tighter timeouts, so a generous ceiling avoids false panics on slow-but-progressing work.

Build verified green (`idf.py build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)