### PR TITLE
Dongle: enable/disable switch for the local blocklist cache

### DIFF
--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -295,6 +295,13 @@ void blocklist_sync_run(void)
     if (s_lock == NULL) {
         return;
     }
+    if (!config_blocklist_enabled()) {
+        // Feature switched off in the web UI: don't refresh the on-flash
+        // files. The existing files stay put but are never consulted (the
+        // call-time path skips them too), so they simply age out.
+        ESP_LOGI(TAG, "skipped — local blocklist cache disabled");
+        return;
+    }
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     s_status.running = true;
@@ -309,7 +316,7 @@ void blocklist_sync_run(void)
 
 bool blocklist_sync_trigger_now(void)
 {
-    if (s_lock == NULL) {
+    if (s_lock == NULL || !config_blocklist_enabled()) {
         return false;
     }
     xSemaphoreTake(s_lock, portMAX_DELAY);

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -38,6 +38,7 @@ static const char *NS   = "phoneblock";
 #define K_CRASH_REPORT  "crash_report"
 #define K_ACCEPT_TEST   "accept_test"
 #define K_BL_WILDCARDS  "bl_wildcards"
+#define K_BL_ENABLED    "bl_enabled"
 #define K_CONTACT_HOST  "contact_host"
 #define K_CONTACT_PORT  "contact_port"
 #define K_SIP_LPORT     "sip_lport"
@@ -106,6 +107,7 @@ typedef struct {
     char crash_report[4];    // "1" | "0" (or empty = default on)
     char accept_test[4];     // "1" | "0" (empty = use Kconfig default)
     char bl_wildcards[4];    // "1" | "0" (empty = default on)
+    char bl_enabled[4];      // "1" | "0" (empty = default on)
     char contact_host[64];
     int  contact_port;
     int  sip_local_port;     // 0 = use DEFAULT_SIP_LOCAL_PORT
@@ -257,6 +259,7 @@ void config_load(void)
         s_config.crash_report[0]  = '\0';
         s_config.accept_test[0]   = '\0';
         s_config.bl_wildcards[0]  = '\0';
+        s_config.bl_enabled[0]    = '\0';
         copy_default(s_config.contact_host, sizeof(s_config.contact_host), CONFIG_SIP_CONTACT_HOST_OVERRIDE);
         s_config.contact_port = CONFIG_SIP_CONTACT_PORT_OVERRIDE;
         s_config.sip_local_port = 0;   // → DEFAULT_SIP_LOCAL_PORT
@@ -328,6 +331,8 @@ void config_load(void)
              s_config.accept_test, sizeof(s_config.accept_test));
     load_str(h, K_BL_WILDCARDS, "",
              s_config.bl_wildcards, sizeof(s_config.bl_wildcards));
+    load_str(h, K_BL_ENABLED, "",
+             s_config.bl_enabled, sizeof(s_config.bl_enabled));
     load_str(h, K_CONTACT_HOST, CONFIG_SIP_CONTACT_HOST_OVERRIDE,
              s_config.contact_host, sizeof(s_config.contact_host));
     s_config.contact_port = load_int(h, K_CONTACT_PORT, CONFIG_SIP_CONTACT_PORT_OVERRIDE);
@@ -437,6 +442,15 @@ bool        config_blocklist_wildcards(void)
     // Only an explicit "0" turns it off; the file format always carries
     // the prefix section, the flag is read locally at lookup time.
     return s_config.bl_wildcards[0] != '0';
+}
+bool        config_blocklist_enabled(void)
+{
+    // Default on (empty / unrecognised → enabled): the local blocklist
+    // cache is the call-time fast path, so a fresh dongle uses it out of
+    // the box. Only an explicit "0" turns the feature off — the daily
+    // download is skipped and call-time lookups bypass the local files
+    // and go straight to the server API.
+    return s_config.bl_enabled[0] != '0';
 }
 bool        config_accept_test_calls(void)
 {
@@ -642,6 +656,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.accept_test, sizeof(s_config.accept_test));
     if (err == ESP_OK) err = set_str_if(h, K_BL_WILDCARDS, u->blocklist_wildcards,
                                         s_config.bl_wildcards, sizeof(s_config.bl_wildcards));
+    if (err == ESP_OK) err = set_str_if(h, K_BL_ENABLED, u->blocklist_enabled,
+                                        s_config.bl_enabled, sizeof(s_config.bl_enabled));
     if (err == ESP_OK) err = set_str_if(h, K_PB_URL, u->phoneblock_base_url,
                                         s_config.pb_base_url, sizeof(s_config.pb_base_url));
     if (err == ESP_OK) err = set_str_if(h, K_PB_TOKEN, u->phoneblock_token,

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -156,6 +156,12 @@ bool        config_accept_test_calls(void);
 // flag is evaluated locally at lookup time.
 bool        config_blocklist_wildcards(void);
 
+// Whether the local blocklist cache is active. Default on. When off, the
+// daily download is skipped and call-time lookups bypass the local
+// community/personal files and query the server API directly — the user
+// trades the offline-resilient fast path for always-live server results.
+bool        config_blocklist_enabled(void);
+
 // PhoneBlock
 // Site root URL, without "/api" suffix — api.c appends "/api/…",
 // web.c appends "/mobile/…" directly.
@@ -283,6 +289,10 @@ typedef struct {
     // "0" = exact matches only. NULL = leave unchanged. Default when
     // unset is "1".
     const char *blocklist_wildcards;
+    // "1" = keep the local blocklist cache active (daily download + call-
+    // time fast path), "0" = disable it. NULL = leave unchanged. Default
+    // when unset is "1".
+    const char *blocklist_enabled;
     const char *phoneblock_base_url;
     const char *phoneblock_token;
     // Direct-hit SPAM threshold. 0 = leave current value untouched

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1153,7 +1153,11 @@ static verdict_t check_invite_caller(const char *req, int req_len)
     pb_check_result_t result;
     verdict_t v;
     const char *digits = (number[0] == '+') ? number + 1 : number;
-    blocklist_verdict_t local = blocklist_sync_check(digits, config_blocklist_wildcards());
+    // Skip the local files entirely when the cache is disabled — every
+    // call then resolves against the live server API.
+    blocklist_verdict_t local = config_blocklist_enabled()
+        ? blocklist_sync_check(digits, config_blocklist_wildcards())
+        : BLOCKLIST_UNKNOWN;
     if (local == BLOCKLIST_SPAM) {
         memset(&result, 0, sizeof(result));
         result.verdict = VERDICT_SPAM;

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -378,6 +378,7 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON_AddNumberToObject(bl, "last_ago_s",      (double)bl_ago_s);
     cJSON_AddStringToObject(bl, "last_error",      bs.last_error);
     cJSON_AddBoolToObject  (bl, "wildcards",       config_blocklist_wildcards());
+    cJSON_AddBoolToObject  (bl, "enabled",         config_blocklist_enabled());
 
     cJSON *ann = cJSON_AddObjectToObject(root, "announcement");
     cJSON_AddBoolToObject  (ann,  "custom",  announcement_is_custom());
@@ -552,6 +553,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char crash_rep_s[4]   = "";
     char test_calls_s[4]  = "";
     char bl_wild_s[4]     = "";
+    char bl_enabled_s[4]  = "";
     char smtp_host[64]    = "";
     char smtp_port_s[8]   = "";
     char smtp_sec[10]     = "";
@@ -585,6 +587,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_crash_rep = form_get(body, "crash_report",  crash_rep_s,   sizeof(crash_rep_s));
     bool have_test_call = form_get(body, "accept_test_calls", test_calls_s, sizeof(test_calls_s));
     bool have_bl_wild   = form_get(body, "blocklist_wildcards", bl_wild_s, sizeof(bl_wild_s));
+    bool have_bl_en     = form_get(body, "blocklist_enabled", bl_enabled_s, sizeof(bl_enabled_s));
     bool have_pb_url     = form_get(body, "pb_url",    pb_url,    sizeof(pb_url));
     bool have_pb_token   = form_get(body, "pb_token",  pb_token,  sizeof(pb_token));
     bool have_min_direct = form_get(body, "min_direct_votes", min_direct_s, sizeof(min_direct_s));
@@ -673,6 +676,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .crash_report    = have_crash_rep ? crash_rep_s   : NULL,
         .accept_test_calls = have_test_call ? test_calls_s : NULL,
         .blocklist_wildcards = have_bl_wild ? bl_wild_s : NULL,
+        .blocklist_enabled   = have_bl_en   ? bl_enabled_s : NULL,
         .phoneblock_base_url = have_pb_url   && pb_url[0]   ? pb_url   : NULL,
         .phoneblock_token    = have_pb_token && pb_token[0] ? pb_token : NULL,
         .min_direct_votes = have_min_direct && min_direct_s[0] ? atoi(min_direct_s) : 0,

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -269,6 +269,9 @@ const I18N = {
     'status.sync.disabled': 'Automatischer Sync deaktiviert — manuell weiterhin möglich.',
     'status.localcache.title': 'Blocklist-Cache',
     'status.localcache.intro': 'Einmal pro Tag lädt der Dongle die aktuelle Sperrliste und Deine persönliche Black-/White-List herunter und legt sie auf dem internen Flash ab. Eingehende Anrufe werden so überwiegend ohne Server-Anfrage entschieden — schneller und auch bei Netzproblemen verlässlich.',
+    'status.localcache.enable': 'Blocklist-Cache verwenden',
+    'status.localcache.enable.help': 'Lädt die Sperrliste auf den Dongle und entscheidet Anrufe lokal. Aus: Jeder Anruf wird direkt beim Server geprüft — langsamer und nur bei funktionierender Internetverbindung möglich.',
+    'status.localcache.disabled': 'Deaktiviert — Anrufe werden direkt beim Server geprüft.',
     'status.localcache.never': 'Noch nicht heruntergeladen.',
     'status.localcache.have': '{community} Einträge in der Gemeinschaftsliste, {personal} persönlich. Aktualisiert vor {ago}.',
     'status.localcache.last_fail': 'Letzter Download vor {ago} fehlgeschlagen: {err}',
@@ -528,6 +531,9 @@ const I18N = {
     'status.sync.disabled': 'Automatic sync disabled — manual run still available.',
     'status.localcache.title': 'Blocklist cache',
     'status.localcache.intro': 'Once a day the dongle downloads the current community blocklist plus your personal black/white list and stores them on internal flash. Incoming calls are then decided without an API round-trip — faster, and resilient to network glitches.',
+    'status.localcache.enable': 'Use blocklist cache',
+    'status.localcache.enable.help': 'Downloads the blocklist onto the dongle and decides calls locally. Off: every call is checked against the server directly — slower, and only possible with a working internet connection.',
+    'status.localcache.disabled': 'Disabled — calls are checked against the server directly.',
     'status.localcache.never': 'Not downloaded yet.',
     'status.localcache.have': '{community} community entries, {personal} personal. Refreshed {ago} ago.',
     'status.localcache.last_fail': 'Last download {ago} ago failed: {err}',
@@ -774,6 +780,9 @@ const I18N = {
     'status.sync.disabled': 'Synchro auto désactivée — exécution manuelle toujours possible.',
     'status.localcache.title': 'Cache de la liste de blocage',
     'status.localcache.intro': 'Une fois par jour, le dongle télécharge la liste de blocage commune et votre liste noire/blanche personnelle, puis les stocke en mémoire flash interne. Les appels entrants sont alors décidés sans appel API — plus rapide, et résistant aux problèmes réseau.',
+    'status.localcache.enable': 'Utiliser le cache de liste de blocage',
+    'status.localcache.enable.help': 'Télécharge la liste de blocage sur le dongle et décide des appels localement. Désactivé : chaque appel est vérifié directement auprès du serveur — plus lent, et possible uniquement avec une connexion Internet active.',
+    'status.localcache.disabled': 'Désactivé — les appels sont vérifiés directement auprès du serveur.',
     'status.localcache.never': 'Pas encore téléchargé.',
     'status.localcache.have': '{community} entrées communes, {personal} personnelles. Rafraîchi il y a {ago}.',
     'status.localcache.last_fail': 'Dernier téléchargement il y a {ago} en échec : {err}',
@@ -1020,6 +1029,9 @@ const I18N = {
     'status.sync.disabled': 'Sincronización auto desactivada — ejecución manual aún posible.',
     'status.localcache.title': 'Caché de lista de bloqueo',
     'status.localcache.intro': 'Una vez al día, el dongle descarga la lista de bloqueo común y tu lista negra/blanca personal, y las guarda en la memoria flash interna. Las llamadas entrantes se deciden entonces sin llamadas a la API — más rápido y resistente a problemas de red.',
+    'status.localcache.enable': 'Usar caché de lista de bloqueo',
+    'status.localcache.enable.help': 'Descarga la lista de bloqueo en el dongle y decide las llamadas localmente. Desactivado: cada llamada se comprueba directamente con el servidor — más lento y solo posible con una conexión a Internet activa.',
+    'status.localcache.disabled': 'Desactivado — las llamadas se comprueban directamente con el servidor.',
     'status.localcache.never': 'Aún no descargado.',
     'status.localcache.have': '{community} entradas comunes, {personal} personales. Actualizado hace {ago}.',
     'status.localcache.last_fail': 'Última descarga hace {ago} falló: {err}',
@@ -1432,6 +1444,11 @@ function renderStatus(){
     + '<details id="localCacheSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.localcache.title')) + '</summary>'
     + '<p class="muted">' + esc(t('status.localcache.intro')) + '</p>'
+    + '<label title="' + esc(t('status.localcache.enable.help')) + '" '
+    +   'style="display:flex;align-items:center;gap:.5rem;margin:.4rem 0;font-size:.9rem;color:#222">'
+    + '  <input type="checkbox" id="blEnabled" style="width:auto;margin:0">'
+    + '  <span>' + esc(t('status.localcache.enable')) + '</span>'
+    + '</label>'
     + '<label title="' + esc(t('status.localcache.wildcards.help')) + '" '
     +   'style="display:flex;align-items:center;gap:.5rem;margin:.4rem 0;font-size:.9rem;color:#222">'
     + '  <input type="checkbox" id="blWildcards" style="width:auto;margin:0">'
@@ -1774,9 +1791,17 @@ async function refreshAll(){
   // button is for fresh setups where the user does not want to wait
   // for the next scheduled tick.
   const bl = s.blocklist || {};
+  const blEnabled  = $('blEnabled');
+  // Default to enabled when the field is absent (older firmware) so the
+  // UI never mis-reports an active cache as off.
+  const blOn = bl.enabled !== false;
+  blEnabled.checked = blOn;
   const blStatus = $('localCacheStatus');
   const blAgo = bl.last_ago_s >= 0 ? fmtSec(bl.last_ago_s) : '–';
-  if (bl.running){
+  if (!blOn){
+    blStatus.textContent = t('status.localcache.disabled');
+    blStatus.style.color = '#888';
+  } else if (bl.running){
     blStatus.textContent = t('status.localcache.running');
     blStatus.style.color = '#e8710a';
   } else if (!bl.ever_ran && !bl.have_community && !bl.have_personal){
@@ -1796,7 +1821,27 @@ async function refreshAll(){
   const blWildcards = $('blWildcards');
   const blRun       = $('blRun');
   blWildcards.checked = !!bl.wildcards;
-  blRun.disabled = !!bl.running;
+  // The wildcards toggle and the manual download only make sense while
+  // the cache is on; grey them out when it is disabled.
+  blWildcards.disabled = !blOn;
+  blRun.disabled = !blOn || !!bl.running;
+  if (!blEnabled.onchange){
+    blEnabled.onchange = async () => {
+      const want = blEnabled.checked;
+      blEnabled.disabled = true;
+      const body = new URLSearchParams();
+      body.append('blocklist_enabled', want ? '1' : '0');
+      try {
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: body.toString(),
+        });
+      } catch (_){ /* next poll reconciles */ }
+      blEnabled.disabled = false;
+      refreshAll();
+    };
+  }
   if (!blWildcards.onchange){
     blWildcards.onchange = async () => {
       const want = blWildcards.checked;


### PR DESCRIPTION
## Summary

The dongle's web UI already shows the local blocklist cache status, a **Download now** button, and the wildcards toggle — but there was no way to turn the cache off entirely. This PR adds a **master enable/disable switch** to the existing "Blocklist cache" admin section.

## Changes

A new `bl_enabled` config flag (default **on**, mirroring the existing `bl_wildcards` flag end-to-end through NVS load/store/update) gates the feature:

- **`blocklist_sync.c`** — `blocklist_sync_run()` skips the daily download when disabled; `blocklist_sync_trigger_now()` refuses the manual trigger.
- **`sip_register.c`** — the call-time fast path bypasses the on-flash community/personal files and resolves every call against the live server API when disabled.
- **`config.c` / `config.h`** — NVS key, struct field, default reset, load, `config_blocklist_enabled()` accessor, and the `config_update_t` field + persistence.
- **`web.c`** — status JSON exposes `enabled`; `/api/config` accepts `blocklist_enabled`.
- **`web/index.html`** — adds the "Use blocklist cache" toggle as the section's master switch; when off, the wildcards toggle and download button grey out and the status line reads "Disabled — calls are checked against the server directly." i18n keys added to all four dictionaries (de/en/fr/es).

## Testing

- `idf.py build` → success (8% partition free).
- `node --check` on the embedded UI JS → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)