### PR TITLE
Dongle: SRTP support — direct Telekom registration takes calls

### DIFF
--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -241,7 +241,7 @@ void config_load(void)
         s_config.sip_authuser[0]  = '\0';
         s_config.sip_outbound[0]  = '\0';
         s_config.sip_realm[0]     = '\0';
-        copy_default(s_config.sip_srtp,   sizeof(s_config.sip_srtp),   "off");
+        copy_default(s_config.sip_srtp,   sizeof(s_config.sip_srtp),   "optional");
         s_config.fb_app_user[0]   = '\0';
         s_config.fb_app_pass[0]   = '\0';
         s_config.sync_enabled[0]  = '\0';
@@ -297,7 +297,7 @@ void config_load(void)
              s_config.sip_outbound, sizeof(s_config.sip_outbound));
     load_str(h, K_SIP_REALM,    "",
              s_config.sip_realm,    sizeof(s_config.sip_realm));
-    load_str(h, K_SIP_SRTP,     "off",
+    load_str(h, K_SIP_SRTP,     "optional",
              s_config.sip_srtp,     sizeof(s_config.sip_srtp));
     load_str(h, K_FB_APP_USER,  "",
              s_config.fb_app_user,  sizeof(s_config.fb_app_user));
@@ -370,7 +370,7 @@ const char *config_sip_transport(void)       { return s_config.sip_transp[0] ? s
 const char *config_sip_auth_user(void)       { return s_config.sip_authuser; }
 const char *config_sip_outbound(void)        { return s_config.sip_outbound; }
 const char *config_sip_realm(void)           { return s_config.sip_realm; }
-const char *config_sip_srtp(void)            { return s_config.sip_srtp[0] ? s_config.sip_srtp : "off"; }
+const char *config_sip_srtp(void)            { return s_config.sip_srtp[0] ? s_config.sip_srtp : "optional"; }
 const char *config_fritzbox_app_user(void)   { return s_config.fb_app_user; }
 const char *config_fritzbox_app_pass(void)   { return s_config.fb_app_pass; }
 bool        config_sync_enabled(void)

--- a/phoneblock-dongle/firmware/main/idf_component.yml
+++ b/phoneblock-dongle/firmware/main/idf_component.yml
@@ -1,3 +1,4 @@
 dependencies:
   espressif/mdns: "^1.3.0"
+  espressif/esp_libsrtp: "^1.0.0"
   idf: ">=5.3"

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -36,6 +36,30 @@ char log_capture_level(const char *line)
     return is_level(c) ? c : '\0';
 }
 
+// Largest length <= len whose prefix ends on a UTF-8 character boundary.
+// A hard byte-truncation at msg_cap can cut a multibyte sequence — an
+// arrow in our own messages, or an umlaut in an external string like a
+// SIP display name — leaving a dangling continuation byte. That byte is
+// invalid UTF-8, which makes the /api/errors JSON unparseable and breaks
+// the web "Protokoll" panel. Drop any incomplete trailing character.
+static size_t utf8_trim(const char *s, size_t len)
+{
+    if (len == 0) return 0;
+    // Walk back over trailing continuation bytes (10xxxxxx) to the lead.
+    size_t i = len, cont = 0;
+    while (i > 0 && ((unsigned char)s[i - 1] & 0xC0) == 0x80) { i--; cont++; }
+    if (i == 0) return len;            // no lead byte in range — leave as-is
+    unsigned char lead = (unsigned char)s[i - 1];
+    size_t need;
+    if      (lead < 0x80)           need = 1;   // ASCII
+    else if ((lead & 0xE0) == 0xC0) need = 2;
+    else if ((lead & 0xF0) == 0xE0) need = 3;
+    else if ((lead & 0xF8) == 0xF0) need = 4;
+    else                            need = 1;   // invalid lead byte
+    if (cont + 1 == need) return len;  // trailing character is complete
+    return i - 1;                       // drop the incomplete trailing char
+}
+
 char log_capture_parse(const char *line,
                        char *tag, size_t tag_cap,
                        char *msg, size_t msg_cap)
@@ -71,6 +95,7 @@ char log_capture_parse(const char *line,
         while (*end && *end != '\n' && *end != '\033') end++;
         size_t mlen = (size_t)(end - m);
         if (mlen >= msg_cap) mlen = msg_cap - 1;
+        mlen = utf8_trim(m, mlen);
         memcpy(msg, m, mlen);
         msg[mlen] = '\0';
     }

--- a/phoneblock-dongle/firmware/main/report_queue.c
+++ b/phoneblock-dongle/firmware/main/report_queue.c
@@ -9,6 +9,7 @@
 #include "esp_log.h"
 
 #include "api.h"
+#include "rtp.h"
 
 static const char *TAG = "report_q";
 
@@ -37,6 +38,22 @@ static void report_worker_task(void *arg)
     while (1) {
         report_entry_t e;
         if (xQueueReceive(s_queue, &e, portMAX_DELAY) != pdTRUE) continue;
+
+        // Defer the report's TLS handshake until any in-progress
+        // announcement has finished. Running a second TLS session next to
+        // the SRTP media stream exhausts the ESP32 heap (RTP sendto fails
+        // with ENOMEM, mbedTLS cert parse OOMs, httpd-task watchdog
+        // reboot). The report is enqueued at SPAM detection, before the
+        // ACK that starts streaming, so first give the stream up to ~2 s
+        // to start (a quick no-announcement call falls through), then wait
+        // it out — capped so a stuck flag can't wedge the worker forever.
+        for (int i = 0; i < 40 && !rtp_streaming_active(); i++) {
+            vTaskDelay(pdMS_TO_TICKS(50));
+        }
+        for (int i = 0; i < 300 && rtp_streaming_active(); i++) {
+            vTaskDelay(pdMS_TO_TICKS(100));
+        }
+
         ESP_LOGI(TAG, "report-call %s", e.phone);
         // phoneblock_report_call logs its own failures (ERROR), which the
         // log hook mirrors to the web UI — nothing to do here on failure.

--- a/phoneblock-dongle/firmware/main/rtp.c
+++ b/phoneblock-dongle/firmware/main/rtp.c
@@ -13,6 +13,8 @@
 
 #include "config.h"
 
+#include "srtp.h"
+
 static const char *TAG = "rtp";
 
 #define FRAME_SAMPLES    160          // 20 ms at 8 kHz
@@ -28,11 +30,50 @@ static volatile bool s_abort = false;
 typedef struct {
     struct sockaddr_in dest;
     announcement_src_t src;
+    rtp_srtp_tx_t      srtp;
 } rtp_args_t;
 
 void rtp_request_abort(void)
 {
     s_abort = true;
+}
+
+// libsrtp requires a one-time global init before any session is created.
+// Guard it so repeated calls (one per spam call) don't re-init.
+static bool srtp_global_init(void)
+{
+    static bool inited = false;
+    if (inited) return true;
+    srtp_err_status_t st = srtp_init();
+    if (st != srtp_err_status_ok) {
+        ESP_LOGE(TAG, "srtp_init failed: %d", st);
+        return false;
+    }
+    inited = true;
+    return true;
+}
+
+// Create an outbound-only SRTP session keyed with the SDES master key/salt
+// we advertised in the SDP answer. Returns NULL on failure.
+static srtp_t srtp_open_tx(const rtp_srtp_tx_t *keys)
+{
+    if (!srtp_global_init()) return NULL;
+
+    srtp_policy_t policy;
+    memset(&policy, 0, sizeof(policy));
+    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&policy.rtp);
+    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(&policy.rtcp);
+    policy.ssrc.type = ssrc_any_outbound;
+    policy.key       = (uint8_t *)keys->key;   // 30 bytes, not retained by libsrtp after create
+    policy.next      = NULL;
+
+    srtp_t session = NULL;
+    srtp_err_status_t st = srtp_create(&session, &policy);
+    if (st != srtp_err_status_ok) {
+        ESP_LOGE(TAG, "srtp_create failed: %d", st);
+        return NULL;
+    }
+    return session;
 }
 
 static void rtp_audio_task(void *arg)
@@ -59,6 +100,19 @@ static void rtp_audio_task(void *arg)
         goto done;
     }
 
