### PR TITLE
Dongle: per-task CPU load + heap readout (field diagnosis)

### DIFF
--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -234,6 +234,51 @@ static esp_err_t handle_root(httpd_req_t *req)
     return ESP_OK;
 }
 
+// Add heap figures and, where the run-time stats are compiled in, a
+// per-task CPU breakdown under "system". This is the live field-diagnosis
+// readout for "the dongle is hot / unstable": a runaway task shows up as a
+// high cpu_pct instead of having to guess. The CPU figures are sampled
+// over a short window (so they reflect *current* load, not a boot
+// average), which briefly delays this one request — fine for a diagnostic
+// poll. Percentages are of total CPU across both cores, so a task pegging
+// a single core reads ~50%.
+static void add_system_load(cJSON *root)
+{
+    cJSON *sys = cJSON_AddObjectToObject(root, "system");
+    cJSON_AddNumberToObject(sys, "free_heap",     (double)esp_get_free_heap_size());
+    cJSON_AddNumberToObject(sys, "min_free_heap", (double)esp_get_minimum_free_heap_size());
+
+#if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+    UBaseType_t cap = uxTaskGetNumberOfTasks() + 4;   // headroom for mid-sample spawns
+    TaskStatus_t *a = malloc(cap * sizeof(TaskStatus_t));
+    TaskStatus_t *b = malloc(cap * sizeof(TaskStatus_t));
+    if (!a || !b) { free(a); free(b); return; }
+
+    uint32_t t0 = 0, t1 = 0;
+    UBaseType_t na = uxTaskGetSystemState(a, cap, &t0);
+    vTaskDelay(pdMS_TO_TICKS(250));
+    UBaseType_t nb = uxTaskGetSystemState(b, cap, &t1);
+    uint32_t dtotal = t1 - t0;
+
+    cJSON *tasks = cJSON_AddArrayToObject(sys, "tasks");
+    for (UBaseType_t i = 0; i < nb; i++) {
+        uint32_t prev = 0;
+        for (UBaseType_t j = 0; j < na; j++) {
+            if (a[j].xHandle == b[i].xHandle) { prev = a[j].ulRunTimeCounter; break; }
+        }
+        uint32_t d   = b[i].ulRunTimeCounter - prev;   // wraps cleanly (unsigned)
+        uint32_t pct = dtotal ? (uint32_t)(((uint64_t)d * 100) / dtotal) : 0;
+        cJSON *t = cJSON_CreateObject();
+        cJSON_AddStringToObject(t, "name",       b[i].pcTaskName);
+        cJSON_AddNumberToObject(t, "cpu_pct",    pct);
+        cJSON_AddNumberToObject(t, "stack_free", b[i].usStackHighWaterMark);
+        cJSON_AddItemToArray(tasks, t);
+    }
+    free(a);
+    free(b);
+#endif
+}
+
 static esp_err_t handle_status(httpd_req_t *req)
 {
     REQUIRE_AUTH_API(req);
@@ -358,6 +403,8 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON_AddBoolToObject  (ml,   "pass_set", config_smtp_pass()[0] != '\0');
     cJSON_AddBoolToObject  (ml,   "on_error", config_mail_on_error());
     cJSON_AddBoolToObject  (ml,   "on_spam",  config_mail_on_spam());
+
+    add_system_load(root);
 
     send_json(req, root);
     return ESP_OK;

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -167,6 +167,11 @@ const I18N = {
     'status.thresholds.range.help': 'Stimmen gegen Nachbarn im selben 10er- oder 100er-Block. Default 10. Wert 0 schaltet Range-Block ab — dann zählen nur Direkt-Treffer.',
     'status.thresholds.saved': 'Gespeichert.',
     'status.thresholds.invalid': 'Ungültiger Wert.',
+    'status.system.title': 'System',
+    'status.system.heap': 'Freier Speicher: {free} (Minimum: {min})',
+    'status.system.col.task': 'Task',
+    'status.system.col.cpu': 'CPU',
+    'status.system.col.stack': 'Stack frei',
     'status.errors.title': 'Protokoll',
     'status.errors.empty': 'keine Einträge',
     'status.errors.ago': 'vor {age}',
@@ -409,6 +414,11 @@ const I18N = {
     'status.thresholds.range.help': 'Votes against neighbors in the same 10/100-block. Default 10. Set to 0 to disable range-based blocking — only direct hits count then.',
     'status.thresholds.saved': 'Saved.',
     'status.thresholds.invalid': 'Invalid value.',
+    'status.system.title': 'System',
+    'status.system.heap': 'Free memory: {free} (minimum: {min})',
+    'status.system.col.task': 'Task',
+    'status.system.col.cpu': 'CPU',
+    'status.system.col.stack': 'Stack free',
     'status.errors.title': 'Log',
     'status.errors.empty': 'no entries',
     'status.errors.ago': '{age} ago',
@@ -639,6 +649,11 @@ const I18N = {
     'status.calls.clear': 'Vider la liste',
     'status.calls.log_known': 'Journaliser les appels connus',
     'status.calls.log_known.help': 'Si désactivé, les appels provenant de numéros du carnet d’adresses et les codes internes (**, *…) n’apparaissent pas dans la liste — les compteurs ci-dessus restent mis à jour.',
+    'status.system.title': 'Système',
+    'status.system.heap': 'Mémoire libre : {free} (minimum : {min})',
+    'status.system.col.task': 'Tâche',
+    'status.system.col.cpu': 'CPU',
+    'status.system.col.stack': 'Pile libre',
     'status.errors.title': 'Journal',
     'status.errors.empty': 'aucune entrée',
     'status.errors.ago': 'il y a {age}',
@@ -869,6 +884,11 @@ const I18N = {
     'status.calls.clear': 'Vaciar lista',
     'status.calls.log_known': 'Registrar llamadas conocidas',
     'status.calls.log_known.help': 'Si está desactivado, las llamadas de números de la agenda y los códigos internos (**, *…) no aparecen en la lista — los contadores de arriba se siguen actualizando.',
+    'status.system.title': 'Sistema',
+    'status.system.heap': 'Memoria libre: {free} (mínimo: {min})',
+    'status.system.col.task': 'Tarea',
+    'status.system.col.cpu': 'CPU',
+    'status.system.col.stack': 'Pila libre',
     'status.errors.title': 'Registro',
     'status.errors.empty': 'sin entradas',
     'status.errors.ago': 'hace {age}',
@@ -1306,6 +1326,15 @@ function renderStatus(){
     +   '<span>' + esc(t('status.errors.capture_info')) + '</span></label>'
     + '<p class="muted" style="font-size:.72rem;margin:.2rem 0 0">'
     +   esc(t('status.errors.capture_info.hint')) + '</p>'
+    + '</details>'
+    + '<details id="systemSection" class="adminsec" style="display:none">'
+    + '<summary>' + esc(t('status.system.title')) + '</summary>'
+    + '<p id="systemHeap" class="muted" style="font-size:.85rem;margin:.2rem 0 .6rem"></p>'
+    + '<table style="width:100%;border-collapse:collapse;font-size:.8rem"><thead><tr>'
+    + '<th style="text-align:left">'   + esc(t('status.system.col.task'))  + '</th>'
+    + '<th style="text-align:right">'  + esc(t('status.system.col.cpu'))   + '</th>'
+    + '<th style="text-align:right">'  + esc(t('status.system.col.stack')) + '</th>'
+    + '</tr></thead><tbody id="systemTasks"></tbody></table>'
     + '</details>'
     + '<details id="thresholdsSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.thresholds.title')) + '</summary>'
@@ -1892,6 +1921,28 @@ async function refreshAll(){
     uptime: esc(fmtSec(s.uptime_s)),
     api: esc(s.phoneblock.last_api_ms > 0 ? s.phoneblock.last_api_ms + ' ms' : '–'),
   });
+
+  // System load / memory — diagnostic card. Surfaces a runaway task as a
+  // high CPU% so "the dongle is hot/unstable" can be pinned, not guessed.
+  if (s.system) {
+    const kb = (n) => (n / 1024).toFixed(1) + ' KB';
+    $('systemSection').style.display = '';
+    $('systemHeap').textContent = t('status.system.heap', {
+      free: kb(s.system.free_heap), min: kb(s.system.min_free_heap),
+    });
+    const tb = $('systemTasks');
+    tb.innerHTML = '';
+    const tasks = (s.system.tasks || []).slice()
+      .sort((a, b) => b.cpu_pct - a.cpu_pct);
+    for (const tk of tasks) {
+      const tr = document.createElement('tr');
+      tr.innerHTML =
+        '<td>' + esc(tk.name) + '</td>'
+      + '<td style="text-align:right">' + tk.cpu_pct + '%</td>'
+      + '<td style="text-align:right">' + tk.stack_free + '</td>';
+      tb.appendChild(tr);
+    }
+  }
 
   // Calls
   const tbody = $('callsBody');

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -134,6 +134,16 @@ CONFIG_ESP_TASK_WDT_TIMEOUT_S=60
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0=y
 CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=y
 
+# Per-task run-time statistics, surfaced on /api/status ("system.tasks")
+# and the web Protokoll/System card. This is the field-diagnosis path for
+# "the dongle is hot / unstable" — it makes a runaway task visible as a
+# high CPU% instead of having to guess. USE_TRACE_FACILITY adds the task
+# list + stack-high-water; GENERATE_RUN_TIME_STATS adds the per-task CPU
+# counter (clocked off esp_timer, the IDF default source, so the cost is
+# a cheap timer read per context switch).
+CONFIG_FREERTOS_USE_TRACE_FACILITY=y
+CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
+
 # OTA rollback: the bootloader marks a freshly flashed image as
 # "pending verify". The app must call
 # esp_ota_mark_app_valid_cancel_rollback() after a successful


### PR DESCRIPTION
## Why

When a dongle runs hot / unstable there was no way to tell whether a task
is running amok — the cause had to be guessed. This adds a live load
readout so a runaway task is *visible* as a high CPU%.

## What

- **`sdkconfig.defaults`**: enable FreeRTOS run-time stats
  (`USE_TRACE_FACILITY` + `GENERATE_RUN_TIME_STATS`, clocked off the
  esp_timer default source — a cheap timer read per context switch).
- **`/api/status`**: new `system` object with `free_heap`,
  `min_free_heap`, and a per-task `tasks[]` (`name`, `cpu_pct`,
  `stack_free`). CPU% is sampled over a 250 ms window, so it reflects
  *current* load rather than a boot average. Percentages are of the
  two-core total, so a single-core spinner reads ~50%.
- **Web UI**: a collapsed "System" admin card shows heap + the task list
  sorted by CPU%. (de/en/fr/es strings added.)

## Status

Builds clean (host + firmware). **Not yet flash-tested on hardware** — the
test device was offline when this was written; needs a live check that the
sampled percentages look sane and the card renders. Intended as the
diagnosis tool for the ongoing "hot / WiFi-drops" investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)