### PR TITLE
Dongle 1.3.6: fix daily self-check reboot (log upload stack overflow)

### DIFF
--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -374,6 +374,10 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out,
 
     pb_sink_t sink = { .kind = PB_SINK_SCAN, .scan = &scan };
     esp_http_client_set_url(client, url);
+    // Every user of the shared handle sets its own method: the handle is
+    // reused across GET (check, selftest) and POST (log upload) requests,
+    // so none may rely on a leftover default. See phoneblock_post_log().
+    esp_http_client_set_method(client, HTTP_METHOD_GET);
     esp_http_client_set_user_data(client, &sink);
     http_util_set_user_agent(client);
     esp_http_client_set_header(client, "Authorization", auth_header);
@@ -628,6 +632,7 @@ bool phoneblock_selftest(api_phases_t *phases_opt)
 
     pb_sink_t sink = { .kind = PB_SINK_BUFFER, .buf = &resp };
     esp_http_client_set_url(client, url);
+    esp_http_client_set_method(client, HTTP_METHOD_GET);
     esp_http_client_set_user_data(client, &sink);
     http_util_set_user_agent(client);
     esp_http_client_set_header(client, "Authorization", auth_header);
@@ -660,6 +665,72 @@ bool phoneblock_selftest(api_phases_t *phases_opt)
     xSemaphoreGive(s_check_mutex);
     free(resp.data);
     return ok;
+}
+
+int phoneblock_post_log(const char *body, size_t len)
+{
+    if (s_check_mutex == NULL) {
+        ESP_LOGE(TAG, "phoneblock_post_log before phoneblock_api_init()");
+        return -1;
+    }
+
+    char url[160];
+    snprintf(url, sizeof(url), "%s/api/dongle/log", config_phoneblock_base_url());
+
+    const char *token = config_phoneblock_token();
+    char auth_header[128];
+    snprintf(auth_header, sizeof(auth_header), "Bearer %s", token);
+
+    // Discard the response body; only the status matters. A small buffer
+    // is enough to capture a short error body for the failure log.
+    response_buffer_t resp = { .data = calloc(1, 128), .len = 0, .cap = 128 };
+    if (!resp.data) {
+        ESP_LOGE(TAG, "log upload: out of memory");
+        return -1;
+    }
+
+    xSemaphoreTake(s_check_mutex, portMAX_DELAY);
+
+    // Runs on the shared session-resuming client on purpose: the daily
+    // selftest primes the TLS ticket moments before this call, so the
+    // upload resumes it (abbreviated handshake, no certificate chain
+    // verify) instead of paying a second full handshake. The full-
+    // handshake fallback (when the per-worker ticket misses) is the
+    // stack-hungry P-384 path - the caller keeps its big snapshot off
+    // the stack so even that case fits. See the comment above
+    // s_check_client.
+    esp_http_client_handle_t client = check_client();
+    if (client == NULL) {
+        xSemaphoreGive(s_check_mutex);
+        free(resp.data);
+        return -1;
+    }
+
+    pb_sink_t sink = { .kind = PB_SINK_BUFFER, .buf = &resp };
+    esp_http_client_set_url(client, url);
+    esp_http_client_set_method(client, HTTP_METHOD_POST);
+    esp_http_client_set_user_data(client, &sink);
+    http_util_set_user_agent(client);
+    esp_http_client_set_header(client, "Authorization", auth_header);
+    esp_http_client_set_header(client, "Content-Type", "text/plain");
+    esp_http_client_set_post_field(client, body, (int)len);
+
+    ESP_LOGI(TAG, "POST %s (%u bytes)", url, (unsigned)len);
+    esp_err_t err = esp_http_client_perform(client);
+    int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : -1;
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "log upload transport: %s", esp_err_to_name(err));
+    }
+
+    // Clear the POST body so a later GET on this shared handle (check,
+    // selftest) carries no stale payload - those callers set only their
+    // method, not the body. Close (not destroy) to keep the refreshed
+    // TLS ticket for the next request.
+    esp_http_client_set_post_field(client, NULL, 0);
+    esp_http_client_close(client);
+    xSemaphoreGive(s_check_mutex);
+    free(resp.data);
+    return status;
 }
 
 // --- Diagnostic latency probe (issue #329) --------------------------