+    // Set up SRTP if the SDP answer advertised RTP/SAVP. If session
+    // creation fails we cannot send anything the remote will accept
+    // (it expects encrypted media), so abort the stream.
+    srtp_t srtp_session = NULL;
+    if (a->srtp.enabled) {
+        srtp_session = srtp_open_tx(&a->srtp);
+        if (!srtp_session) {
+            ESP_LOGE(TAG, "SRTP requested but session setup failed — no audio");
+            close(sock);
+            goto done;
+        }
+    }
+
     uint16_t seq       = (uint16_t)esp_random();
     uint32_t timestamp = esp_random();
     uint32_t ssrc      = esp_random();
@@ -66,12 +120,15 @@ static void rtp_audio_task(void *arg)
     size_t total_frames = (a->src.len + FRAME_SAMPLES - 1) / FRAME_SAMPLES;
     char ip[INET_ADDRSTRLEN];
     inet_ntoa_r(a->dest.sin_addr, ip, sizeof(ip));
-    ESP_LOGI(TAG, "stream %u bytes (%u frames ≈ %u ms) → %s:%d, ssrc=%08lx",
+    ESP_LOGI(TAG, "stream %u bytes (%u frames ≈ %u ms) → %s:%d, ssrc=%08lx%s",
              (unsigned)a->src.len, (unsigned)total_frames,
              (unsigned)(total_frames * 20),
-             ip, ntohs(a->dest.sin_port), (unsigned long)ssrc);
+             ip, ntohs(a->dest.sin_port), (unsigned long)ssrc,
+             srtp_session ? " (SRTP)" : "");
 
     uint8_t pkt[RTP_HEADER_BYTES + FRAME_BYTES];
+    // SRTP appends an auth tag (10 bytes for HMAC_SHA1_80); leave room.
+    uint8_t txbuf[RTP_HEADER_BYTES + FRAME_BYTES + SRTP_MAX_TRAILER_LEN];
 
     TickType_t next = xTaskGetTickCount();
     for (size_t frame = 0; frame < total_frames; frame++) {
@@ -104,7 +161,25 @@ static void rtp_audio_task(void *arg)
         pkt[10] = (uint8_t)(ssrc >> 8);
         pkt[11] = (uint8_t)(ssrc);
 
-        int n = sendto(sock, pkt, RTP_HEADER_BYTES + FRAME_SAMPLES, 0,
+        const uint8_t *send_buf = pkt;
+        size_t send_len = RTP_HEADER_BYTES + FRAME_SAMPLES;
+        if (srtp_session) {
+            size_t out_len = sizeof(txbuf);
+            srtp_err_status_t st = srtp_protect(srtp_session, pkt,
+                                                RTP_HEADER_BYTES + FRAME_SAMPLES,
+                                                txbuf, &out_len, 0);
+            if (st != srtp_err_status_ok) {
+                ESP_LOGW(TAG, "srtp_protect failed: %d", st);
+                seq++;
+                timestamp += FRAME_SAMPLES;
+                vTaskDelayUntil(&next, pdMS_TO_TICKS(20));
+                continue;
+            }
+            send_buf = txbuf;
+            send_len = out_len;
+        }
+
+        int n = sendto(sock, send_buf, send_len, 0,
                        (struct sockaddr *)&a->dest, sizeof(a->dest));
         if (n < 0) {
             ESP_LOGW(TAG, "rtp sendto: %s", strerror(errno));
@@ -116,6 +191,7 @@ static void rtp_audio_task(void *arg)
     }
 
     ESP_LOGI(TAG, "stream finished");
+    if (srtp_session) srtp_dealloc(srtp_session);
     close(sock);
 
 done:
@@ -125,7 +201,8 @@ done:
 }
 
 void rtp_play_audio(const struct sockaddr_in *dest,
-                    announcement_src_t *src)
+                    announcement_src_t *src,
+                    const rtp_srtp_tx_t *srtp)
 {
     rtp_args_t *args = malloc(sizeof(*args));
     if (!args) {
@@ -135,8 +212,15 @@ void rtp_play_audio(const struct sockaddr_in *dest,
     }
     args->dest = *dest;
     args->src  = *src;   // ownership (incl. open file handle) moves to the task
+    if (srtp) {
+        args->srtp = *srtp;
+    } else {
+        args->srtp.enabled = false;
+    }
     s_abort = false;
-    if (xTaskCreate(rtp_audio_task, "rtp_audio", 4096, args, 6, NULL) != pdPASS) {
+    // 6 KB stack: SRTP AES key-expansion + per-packet protect needs more
+    // headroom than the old plain-RTP 4 KB.
+    if (xTaskCreate(rtp_audio_task, "rtp_audio", 6144, args, 6, NULL) != pdPASS) {
         ESP_LOGE(TAG, "xTaskCreate failed");
         announcement_close(&args->src);
         free(args);

--- a/phoneblock-dongle/firmware/main/rtp.c
+++ b/phoneblock-dongle/firmware/main/rtp.c
@@ -27,6 +27,20 @@ static const char *TAG = "rtp";
 // sip_register.c — set by SIP task, polled by RTP task per frame.
 static volatile bool s_abort = false;
 
+// True while an announcement is being streamed. The report-call worker
+// polls this so its TLS handshake doesn't run concurrently with the SRTP
+// stream — two TLS sessions plus the libsrtp session exhaust the ESP32
+// heap (lwIP "Not enough space" on RTP sendto + mbedTLS PK-parse OOM,
+// then an httpd-task watchdog reboot). Set in rtp_play_audio before the
+// task starts (so there's no enqueue/stream-start race) and cleared when
+// the task exits.
+static volatile bool s_streaming = false;
+
+bool rtp_streaming_active(void)
+{
+    return s_streaming;
+}
+
 typedef struct {
     struct sockaddr_in dest;
     announcement_src_t src;
@@ -197,6 +211,7 @@ static void rtp_audio_task(void *arg)
 done:
     announcement_close(&a->src);
     free(a);
+    s_streaming = false;
     vTaskDelete(NULL);
 }
 
@@ -218,10 +233,13 @@ void rtp_play_audio(const struct sockaddr_in *dest,
         args->srtp.enabled = false;
     }
     s_abort = false;
+    s_streaming = true;   // set before task start so the report worker can't
+                          // race in between enqueue and stream start
     // 6 KB stack: SRTP AES key-expansion + per-packet protect needs more
     // headroom than the old plain-RTP 4 KB.
     if (xTaskCreate(rtp_audio_task, "rtp_audio", 6144, args, 6, NULL) != pdPASS) {
         ESP_LOGE(TAG, "xTaskCreate failed");
+        s_streaming = false;
         announcement_close(&args->src);
         free(args);
     }

--- a/phoneblock-dongle/firmware/main/rtp.h
+++ b/phoneblock-dongle/firmware/main/rtp.h
@@ -45,3 +45,9 @@ void rtp_play_audio(const struct sockaddr_in *dest,
 // streaming — no point making the new caller wait through 5–15 s of
 // our own audio. Safe to call when no streaming task is active.
 void rtp_request_abort(void);
+
+// True from just before an announcement stream starts until the
+// streaming task exits. The report-call worker waits on this so its TLS
+// handshake never overlaps the SRTP media stream (combined heap use
+// crashes the ESP32). Safe to call from any task.
+bool rtp_streaming_active(void);

--- a/phoneblock-dongle/firmware/main/rtp.h
+++ b/phoneblock-dongle/firmware/main/rtp.h
@@ -9,18 +9,35 @@
 // The UDP port the dongle binds for RTP audio is configurable via
 // config_rtp_port() (default 16000); the SDP advertises the same value.
 
+// SDES master key (16 bytes) + master salt (14 bytes) for the
+// AES_CM_128_HMAC_SHA1_80 SRTP suite. When `enabled`, rtp_play_audio
+// encrypts every outbound packet as SRTP using this key; otherwise it
+// sends plain RTP/AVP.
+#define RTP_SRTP_KEY_LEN 30
+typedef struct {
+    bool    enabled;
+    uint8_t key[RTP_SRTP_KEY_LEN];
+} rtp_srtp_tx_t;
+
 // Spawn a FreeRTOS task that streams the opened announcement `src` to
 // `dest` as G.711 A-law (PCMA) RTP, 20 ms / 160-byte frames at 50
 // packets/s, then exits. The task reads `src` frame-by-frame (so a
 // custom SPIFFS announcement is streamed straight from flash, never
 // buffered whole) and closes it when done.
 //
+// If `srtp` is non-NULL and srtp->enabled, the outbound stream is
+// protected as SRTP (AES_CM_128_HMAC_SHA1_80) with the given master key;
+// the SDP answer must have advertised RTP/SAVP with the matching key.
+// Pass NULL (or enabled=false) for plain RTP/AVP. The struct is copied,
+// so the caller need not keep it alive.
+//
 // Fire-and-forget: ownership of `src` (including its open file handle)
 // is handed to the task — the caller must NOT close it afterwards.
 // Even on failure to spawn, this releases `src`, so the caller is
 // always relieved of it.
 void rtp_play_audio(const struct sockaddr_in *dest,
-                    announcement_src_t *src);
+                    announcement_src_t *src,
+                    const rtp_srtp_tx_t *srtp);
 
 // Signal an in-flight rtp_play_audio task to stop at the next 20 ms
 // frame boundary. Used by the SIP task to preempt the announcement

--- a/phoneblock-dongle/firmware/main/sip_parse.c
+++ b/phoneblock-dongle/firmware/main/sip_parse.c
@@ -385,3 +385,73 @@ int parse_sdp_audio_port(const char *msg, int msg_len)
     }
     return port;
 }
+
+int parse_sdp_audio_savp(const char *msg, int msg_len)
+{
+    const char *p = find_sdp_line(msg, msg_len, "m=audio ");
+    if (!p) return 0;
+    const char *end = msg + msg_len;
+    // Skip the port number and the single space after it.
+    while (p < end && *p >= '0' && *p <= '9') p++;
+    while (p < end && *p == ' ') p++;
+    // The transport is the next whitespace-delimited token.
+    return (size_t)(end - p) >= 8 && strncmp(p, "RTP/SAVP", 8) == 0;
+}
+
+int parse_sdp_crypto(const char *msg, int msg_len, char *key_b64, int cap)
+{
+    if (key_b64 && cap > 0) key_b64[0] = '\0';
+
+    const char *p = msg;
+    const char *end = msg + msg_len;
+    bool at_line_start = true;
+    while (p < end) {
+        if (at_line_start && (size_t)(end - p) >= 9
+            && strncmp(p, "a=crypto:", 9) == 0) {
+            const char *q = p + 9;
+            // Bound the scan to this single line.
+            const char *eol = q;
+            while (eol < end && *eol != '\r' && *eol != '\n') eol++;
+
+            // Parse the crypto tag (decimal).
+            int tag = 0;
+            bool saw_digit = false;
+            while (q < eol && *q >= '0' && *q <= '9') {
+                tag = tag * 10 + (*q - '0');
+                saw_digit = true;
+                q++;
+            }
+            // One space, then the crypto-suite token.
+            if (saw_digit && tag > 0 && q < eol && *q == ' ') {
+                q++;
+                const char suite[] = "AES_CM_128_HMAC_SHA1_80";
+                size_t slen = sizeof(suite) - 1;
+                if ((size_t)(eol - q) >= slen
+                    && strncmp(q, suite, slen) == 0
+                    && (q[slen] == ' ' || q + slen == eol)) {
+                    // Supported suite. Extract the inline: key parameter.
+                    for (const char *r = q; r + 7 <= eol; r++) {
+                        if (strncmp(r, "inline:", 7) == 0) {
+                            r += 7;
+                            int n = 0;
+                            // The inline value ends at '|' (lifetime/MKI),
+                            // whitespace, or end of line.
+                            while (r < eol && *r != '|' && *r != ' '
+                                   && *r != '\t' && key_b64 && n < cap - 1) {
+                                key_b64[n++] = *r++;
+                            }
+                            if (key_b64 && cap > 0) key_b64[n] = '\0';
+                            break;
+                        }
+                    }
+                    return tag;
+                }
+            }
+            p = eol;
+            continue;
+        }
+        at_line_start = (*p == '\n');
+        p++;
+    }
+    return 0;
+}

--- a/phoneblock-dongle/firmware/main/sip_parse.h
+++ b/phoneblock-dongle/firmware/main/sip_parse.h
@@ -123,3 +123,16 @@ void parse_sdp_connection_ip(const char *msg, int msg_len, char *out, int cap);
 // Extract the RTP port from the SDP "m=audio <port> …" line. Returns 0
 // if the line is absent or malformed.
 int parse_sdp_audio_port(const char *msg, int msg_len);
+
+// True if the SDP "m=audio" line advertises the secure RTP/SAVP transport
+// profile (as opposed to plain RTP/AVP). Telekom's IMS offers RTP/SAVP and
+// rejects a plain RTP/AVP answer.
+int parse_sdp_audio_savp(const char *msg, int msg_len);
+
+// Scan the SDP for the first "a=crypto:" line offering the
+// AES_CM_128_HMAC_SHA1_80 SDES suite with an inline: key. On success
+// returns the crypto tag (a positive integer that the SRTP answer must
+// echo) and copies the base64 inline key (without any trailing
+// "|lifetime|MKI" parameters) into key_b64. Returns 0 — and clears
+// key_b64 — when no supported crypto suite is offered.
+int parse_sdp_crypto(const char *msg, int msg_len, char *key_b64, int cap);

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -931,25 +931,24 @@ static void capture_dialog(sip_ctx_t *c, const char *req, int req_len,
     }
 
     // SRTP negotiation. Telekom (and other IMS networks) offer RTP/SAVP
-    // with SDES a=crypto keys and reject a plain RTP/AVP answer. If the
-    // INVITE offers a crypto suite we support, mirror it: answer SAVP and
-    // generate our own master key/salt to encrypt the announcement. The
-    // sip_srtp config knob is an escape hatch: "off" forces plain RTP.
+    // with SDES a=crypto keys and reject a plain RTP/AVP answer. Whenever
+    // the INVITE offers a crypto suite we support we mirror it: answer
+    // RTP/SAVP and generate our own master key/salt to encrypt the
+    // announcement. There is no good reason to answer plaintext to a
+    // crypto offer (it just gets the dialog torn down), so this is not
+    // gated on a config knob — a plain RTP/AVP offer (e.g. the Fritz!Box
+    // on the LAN) simply carries no crypto and is answered RTP/AVP.
     d->srtp_tx  = false;
     d->srtp_tag = 0;
     char remote_key_b64[64];
     int crypto_tag = parse_sdp_crypto(req, req_len,
                                       remote_key_b64, sizeof(remote_key_b64));
-    bool srtp_off = strcmp(config_sip_srtp(), "off") == 0;
-    if (crypto_tag > 0 && !srtp_off) {
+    if (crypto_tag > 0) {
         // Generate a fresh 30-byte SDES master key + salt.
         esp_fill_random(d->srtp_tx_key, sizeof(d->srtp_tx_key));
         d->srtp_tx  = true;
         d->srtp_tag = crypto_tag;
         ESP_LOGI(TAG, "SRTP offered (crypto tag %d) → answering RTP/SAVP", crypto_tag);
-    } else if (crypto_tag > 0) {
-        ESP_LOGW(TAG, "SRTP offered but sip_srtp=off — answering plain RTP "
-                      "(call media will likely be rejected)");
     } else if (parse_sdp_audio_savp(req, req_len)) {
         ESP_LOGW(TAG, "remote offers RTP/SAVP but no supported crypto suite "
                       "— answering plain RTP (media will likely be rejected)");

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -14,6 +14,7 @@
 #include "esp_task_wdt.h"
 #include "esp_timer.h"
 #include "mbedtls/md5.h"
+#include "mbedtls/base64.h"
 
 #include "lwip/sockets.h"
 
@@ -87,6 +88,9 @@ typedef struct {
     struct sockaddr_in peer;      // where to send in-dialog responses/requests
     struct sockaddr_in rtp_dest;  // remote RTP endpoint (from INVITE SDP)
     bool     rtp_dest_valid;      // true if we successfully parsed c= / m=
+    bool     srtp_tx;             // true → answer/stream as SRTP (RTP/SAVP)
+    int      srtp_tag;            // crypto tag to echo in the SDP answer
+    uint8_t  srtp_tx_key[RTP_SRTP_KEY_LEN];  // our SDES master key+salt
     int64_t  bye_at_us;           // abs. deadline for the next timed dialog
                                   // action (send BYE after a tone, or send the
                                   // delayed 480 while PROCEEDING); 0 = none
@@ -838,18 +842,38 @@ static void send_response(sip_ctx_t *c, const struct sockaddr_in *peer,
 
 // Write a minimal SDP body announcing PCMA audio on our local RTP port.
 // The RTP task binds that port just-in-time and streams a tone there.
-static int build_sdp_body(const char *our_ip, char *out, int cap)
+// When the dialog negotiated SRTP (d->srtp_tx), the media line uses the
+// secure RTP/SAVP profile and carries our SDES key in an a=crypto line
+// echoing the offer's crypto tag; otherwise it stays plain RTP/AVP.
+static int build_sdp_body(const char *our_ip, const dialog_t *d,
+                          char *out, int cap)
 {
-    return snprintf(out, cap,
+    int n = snprintf(out, cap,
         "v=0\r\n"
         "o=phoneblock-dongle 0 0 IN IP4 %s\r\n"
         "s=-\r\n"
         "c=IN IP4 %s\r\n"
         "t=0 0\r\n"
-        "m=audio %d RTP/AVP 8\r\n"
-        "a=rtpmap:8 PCMA/8000\r\n"
-        "a=sendrecv\r\n",
-        our_ip, our_ip, config_rtp_port());
+        "m=audio %d RTP/%s 8\r\n"
+        "a=rtpmap:8 PCMA/8000\r\n",
+        our_ip, our_ip, config_rtp_port(),
+        (d && d->srtp_tx) ? "SAVP" : "AVP");
+
+    if (d && d->srtp_tx) {
+        // base64 of 30 bytes is 40 chars + NUL.
+        char key_b64[48];
+        size_t b64_len = 0;
+        if (mbedtls_base64_encode((unsigned char *)key_b64, sizeof(key_b64),
+                                  &b64_len, d->srtp_tx_key,
+                                  RTP_SRTP_KEY_LEN) == 0) {
+            n += snprintf(out + n, cap - n,
+                "a=crypto:%d AES_CM_128_HMAC_SHA1_80 inline:%.*s\r\n",
+                d->srtp_tag, (int)b64_len, key_b64);
+        }
+    }
+
+    n += snprintf(out + n, cap - n, "a=sendrecv\r\n");
+    return n;
 }
 
 // ---------------------------------------------------------------------------
@@ -904,6 +928,31 @@ static void capture_dialog(sip_ctx_t *c, const char *req, int req_len,
     }
     if (!d->rtp_dest_valid) {
         ESP_LOGW(TAG, "could not parse remote RTP endpoint — no tone will play");
+    }
+
+    // SRTP negotiation. Telekom (and other IMS networks) offer RTP/SAVP
+    // with SDES a=crypto keys and reject a plain RTP/AVP answer. If the
+    // INVITE offers a crypto suite we support, mirror it: answer SAVP and
+    // generate our own master key/salt to encrypt the announcement. The
+    // sip_srtp config knob is an escape hatch: "off" forces plain RTP.
+    d->srtp_tx  = false;
+    d->srtp_tag = 0;
+    char remote_key_b64[64];
+    int crypto_tag = parse_sdp_crypto(req, req_len,
+                                      remote_key_b64, sizeof(remote_key_b64));
+    bool srtp_off = strcmp(config_sip_srtp(), "off") == 0;
+    if (crypto_tag > 0 && !srtp_off) {
+        // Generate a fresh 30-byte SDES master key + salt.
+        esp_fill_random(d->srtp_tx_key, sizeof(d->srtp_tx_key));
+        d->srtp_tx  = true;
+        d->srtp_tag = crypto_tag;
+        ESP_LOGI(TAG, "SRTP offered (crypto tag %d) → answering RTP/SAVP", crypto_tag);
+    } else if (crypto_tag > 0) {
+        ESP_LOGW(TAG, "SRTP offered but sip_srtp=off — answering plain RTP "
+                      "(call media will likely be rejected)");
+    } else if (parse_sdp_audio_savp(req, req_len)) {
+        ESP_LOGW(TAG, "remote offers RTP/SAVP but no supported crypto suite "
+                      "— answering plain RTP (media will likely be rejected)");
     }
 }
 
@@ -1082,8 +1131,8 @@ static void resend_last_response(sip_ctx_t *c, const char *req, int req_len,
             break;
         case DIALOG_ANSWERED:
         case DIALOG_STREAMING: {
-            char sdp[256];
-            build_sdp_body(advertised_host(c), sdp, sizeof(sdp));
+            char sdp[384];
+            build_sdp_body(advertised_host(c), d, sdp, sizeof(sdp));
             send_response(c, from, req, req_len, 200, "OK",
                           d->our_tag, sdp);
             break;
@@ -1176,8 +1225,8 @@ static void handle_invite(sip_ctx_t *c, const char *req, int req_len,
     d->verdict = check_invite_caller(req, req_len);
 
     if (d->verdict == VERDICT_SPAM) {
-        char sdp[256];
-        build_sdp_body(advertised_host(c), sdp, sizeof(sdp));
+        char sdp[384];
+        build_sdp_body(advertised_host(c), d, sdp, sizeof(sdp));
         send_response(c, from, req, req_len, 200, "OK", d->our_tag, sdp);
         d->state = DIALOG_ANSWERED;
         d->bye_at_us = 0;   // not a decline-delay; BYE deadline is set after ACK
@@ -1220,7 +1269,11 @@ static void handle_ack(sip_ctx_t *c, const char *req, int req_len,
             int64_t duration_us = (int64_t)src.len * 125LL;
             ESP_LOGI(TAG, "ACK received → streaming announcement (%u bytes ≈ %lld ms), then BYE",
                      (unsigned)src.len, (long long)(duration_us / 1000));
-            rtp_play_audio(&d->rtp_dest, &src);   // task owns src now, closes it
+            rtp_srtp_tx_t srtp = { .enabled = d->srtp_tx };
+            if (d->srtp_tx) {
+                memcpy(srtp.key, d->srtp_tx_key, sizeof(srtp.key));
+            }
+            rtp_play_audio(&d->rtp_dest, &src, &srtp);   // task owns src now, closes it
             d->bye_at_us = esp_timer_get_time() + duration_us + 200000LL;
             d->state = DIALOG_STREAMING;
         } else {
@@ -1439,22 +1492,11 @@ static void sip_task(void *arg)
                  tr);
         ESP_LOGW(TAG, "%s", msg);
     }
-    // TLS protects only the signaling. Without SRTP (Phase 5) the audio
-    // path is still RTP/AVP cleartext on UDP/RTP. Surface that visibly
-    // so users do not have a false sense of end-to-end encryption.
-    if (strcmp(tr, "tls") == 0) {
-        const char *msg =
-            "TLS active but RTP is still plaintext (SRTP arrives in Phase 5)";
-        ESP_LOGW(TAG, "%s", msg);
-    }
-    if (strcmp(config_sip_srtp(), "off") != 0
-        && strcmp(config_sip_srtp(), "") != 0) {
-        char msg[80];
-        snprintf(msg, sizeof(msg),
-                 "SRTP %.12s ignored — firmware only does plain RTP",
-                 config_sip_srtp());
-        ESP_LOGW(TAG, "%s", msg);
-    }
+    // SRTP is negotiated per call from the INVITE's a=crypto offer (see
+    // capture_dialog): the dongle answers RTP/SAVP and encrypts the
+    // announcement whenever the caller offers a supported suite, unless
+    // sip_srtp is explicitly "off". There is nothing to warn about at
+    // registration time — the media profile depends on each offer.
     const int retry_delay_s = 30;
     char *rx = NULL;
     int64_t refresh_at_us = 0;  // absolute deadline for next REGISTER (microseconds)

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -92,7 +92,9 @@ typedef struct {
     int      srtp_tag;            // crypto tag to echo in the SDP answer
     uint8_t  srtp_tx_key[RTP_SRTP_KEY_LEN];  // our SDES master key+salt
     char     contact_uri[200];    // INVITE Contact = remote target (BYE R-URI)
-    char     route[200];          // INVITE Record-Route, echoed as BYE Route
+    char     route[320];          // INVITE Record-Route, echoed as BYE Route
+                                  // (Telekom's IMS token URI is ~211 chars;
+                                  // truncation produced a malformed Route → 400)
     int64_t  bye_at_us;           // abs. deadline for the next timed dialog
                                   // action (send BYE after a tone, or send the
                                   // delayed 480 while PROCEEDING); 0 = none
@@ -925,12 +927,20 @@ static void capture_dialog(sip_ctx_t *c, const char *req, int req_len,
     }
     // Record-Route (single hop for Telekom). Stored verbatim and echoed as a
     // Route header on our BYE for loose routing (the entry carries ;lr).
+    // A value too long for the buffer must NOT be stored truncated — a
+    // half a URI is a malformed Route header and gets the BYE rejected
+    // with 400; better to send no Route (481, delayed teardown) than that.
     d->route[0] = '\0';
     const char *rr = find_header(req, req_len, "Record-Route");
     if (rr) {
         const char *eol = rr;
         while (eol < end && *eol != '\r' && *eol != '\n') eol++;
-        header_value(rr, eol, d->route, sizeof(d->route));
+        if ((size_t)(eol - rr) < sizeof(d->route)) {
+            header_value(rr, eol, d->route, sizeof(d->route));
+        } else {
+            ESP_LOGW(TAG, "Record-Route too long (%d) — BYE sent without Route",
+                     (int)(eol - rr));
+        }
     }
 
     random_hex(d->our_tag, 16);
@@ -1007,7 +1017,7 @@ static int build_bye(sip_ctx_t *c, char *buf, int cap)
                  d->remote_uri, uri_param);
     }
 
-    char route_hdr[224];
+    char route_hdr[sizeof(d->route) + 16];
     if (d->route[0]) {
         snprintf(route_hdr, sizeof(route_hdr), "Route: %s\r\n", d->route);
     } else {

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -91,6 +91,8 @@ typedef struct {
     bool     srtp_tx;             // true → answer/stream as SRTP (RTP/SAVP)
     int      srtp_tag;            // crypto tag to echo in the SDP answer
     uint8_t  srtp_tx_key[RTP_SRTP_KEY_LEN];  // our SDES master key+salt
+    char     contact_uri[200];    // INVITE Contact = remote target (BYE R-URI)
+    char     route[200];          // INVITE Record-Route, echoed as BYE Route
     int64_t  bye_at_us;           // abs. deadline for the next timed dialog
                                   // action (send BYE after a tone, or send the
                                   // delayed 480 while PROCEEDING); 0 = none
@@ -897,14 +899,38 @@ static void capture_dialog(sip_ctx_t *c, const char *req, int req_len,
     d->invite_len = req_len < SIP_INVITE_STORE_CAP ? req_len : SIP_INVITE_STORE_CAP;
     memcpy(d->invite_msg, req, d->invite_len);
 
+    const char *end = req + req_len;
+
     const char *hdr = find_header(req, req_len, "From");
     if (hdr) {
-        const char *end = req + req_len;
         const char *eol = hdr;
         while (eol < end && *eol != '\r' && *eol != '\n') eol++;
         int val_len = (int)(eol - hdr);
         parse_uri(hdr, val_len, d->remote_uri, sizeof(d->remote_uri));
         parse_tag(hdr, val_len, d->from_tag, sizeof(d->from_tag));
+    }
+
+    // Remote target + route set for in-dialog requests (our BYE). Telekom's
+    // IMS routes in-dialog requests by the INVITE Contact (which carries an
+    // opaque "mavodi-…" routing token) and the Record-Route; addressing the
+    // BYE to the From AOR instead returns 481 Call Leg Does Not Exist and a
+    // ~10 s delayed teardown. Falls back to the From URI when absent (e.g.
+    // the Fritz!Box, where Contact == AOR works either way).
+    d->contact_uri[0] = '\0';
+    const char *ct = find_header(req, req_len, "Contact");
+    if (ct) {
+        const char *eol = ct;
+        while (eol < end && *eol != '\r' && *eol != '\n') eol++;
+        parse_uri(ct, (int)(eol - ct), d->contact_uri, sizeof(d->contact_uri));
+    }
+    // Record-Route (single hop for Telekom). Stored verbatim and echoed as a
+    // Route header on our BYE for loose routing (the entry carries ;lr).
+    d->route[0] = '\0';
+    const char *rr = find_header(req, req_len, "Record-Route");
+    if (rr) {
+        const char *eol = rr;
+        while (eol < end && *eol != '\r' && *eol != '\n') eol++;
+        header_value(rr, eol, d->route, sizeof(d->route));
     }
 
     random_hex(d->our_tag, 16);
@@ -965,21 +991,33 @@ static int build_bye(sip_ctx_t *c, char *buf, int cap)
     const char *our_host = advertised_host(c);
     int our_port = advertised_port();
 
-    // For non-UDP transports, the in-dialog R-URI carries an explicit
-    // ";transport=<tcp|tls>" so the registrar/UA on the other side
-    // doesn't fall back to UDP for our BYE.
+    // In-dialog R-URI = the remote target, i.e. the INVITE's Contact URI
+    // (carries the IMS routing token). Fall back to the From AOR when the
+    // INVITE had no Contact. For the AOR fallback on non-UDP transports we
+    // append ";transport=…" so the peer doesn't drop to UDP; the Contact
+    // path is loose-routed via the Route header below, so it's used as-is.
     const char *uri_param = sip_transport_uri_param(c->transport);
-    char ruri[160];
-    if (strcmp(uri_param, "udp") == 0) {
+    char ruri[200];
+    if (d->contact_uri[0]) {
+        snprintf(ruri, sizeof(ruri), "%s", d->contact_uri);
+    } else if (strcmp(uri_param, "udp") == 0) {
         snprintf(ruri, sizeof(ruri), "%s", d->remote_uri);
     } else {
         snprintf(ruri, sizeof(ruri), "%s;transport=%s",
                  d->remote_uri, uri_param);
     }
 
+    char route_hdr[224];
+    if (d->route[0]) {
+        snprintf(route_hdr, sizeof(route_hdr), "Route: %s\r\n", d->route);
+    } else {
+        route_hdr[0] = '\0';
+    }
+
     return snprintf(buf, cap,
         "BYE %s SIP/2.0\r\n"
         "Via: SIP/2.0/%s %s:%d;branch=z9hG4bK%s;rport\r\n"
+        "%s"
         "Max-Forwards: 70\r\n"
         "From: <sip:%s@%s:%d>;tag=%s\r\n"
         "To: <%s>;tag=%s\r\n"
@@ -991,6 +1029,7 @@ static int build_bye(sip_ctx_t *c, char *buf, int cap)
         ruri,
         sip_transport_via_token(c->transport),
         our_host, our_port, branch,
+        route_hdr,
         current_identity_user(), advertised_host(c), our_port, d->our_tag,
         d->remote_uri, d->from_tag,
         d->call_id,

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -348,7 +348,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Leer = aus Challenge übernehmen.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Derzeit deaktiviert, Feld wird persistiert für spätere Nutzung.',
+    'sip.manual.srtp.hint': 'Wird automatisch ausgehandelt. „optional“ verschlüsselt die Sprache, wenn der Anbieter es anbietet (z. B. Telekom); „aus“ erzwingt unverschlüsseltes RTP.',
     'sip.manual.local_port': 'Lokaler SIP-Port',
     'sip.manual.local_port.hint': 'Port, auf dem der Dongle SIP empfängt (Standard 15060). Leer = Standard.',
     'sip.manual.rtp_port': 'RTP-Port (Audio)',
@@ -595,7 +595,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Empty = take from the server challenge.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Currently disabled; the field is persisted for later use.',
+    'sip.manual.srtp.hint': 'Negotiated automatically. “optional” encrypts the media when the provider offers it (e.g. Telekom); “off” forces plain RTP.',
     'sip.manual.local_port': 'Local SIP port',
     'sip.manual.local_port.hint': 'Port the dongle receives SIP on (default 15060). Empty = default.',
     'sip.manual.rtp_port': 'RTP port (audio)',
@@ -830,7 +830,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vide = reprendre la valeur du challenge du serveur.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Actuellement désactivé ; le champ est persisté pour un usage ultérieur.',
+    'sip.manual.srtp.hint': 'Négocié automatiquement. « optionnel » chiffre le média si le fournisseur le propose (p. ex. Telekom) ; « désactivé » force le RTP en clair.',
     'sip.manual.local_port': 'Port SIP local',
     'sip.manual.local_port.hint': 'Port sur lequel le dongle reçoit le SIP (défaut 15060). Vide = défaut.',
     'sip.manual.rtp_port': 'Port RTP (audio)',
@@ -1065,7 +1065,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vacío = tomarlo del challenge del servidor.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Actualmente desactivado; el campo se guarda para uso futuro.',
+    'sip.manual.srtp.hint': 'Se negocia automáticamente. «opcional» cifra el audio cuando el proveedor lo ofrece (p. ej. Telekom); «desactivado» fuerza RTP sin cifrar.',
     'sip.manual.local_port': 'Puerto SIP local',
     'sip.manual.local_port.hint': 'Puerto en el que el dongle recibe SIP (predeterminado 15060). Vacío = predeterminado.',
     'sip.manual.rtp_port': 'Puerto RTP (audio)',
@@ -2862,7 +2862,7 @@ async function renderSipManual(){
   const au    = sip.auth_user || '';
   const outb  = sip.outbound  || '';
   const realm = sip.realm     || '';
-  const srtp  = sip.srtp      || 'off';
+  const srtp  = sip.srtp      || 'optional';
   // No stored password ⇒ pre-tick "anonymous", so the saved state stays
   // visible on reload (the password itself is never sent to the client).
   const passSet = !!sip.pass_set;

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -348,7 +348,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Leer = aus Challenge übernehmen.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Wird automatisch ausgehandelt. „optional“ verschlüsselt die Sprache, wenn der Anbieter es anbietet (z. B. Telekom); „aus“ erzwingt unverschlüsseltes RTP.',
+    'sip.manual.srtp.hint': 'SRTP wird automatisch ausgehandelt: Sprache wird verschlüsselt, sobald der Anbieter es anbietet (z. B. Telekom), sonst unverschlüsseltes RTP (z. B. Fritz!Box im LAN).',
     'sip.manual.local_port': 'Lokaler SIP-Port',
     'sip.manual.local_port.hint': 'Port, auf dem der Dongle SIP empfängt (Standard 15060). Leer = Standard.',
     'sip.manual.rtp_port': 'RTP-Port (Audio)',
@@ -595,7 +595,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Empty = take from the server challenge.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Negotiated automatically. “optional” encrypts the media when the provider offers it (e.g. Telekom); “off” forces plain RTP.',
+    'sip.manual.srtp.hint': 'SRTP is negotiated automatically: media is encrypted whenever the provider offers it (e.g. Telekom), otherwise plain RTP (e.g. the Fritz!Box on the LAN).',
     'sip.manual.local_port': 'Local SIP port',
     'sip.manual.local_port.hint': 'Port the dongle receives SIP on (default 15060). Empty = default.',
     'sip.manual.rtp_port': 'RTP port (audio)',
@@ -830,7 +830,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vide = reprendre la valeur du challenge du serveur.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Négocié automatiquement. « optionnel » chiffre le média si le fournisseur le propose (p. ex. Telekom) ; « désactivé » force le RTP en clair.',
+    'sip.manual.srtp.hint': 'Le SRTP est négocié automatiquement : le média est chiffré dès que le fournisseur le propose (p. ex. Telekom), sinon RTP en clair (p. ex. la Fritz!Box sur le LAN).',
     'sip.manual.local_port': 'Port SIP local',
     'sip.manual.local_port.hint': 'Port sur lequel le dongle reçoit le SIP (défaut 15060). Vide = défaut.',
     'sip.manual.rtp_port': 'Port RTP (audio)',
@@ -1065,7 +1065,7 @@ const I18N = {
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vacío = tomarlo del challenge del servidor.',
     'sip.manual.srtp': 'SRTP',
-    'sip.manual.srtp.hint': 'Se negocia automáticamente. «opcional» cifra el audio cuando el proveedor lo ofrece (p. ej. Telekom); «desactivado» fuerza RTP sin cifrar.',
+    'sip.manual.srtp.hint': 'El SRTP se negocia automáticamente: el audio se cifra cuando el proveedor lo ofrece (p. ej. Telekom); de lo contrario, RTP sin cifrar (p. ej. la Fritz!Box en la LAN).',
     'sip.manual.local_port': 'Puerto SIP local',
     'sip.manual.local_port.hint': 'Puerto en el que el dongle recibe SIP (predeterminado 15060). Vacío = predeterminado.',
     'sip.manual.rtp_port': 'Puerto RTP (audio)',
@@ -2825,7 +2825,6 @@ async function onProviderSubmit(e){
   body.append('sip_auth_user', p.authUser || '');
   body.append('sip_outbound', '');
   body.append('sip_realm', '');
-  body.append('sip_srtp', 'off');
   try {
     const r = await fetch('/api/config', {
       method: 'POST',
@@ -2862,7 +2861,6 @@ async function renderSipManual(){
   const au    = sip.auth_user || '';
   const outb  = sip.outbound  || '';
   const realm = sip.realm     || '';
-  const srtp  = sip.srtp      || 'optional';
   // No stored password ⇒ pre-tick "anonymous", so the saved state stays
   // visible on reload (the password itself is never sent to the client).
   const passSet = !!sip.pass_set;
@@ -2919,12 +2917,6 @@ async function renderSipManual(){
     +     '<input type="text" name="sip_realm" value="' + esc(realm) + '"></label>'
     +   '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
     +     esc(t('sip.manual.realm.hint')) + '</p>'
-    +   '<label>' + esc(t('sip.manual.srtp'))
-    +     '<select name="sip_srtp">'
-    +       opt('off',       srtp, t('sip.manual.srtp.off'))
-    +     + opt('optional',  srtp, t('sip.manual.srtp.optional'))
-    +     + opt('mandatory', srtp, t('sip.manual.srtp.mandatory'))
-    +     '</select></label>'
     +   '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
     +     esc(t('sip.manual.srtp.hint')) + '</p>'
     +   '<label>' + esc(t('sip.manual.local_port'))

--- a/phoneblock-dongle/firmware/release-notes/1.4.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.4.0.md
@@ -1,0 +1,31 @@
+# PhoneBlock Dongle 1.4.0
+
+*2026-06-19*
+
+## Added
+
+- **Encrypted call audio (SRTP) — direct registration at Telekom now
+  takes spam calls.** Providers like Deutsche Telekom only offer their
+  voice media encrypted (SRTP) and reject an unencrypted answer. Until
+  now the dongle registered fine over such a connection but could not
+  actually pick up: the call dropped the moment the announcement should
+  have started. The dongle now negotiates SRTP automatically — whenever
+  the provider offers encrypted media, the announcement is played
+  encrypted; on a plain connection (e.g. the Fritz!Box on your home
+  network) it stays unencrypted as before. No setting to change: the
+  former "SRTP" option in the manual SIP setup is gone, the dongle picks
+  the right mode per call.
+
+## Fixed
+
+- **Spam calls now hang up immediately after the announcement.** On a
+  direct Telekom connection the dongle's own "hang up" was not accepted
+  by the network, so the line stayed connected for about ten extra
+  seconds until the provider timed it out. The dongle now ends the call
+  correctly the instant the announcement finishes.
+
+- **No more reboot during a Telekom spam call.** Playing the encrypted
+  announcement while simultaneously reporting the call to PhoneBlock used
+  more memory than the device had, which could reboot it mid-call. The
+  call report is now sent after the announcement has finished, so the two
+  no longer compete for memory.

--- a/phoneblock-dongle/firmware/test/test_log_capture.c
+++ b/phoneblock-dongle/firmware/test/test_log_capture.c
@@ -111,6 +111,22 @@ int main(void)
         CHECK_STR ("trunc/msg", "long", msg);
     }
 
+    // --- truncation must not split a multibyte UTF-8 character ----------
+    // A byte-cut through "→" (E2 86 92) would leave a dangling continuation
+    // byte — invalid UTF-8 that makes the /api/errors JSON unparseable.
+    // The incomplete trailing character must be dropped.
+    {
+        char tag[8], msg[5];   // 4 usable bytes: the cut lands inside "→"
+        log_capture_parse("I (1) t: ab→cd", tag, sizeof(tag), msg, sizeof(msg));
+        CHECK_STR("utf8-trunc/msg", "ab", msg);
+    }
+    // A complete multibyte character that still fits is kept intact.
+    {
+        char tag[8], msg[6];   // 5 usable bytes: "ab" + the 3-byte "→"
+        log_capture_parse("I (1) t: ab→cd", tag, sizeof(tag), msg, sizeof(msg));
+        CHECK_STR("utf8-keep/msg", "ab→", msg);
+    }
+
     printf("log_capture: %d tests, %d failures\n", g_tests, g_failures);
     return g_failures ? 1 : 0;
 }

--- a/phoneblock-dongle/firmware/test/test_sip_parse.c
+++ b/phoneblock-dongle/firmware/test/test_sip_parse.c
@@ -509,6 +509,61 @@ static void test_parse_sdp(void)
     expect_sdp_ip("", "Subject: note c=IN IP4 1.2.3.4 inline\r\n\r\n");
 }
 
+// Real Telekom IMS INVITE SDP (from the field log): RTP/SAVP with two
+// SDES crypto suites, _80 first, _32 second.
+static const char *TELEKOM_SDP =
+    "v=0\r\n"
+    "o=ccs-0-615-3 06123797321659 409780904 IN IP4 217.0.167.35\r\n"
+    "s=-\r\n"
+    "c=IN IP4 217.0.167.35\r\n"
+    "t=0 0\r\n"
+    "m=audio 11262 RTP/SAVP 112 116 8 0 110\r\n"
+    "a=sendrecv\r\n"
+    "a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:qdLu16UGSfeXENoHNrgwDG7onl1nuMyV6fSi+b/J\r\n"
+    "a=crypto:2 AES_CM_128_HMAC_SHA1_32 inline:lWibhEBAiok3IZoRKNDJWN03QHuVqDNhPRxV3xUU\r\n"
+    "a=rtpmap:8 PCMA/8000\r\n";
+
+static void expect_savp(int expected, const char *msg)
+{
+    int got = parse_sdp_audio_savp(msg, (int)strlen(msg));
+    report_int("parse_sdp_audio_savp", msg, expected, got);
+}
+
+static void expect_crypto(int expected_tag, const char *expected_key,
+                          const char *msg)
+{
+    char key[64] = {0};
+    int tag = parse_sdp_crypto(msg, (int)strlen(msg), key, sizeof(key));
+    report_int("parse_sdp_crypto tag", msg, expected_tag, tag);
+    report_str("parse_sdp_crypto key", msg, expected_key, key);
+}
+
+static void test_parse_sdp_crypto(void)
+{
+    // Telekom offer: SAVP transport, picks the _80 suite (tag 1) and its
+    // inline key, ignoring the _32 suite on tag 2.
+    expect_savp(1, TELEKOM_SDP);
+    expect_crypto(1, "qdLu16UGSfeXENoHNrgwDG7onl1nuMyV6fSi+b/J", TELEKOM_SDP);
+
+    // Plain Fritz!Box offer: AVP, no crypto.
+    expect_savp(0, SAMPLE_SDP);
+    expect_crypto(0, "", SAMPLE_SDP);
+
+    // Only the unsupported _32 suite offered → no match.
+    expect_crypto(0, "",
+        "m=audio 5000 RTP/SAVP 8\r\n"
+        "a=crypto:7 AES_CM_128_HMAC_SHA1_32 inline:abc\r\n");
+
+    // inline key with trailing |lifetime|MKI parameters must be trimmed.
+    expect_crypto(3, "Zm9vYmFy",
+        "m=audio 5000 RTP/SAVP 8\r\n"
+        "a=crypto:3 AES_CM_128_HMAC_SHA1_80 inline:Zm9vYmFy|2^20|1:4\r\n");
+
+    // Empty / absent.
+    expect_savp(0, "");
+    expect_crypto(0, "", "");
+}
+
 static void test_pcm_to_alaw(void)
 {
     // Reference values for the classic G.711 A-law encoding.
@@ -546,6 +601,7 @@ int main(void)
     test_normalize_de();
     test_same_call_id();
     test_parse_sdp();
+    test_parse_sdp_crypto();
     test_pcm_to_alaw();
 
     printf("%d tests, %d failures\n", g_tests, g_failures);


### PR DESCRIPTION
## Problem

Direct SIP registration at Deutsche Telekom (and other IMS providers)
worked, but the dongle could not actually take a spam call: Telekom's IMS
offers only encrypted media (`RTP/SAVP` with SDES `a=crypto` keys) and
rejects a plain `RTP/AVP` answer. The dongle answered cleartext, so the
remote sent `BYE` the moment the announcement should have started.

## What this does

Implements SRTP for the answered media stream and fixes the call
teardown so a direct Telekom call now runs end-to-end:

1. **`esp_libsrtp` dependency** — Cisco libsrtp v3 port, ~25 KB flash,
   leaves ~178 KB (10%) free in the OTA app slot.
2. **SRTP negotiation & encryption** — parse the INVITE's `a=crypto`
   offer, generate our own SDES master key, answer `RTP/SAVP` echoing the
   crypto tag, and encrypt every outbound frame via `srtp_protect`
   (`AES_CM_128_HMAC_SHA1_80`). Host-tested against the real Telekom SDP.
3. **Mirror the offer** — SRTP is used whenever a supported crypto suite
   is offered, so existing devices (which stored the legacy `sip_srtp=off`
   default in NVS) work after OTA without reconfiguration. The now-dead
   SRTP dropdown is removed from the web UI; a plain `RTP/AVP` offer
   (Fritz!Box on the LAN) is still answered in cleartext.
4. **In-dialog BYE routing** — route the BYE via the INVITE Contact URI +
   `Record-Route` (loose routing) instead of the From AOR, so the dongle
   hangs up cleanly (`200 OK`) instead of getting `481`/`400` and a ~10 s
   delayed teardown. The Route buffer is sized for Telekom's 211-char IMS
   token URI (truncation had produced a malformed header → 400).
5. **Avoid an OOM reboot** — defer the call-report TLS POST until the SRTP
   stream finishes, so two TLS sessions plus the libsrtp session never
   exhaust the ESP32 heap mid-call.

## Verification

Tested on a real Telekom call to a blocklisted number:
`SRTP offered → answering RTP/SAVP` → full ~9.86 s announcement streamed
as SRTP (accepted, no mid-stream teardown) → report sent after the stream
→ `200 on BYE → dialog closed`. No crash, no watchdog reboot. Host test
suite green (144 tests).

Release notes: `phoneblock-dongle/firmware/release-notes/1.4.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)