--- a/phoneblock-dongle/firmware/main/api.h
+++ b/phoneblock-dongle/firmware/main/api.h
@@ -115,6 +115,16 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out,
 // measured.
 bool phoneblock_selftest(api_phases_t *phases_opt);
 
+// Ships a diagnostic log body (newline-separated WARN/ERROR lines) via
+// POST /api/dongle/log. Runs on the shared session-resuming client so
+// the daily upload resumes the TLS ticket the selftest just primed
+// instead of paying a second full handshake (and its stack-hungry P-384
+// certificate-chain verification). Serialised with phoneblock_check()/
+// phoneblock_selftest() via the internal mutex; safe to call right after
+// phoneblock_selftest() on the same task. Returns the HTTP status code,
+// or -1 on a transport/setup failure.
+int phoneblock_post_log(const char *body, size_t len);
+
 // Diagnostic latency probe for issue #329. Runs `rounds` (clamped to
 // 1..5) back-to-back iterations; each iteration measures one /api/test
 // and one /api/check-prefix call. The check call uses a fixed synthetic

--- a/phoneblock-dongle/firmware/main/logreport.c
+++ b/phoneblock-dongle/firmware/main/logreport.c
@@ -4,25 +4,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "esp_crt_bundle.h"
-#include "esp_err.h"
-#include "esp_http_client.h"
 #include "esp_log.h"
 #include "esp_system.h"
 
+#include "api.h"
 #include "config.h"
-#include "http_util.h"
 #include "stats.h"
 #include "wifi.h"
 
 static const char *TAG = "logreport";
 
-#define LOGREPORT_HTTP_TIMEOUT_MS   30000
-
-// Same heap headroom rationale as crashreport.c: the TLS handshake to
+// Same heap headroom rationale as crashreport.c: a full TLS handshake to
 // phoneblock.net wants ~30 KB of bignum scratch for the cert-chain
-// verify. Below this, defer to the next cycle rather than fail the
-// handshake noisily.
+// verify. The upload normally resumes the selftest's session ticket and
+// skips that, but the per-worker ticket can miss and force a full
+// handshake — so keep the guard. Below this, defer to the next cycle
+// rather than fail the handshake noisily.
 #define LOGREPORT_MIN_FREE_HEAP     (64 * 1024)
 
 // Upper bound for the assembled text body. The ring holds at most
@@ -39,19 +36,23 @@ static const char *TAG = "logreport";
 // it across boots.
 static int64_t s_reported_through_us = 0;
 
-void logreport_flush(void)
+// Snapshots the WARN/ERROR ring and assembles the upload body on the
+// heap. The 32-entry stats_error_t snapshot (~5 KB) lives only in this
+// frame and is gone the moment it returns — so it is not sitting on the
+// stack underneath the subsequent TLS handshake. That matters: the
+// upload runs on the 8 KB selftest task, and a full handshake's P-384
+// cert-chain verify already comes close to that limit on its own. The
+// 1.3.5 field crashes were exactly this — the ~5 KB array plus the
+// handshake tipped the task over its stack guard.
+//
+// Returns the malloc'd body (caller frees) and fills *out_len /
+// *out_through / *out_shipped, or NULL when there is nothing new to ship.
+static char *logreport_build_body(size_t *out_len, int64_t *out_through,
+                                  int *out_shipped)
 {
-    // Opt-in: the same toggle that governs crash reports ("send errors to
-    // PhoneBlock"). Off → never ship anything.
-    if (!config_crash_report_enabled()) return;
-    if (strlen(config_phoneblock_token()) == 0) return;
-    // No network → try again next cycle instead of failing a pointless
-    // TLS handshake.
-    if (!wifi_has_ip()) return;
-
     stats_error_t errs[STATS_MAX_ERRORS];
     int n = stats_snapshot_errors(errs, STATS_MAX_ERRORS);
-    if (n <= 0) return;
+    if (n <= 0) return NULL;
 
     // De-noising rule: a lone WARN is almost always transient or benign —
     // ESP-IDF's httpd logs every client socket reset (errno 104/113) at
@@ -71,10 +72,10 @@ void logreport_flush(void)
             break;
         }
     }
-    if (!have_new_error) return;
+    if (!have_new_error) return NULL;
 
     char *body = malloc(LOGREPORT_BODY_CAP);
-    if (!body) return;
+    if (!body) return NULL;
 
     // stats_snapshot_errors returns newest-first; walk it back to front so
     // the body reads oldest-first. Advance the high-water mark only to the
@@ -114,8 +115,30 @@ void logreport_flush(void)
         // Nothing new at WARN/ERROR — the healthy path. No POST, no heap
         // pressure, no server load.
         free(body);
-        return;
+        return NULL;
     }
+
+    *out_len     = len;
+    *out_through = shipped_through;
+    *out_shipped = shipped;
+    return body;
+}
+
+void logreport_flush(void)
+{
+    // Opt-in: the same toggle that governs crash reports ("send errors to
+    // PhoneBlock"). Off → never ship anything.
+    if (!config_crash_report_enabled()) return;
+    if (strlen(config_phoneblock_token()) == 0) return;
+    // No network → try again next cycle instead of failing a pointless
+    // TLS handshake.
+    if (!wifi_has_ip()) return;
+
+    size_t  len;
+    int64_t shipped_through;
+    int     shipped;
+    char *body = logreport_build_body(&len, &shipped_through, &shipped);
+    if (!body) return;   // nothing new to ship; errs[] already off the stack
 
     size_t free_heap = esp_get_free_heap_size();
     if (free_heap < LOGREPORT_MIN_FREE_HEAP) {
@@ -124,36 +147,10 @@ void logreport_flush(void)
         return;
     }
 
-    char auth[160];
-    snprintf(auth, sizeof(auth), "Bearer %s", config_phoneblock_token());
-
-    char url[200];
-    snprintf(url, sizeof(url), "%s/api/dongle/log",
-             config_phoneblock_base_url());
-
-    esp_http_client_config_t cfg = {
-        .url               = url,
-        .method            = HTTP_METHOD_POST,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-        .timeout_ms        = LOGREPORT_HTTP_TIMEOUT_MS,
-        .auth_type         = HTTP_AUTH_TYPE_NONE,
-    };
-    esp_http_client_handle_t client = esp_http_client_init(&cfg);
-    if (!client) {
-        free(body);
-        return;
-    }
-    // The User-Agent carries the firmware version and the stable per-device
-    // id, so the server can attribute each line to a specific dongle (the
-    // Bearer token already attributes it to the account/user).
-    http_util_set_user_agent(client);
-    esp_http_client_set_header(client, "Authorization", auth);
-    esp_http_client_set_header(client, "Content-Type", "text/plain");
-    esp_http_client_set_post_field(client, body, (int)len);
-
-    esp_err_t err = esp_http_client_perform(client);
-    int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : -1;
-    esp_http_client_cleanup(client);
+    // Hands off to the shared session-resuming client (POST
+    // /api/dongle/log). The selftest just primed the TLS ticket, so this
+    // normally resumes it and skips the cert-chain verify entirely.
+    int status = phoneblock_post_log(body, len);
     free(body);
 
     if (status >= 200 && status < 300) {
@@ -165,7 +162,6 @@ void logreport_flush(void)
                  shipped, shipped == 1 ? "y" : "ies");
     } else {
         // Keep the high-water mark unchanged → retry next cycle.
-        ESP_LOGI(TAG, "log upload failed (err=%s status=%d) — retry next cycle",
-                 esp_err_to_name(err), status);
+        ESP_LOGI(TAG, "log upload failed (status=%d) — retry next cycle", status);
     }
 }

--- a/phoneblock-dongle/firmware/release-notes/1.3.6.md
+++ b/phoneblock-dongle/firmware/release-notes/1.3.6.md
@@ -1,0 +1,18 @@
+# PhoneBlock Dongle 1.3.6
+
+*2026-06-19*
+
+## Fixed
+
+- **No more occasional reboots around the daily self-check.** Once a day
+  the dongle verifies its PhoneBlock token and, right afterwards, uploads
+  any new warnings so problems can be diagnosed remotely. That upload
+  opened a second, redundant secure connection from scratch; together
+  with the log data it had buffered, the background task could run out of
+  working memory mid-handshake and reboot the device — sometimes visibly
+  as the crash, sometimes as a follow-on fault in an unrelated task. The
+  upload now reuses the secure session the self-check just established
+  (faster, too), and the buffered data is released before the handshake,
+  so the daily check stays comfortably within its limits. (This builds on
+  the 1.3.5 watchdog fix and addresses a separate crash seen in field
+  reports.)


### PR DESCRIPTION
## Summary

Fixes the crash behind the 1.3.5 field core dumps: the `selftest` task overflowing its 8 KB stack during the daily log upload. Released as **1.3.6** on the `dongle-1.3.x` maintenance line (tag `dongle-v1.3.6`); merging it back into `master` here.

## Root cause

Once a day `selftest_task` runs `phoneblock_selftest()` and then `logreport_flush()`. The crash dumps (`8292d417` stack-overflow canary; `63344668` mutex assert during ECDSA verify; `ebca8d16`/`66d04948` `tcpip_thread` faulting on a corrupted lwIP pcb with the selftest stack at 72/236 bytes free) all pointed at `logreport_flush()`:

- It spun up its **own** `esp_http_client` and did a fresh **full** TLS handshake every cycle — including the stack-hungry P-384 ECDSA certificate-chain verify — instead of reusing the shared session-resuming client (`s_check_client`) that the selftest just primed.
- A ~5 KB `stats_error_t[32]` snapshot sat on the 8 KB task's stack across that handshake.

Together they tipped the task over its stack guard — sometimes caught cleanly by the canary, sometimes after smashing adjacent memory (hence the faults in unrelated tasks).

## Fix (both parts needed)

1. **Route the upload through `phoneblock_post_log()` on the shared client**, so it normally resumes the ticket the selftest just primed (abbreviated handshake, no cert verify, ~1–2 s faster). Resumption is best-effort (phoneblock.net has per-worker ticket keys), so a full handshake can still happen — hence part 2.
2. **Move the ~5 KB snapshot into `logreport_build_body()`**, so it is off the stack before the handshake. Even the full-handshake fallback now fits in 8 KB.

Every user of the shared handle now sets its method explicitly (GET for check/selftest, POST for the log upload) instead of relying on the `esp_http_client` GET default, so reusing the handle across methods has no hidden coupling; the POST path also clears its body afterwards.

## Verification

- Builds clean (`idf.py build`).
- Flashed onto the dev dongle over OTA: boots stable, SIP registered, `token_ok`, `errors:0`.
- Confirmed session resumption on the shared client live: full handshake at boot `connect_ms` 2560 → resumed `connect_ms` ~80 ms on `/api/token-test`. That is exactly the path the daily log upload now reuses.

The `phoneblock_post_log()` POST only fires from the daily `selftest_task` (with a new ERROR in the ring), so it was not triggered live; its POST mechanics are identical to the in-production `phoneblock_rate`/`report_call` over the now-verified shared-client path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)