### PR TITLE
Binary blocklist: server-side size cap + region localization

### DIFF
--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "freertos/FreeRTOS.h"
@@ -16,6 +17,7 @@
 #include "esp_timer.h"
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
+#include "esp_spiffs.h"
 
 #include "config.h"
 #include "http_util.h"
@@ -29,6 +31,19 @@ static const char *TAG = "blsync";
 
 #define COMMUNITY_TMP      BLOCKLIST_COMMUNITY_PATH ".tmp"
 #define PERSONAL_TMP       BLOCKLIST_PERSONAL_PATH ".tmp"
+
+// SPIFFS partition label shared with announcement.c — the community,
+// personal and announcement files all live on this one mount.
+#define SPIFFS_LABEL       "storage"
+
+// Headroom kept free on the storage partition: SPIFFS block/metadata
+// overhead the raw free-byte count overstates, plus room for the small
+// personal list. Used both to size the budget advertised to the server
+// (&maxBytes) and to guard each download against a mid-write ENOSPC.
+#define BLOCKLIST_FS_MARGIN      (48 * 1024)
+
+// Community budget advertised when the filesystem size cannot be read.
+#define DEFAULT_COMMUNITY_BUDGET (256 * 1024)
 
 static SemaphoreHandle_t s_lock    = NULL;
 static blocklist_sync_status_t s_status;
@@ -69,11 +84,46 @@ static void refresh_sizes_locked(void)
 // Streaming HTTPS download into a temp file.
 // ---------------------------------------------------------------------------
 
-// Downloads `url` into `tmp_path`. On any error returns false and writes a
-// short diagnostic into `err`. Caller is responsible for removing the
-// temp file on failure.
+// Size of a file in bytes, or 0 if it does not exist / cannot be stat'd.
+static int64_t file_size_bytes(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return 0;
+    }
+    return (int64_t) st.st_size;
+}
+
+// Free bytes on the storage SPIFFS partition, or -1 if it cannot be read.
+static int64_t spiffs_free_bytes(void)
+{
+    size_t total = 0, used = 0;
+    if (esp_spiffs_info(SPIFFS_LABEL, &total, &used) != ESP_OK) {
+        return -1;
+    }
+    return (int64_t) total - (int64_t) used;
+}
+
+// Storage budget the dongle offers the community file: current free space
+// plus the bytes the existing community file frees when replaced, minus a
+// margin for SPIFFS overhead and the small personal list. Sent to the server
+// as &maxBytes so it caps the encoded file to what actually fits here.
+static int64_t community_budget_bytes(void)
+{
+    int64_t freeb = spiffs_free_bytes();
+    if (freeb < 0) {
+        return DEFAULT_COMMUNITY_BUDGET;
+    }
+    int64_t budget = freeb + file_size_bytes(BLOCKLIST_COMMUNITY_PATH) - BLOCKLIST_FS_MARGIN;
+    return budget > 0 ? budget : 0;
+}
+
+// Downloads `url` into `tmp_path`. `final_path` is the file `tmp_path` will be
+// renamed onto by the caller; its current bytes are reclaimable, so they count
+// toward the space available for this download. On any error returns false and
+// writes a message to `err`.
 static bool download_to_tmp(const char *url, const char *tmp_path,
-                            char *err, size_t err_cap)
+                            const char *final_path, char *err, size_t err_cap)
 {
     FILE *out = fopen(tmp_path, "wb");
     if (out == NULL) {
@@ -119,6 +169,32 @@ static bool download_to_tmp(const char *url, const char *tmp_path,
         esp_http_client_cleanup(client);
         fclose(out);
         return false;
+    }
+
+    // Storage pre-check. Turn a mid-write ENOSPC (which leaves a half-written
+    // .tmp) into a clean, actionable error before any bytes land. The file we
+    // are about to replace is reclaimable: if the body fits beside it, keep it
+    // until the atomic rename; if not but it fits once the old one is freed,
+    // reclaim it now (losing the old-file fallback for this download window);
+    // if it does not fit even then, refuse and leave the old file intact.
+    if (content_length > 0) {
+        int64_t freeb = spiffs_free_bytes();
+        if (freeb >= 0) {
+            int64_t need = content_length + BLOCKLIST_FS_MARGIN;
+            if (need > freeb) {
+                int64_t reclaim = file_size_bytes(final_path);
+                if (need > freeb + reclaim) {
+                    snprintf(err, err_cap, "too large: %lld B needs > %lld B free",
+                             (long long) content_length, (long long) (freeb + reclaim));
+                    esp_http_client_close(client);
+                    esp_http_client_cleanup(client);
+                    fclose(out);
+                    unlink(tmp_path);
+                    return false;
+                }
+                unlink(final_path);
+            }
+        }
     }
 
     char buf[DOWNLOAD_CHUNK];
@@ -195,13 +271,18 @@ static bool sync_one(const char *type, const char *path, const char *tmp_path,
     // The personal list is the user's explicit black/white set — no
     // thresholding, so no parameters.
     if (strcmp(type, "community") == 0 && n > 0 && (size_t) n < sizeof(url)) {
-        snprintf(url + n, sizeof(url) - n, "&minDirect=%d&minRange=%d",
-                 config_min_direct_votes(), config_min_range_votes());
+        // maxBytes lets the server cap the (size-unbounded) community list to
+        // our free flash: it keeps all wildcards + whitelist and truncates the
+        // Heat-ranked direct numbers to fit. minDirect/minRange keep the
+        // encoded verdict identical to the API-fallback path.
+        snprintf(url + n, sizeof(url) - n, "&minDirect=%d&minRange=%d&maxBytes=%lld",
+                 config_min_direct_votes(), config_min_range_votes(),
+                 (long long) community_budget_bytes());
     }
 
     unlink(tmp_path);
 
-    if (!download_to_tmp(url, tmp_path, err, err_cap)) {
+    if (!download_to_tmp(url, tmp_path, path, err, err_cap)) {
         unlink(tmp_path);
         return false;
     }

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BinaryBlocklistCache.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BinaryBlocklistCache.java
@@ -24,17 +24,21 @@ import java.util.function.LongSupplier;
  * API-fallback verdict identical.
  * </p>
  *
+ * <h2>What the cache key captures</h2>
+ *
+ * Beyond the threshold pair, the key carries the {@code dialPrefix} (the list
+ * is region-scoped &mdash; #340 Heat ranking restricted to the caller's
+ * region) and the {@code maxBytes} budget bucket (the direct-number section is
+ * truncated to fit the dongle's storage). Both change the produced bytes, so
+ * both must distinguish cache entries; the servlet snaps each to a small
+ * shared grid (dial set, {@code MAX_BYTES_OPTIONS}) so the fleet still shares
+ * entries.
+ *
  * <h2>What lives outside the cache key</h2>
  *
- * The community binary file is shared across:
- * <ul>
- *   <li>users with different {@code dialPrefix} settings &mdash; phone IDs
- *       are normalised to bare E.164 digits server-side, so the bytes are
- *       dial-prefix-independent;</li>
- *   <li>users with {@code wildcards} on or off &mdash; the file always
- *       carries the prefix section; the dongle decides locally whether to
- *       consult it.</li>
- * </ul>
+ * The community binary file is still shared across users with {@code wildcards}
+ * on or off &mdash; the file always carries the prefix section; the dongle
+ * decides locally whether to consult it.
  *
  * <h2>Staleness</h2>
  *
@@ -55,15 +59,19 @@ public final class BinaryBlocklistCache {
 		return INSTANCE;
 	}
 
-	/** Cache key: the dongle's two SPAM-vote thresholds. */
-	public record Key(int minDirect, int minRange) {
-		// Value-based key; record gives equals/hashCode over both fields.
+	/**
+	 * Cache key: region ({@code dialPrefix}, {@code null} for the global list),
+	 * the dongle's two SPAM-vote thresholds, and the storage budget bucket that
+	 * caps the direct-number section.
+	 */
+	public record Key(String dialPrefix, int minDirect, int minRange, int maxBytes) {
+		// Value-based key; record gives equals/hashCode over all fields.
 	}
 
-	/** Producer of community bytes for a given threshold pair. */
+	/** Producer of community bytes for a given region / threshold / budget. */
 	@FunctionalInterface
 	public interface Encoder {
-		byte[] encode(int minDirect, int minRange);
+		byte[] encode(String dialPrefix, int minDirect, int minRange, int maxBytes);
 	}
 
 	private final ConcurrentMap<Key, Entry> _entries = new ConcurrentHashMap<>();
@@ -83,20 +91,24 @@ public final class BinaryBlocklistCache {
 	 * Returns the cached bytes for the {@code (minDirect, minRange)} pair,
 	 * computing and caching them on a miss or after the entry has expired.
 	 *
+	 * @param dialPrefix Region scope (part of the cache key); {@code null} for
+	 *                   the global list.
 	 * @param minDirect Exact-entry vote threshold (part of the cache key).
 	 * @param minRange  Wildcard net-vote threshold (part of the cache key).
+	 * @param maxBytes  Storage budget bucket capping the direct section (part of
+	 *                  the cache key).
 	 * @param compute   Producer called on a cache miss. Must be deterministic
-	 *                  modulo data freshness: the same pair must always yield
+	 *                  modulo data freshness: the same key must always yield
 	 *                  bytes that are interchangeable between users.
 	 */
-	public byte[] getOrCompute(int minDirect, int minRange, Encoder compute) {
-		Key key = new Key(minDirect, minRange);
+	public byte[] getOrCompute(String dialPrefix, int minDirect, int minRange, int maxBytes, Encoder compute) {
+		Key key = new Key(dialPrefix, minDirect, minRange, maxBytes);
 		long now = _clock.getAsLong();
 		Entry existing = _entries.get(key);
 		if (existing != null && !existing.isStale(now)) {
 			return existing.bytes();
 		}
-		byte[] fresh = compute.encode(minDirect, minRange);
+		byte[] fresh = compute.encode(dialPrefix, minDirect, minRange, maxBytes);
 		_entries.put(key, new Entry(now, fresh));
 		return fresh;
 	}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BlocklistServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BlocklistServlet.java
@@ -12,13 +12,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.haumacher.phoneblock.app.LoginFilter;
+import de.haumacher.phoneblock.app.api.model.BlockListEntry;
 import de.haumacher.phoneblock.app.api.model.Blocklist;
 import de.haumacher.phoneblock.db.DB;
 import de.haumacher.phoneblock.db.DBService;
 import de.haumacher.phoneblock.db.settings.UserSettings;
-import de.haumacher.phoneblock.sync.binary.BlocklistBinaryAdapter;
 import de.haumacher.phoneblock.sync.binary.BlocklistBinaryEncoder;
 import de.haumacher.phoneblock.sync.binary.BlocklistBinaryEncoder.Entry;
+import de.haumacher.phoneblock.sync.binary.BlocklistBinaryFormat;
 import de.haumacher.phoneblock.util.ServletUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -81,6 +82,16 @@ public class BlocklistServlet extends HttpServlet {
 	public static final String PARAM_MIN_RANGE = "minRange";
 
 	/**
+	 * Query parameter: the dongle's storage budget for the community file, in
+	 * bytes. The server keeps all wildcards and the whitelist (small), then
+	 * truncates the Heat-ranked direct numbers so the encoded file fits. Snapped
+	 * <em>down</em> to {@link #MAX_BYTES_OPTIONS} so the budget bucket — part of
+	 * the cache key — stays shared across the fleet and never exceeds what the
+	 * caller asked for. Defaults to {@link #DEFAULT_BINARY_MAX_BYTES}.
+	 */
+	public static final String PARAM_MAX_BYTES = "maxBytes";
+
+	/**
 	 * Allowed {@code minDirect} values, ascending. Must mirror the client
 	 * pickers (mobile app + dongle UI). A requested value is snapped up to the
 	 * smallest of these that is {@code >=} it (capped at the largest), so the
@@ -95,6 +106,25 @@ public class BlocklistServlet extends HttpServlet {
 	 * {@link #MIN_DIRECT_OPTIONS} and {@link #clampToAllowed}.
 	 */
 	static final int[] MIN_RANGE_OPTIONS = { 0, 10, 20, 50, 100, 500 };
+
+	/**
+	 * Allowed {@code maxBytes} budget buckets, ascending (64/128/256/384/512
+	 * KB). A requested budget is snapped <em>down</em> to the largest bucket
+	 * {@code <=} it (see {@link #clampDownToAllowed}) so the encoded file never
+	 * exceeds the dongle's free flash, while the {@code (dialPrefix, minDirect,
+	 * minRange, maxBytes)} cache key only ever takes a handful of budget values
+	 * across the fleet. A budget below the smallest bucket still gets the
+	 * smallest bucket; the dongle's own free-space pre-check is the backstop.
+	 */
+	static final int[] MAX_BYTES_OPTIONS = { 65536, 131072, 262144, 393216, 524288 };
+
+	/**
+	 * Default community budget when a caller omits {@link #PARAM_MAX_BYTES}.
+	 * 256&nbsp;KB — comfortable for the first-generation dongle's storage
+	 * partition after the answering-machine announcement, and the value the
+	 * dongle would compute on typical hardware.
+	 */
+	public static final int DEFAULT_BINARY_MAX_BYTES = 262144;
 
 	/**
 	 * Hard cap on the {@code ?limit=N} request parameter (#336).
@@ -167,10 +197,7 @@ public class BlocklistServlet extends HttpServlet {
 			// top-N to numbers active in their region. Falls back to the global
 			// ranking when no dial is configured (legacy clients, unmapped
 			// regions).
-			String dialPrefix = (cachedSettings != null) ? cachedSettings.getDialPrefix() : null;
-			if (dialPrefix != null && dialPrefix.isEmpty()) {
-				dialPrefix = null;
-			}
+			String dialPrefix = dialPrefixOf(cachedSettings);
 			result = db.getBlockListByHeatAPI(dialPrefix, limit);
 			LOG.info("Sending Heat-ranked blocklist (dial={}, limit={}, minVotes {}) to user '{}' (agent '{}')",
 				dialPrefix, limit, db.getMinVisibleVotes(), userName, userAgent);
@@ -238,10 +265,17 @@ public class BlocklistServlet extends HttpServlet {
 					db.getMinVisibleVotes()),
 				MIN_DIRECT_OPTIONS);
 			int minRange = clampToAllowed(intParam(req, PARAM_MIN_RANGE, minDirect), MIN_RANGE_OPTIONS);
-			byte[] bytes = BinaryBlocklistCache.getInstance().getOrCompute(minDirect, minRange,
-					(d, r) -> encodeCommunity(db, d, r));
-			LOG.info("Sending binary community blocklist ({} bytes, minDirect {}, minRange {}) to user '{}' (agent '{}')",
-				bytes.length, minDirect, minRange, userName, userAgent);
+			// Storage budget snapped DOWN so the encoded file never exceeds the
+			// dongle's free flash; the direct section is truncated to fit.
+			int maxBytes = clampDownToAllowed(intParam(req, PARAM_MAX_BYTES, DEFAULT_BINARY_MAX_BYTES),
+				MAX_BYTES_OPTIONS);
+			// Region scope: the account's dial prefix restricts the Heat-ranked
+			// direct numbers to the user's region (#340). Part of the cache key.
+			String dialPrefix = dialPrefixOf(cachedSettings);
+			byte[] bytes = BinaryBlocklistCache.getInstance().getOrCompute(dialPrefix, minDirect, minRange, maxBytes,
+					(dp, d, r, mb) -> encodeCommunity(db, dp, d, r, mb));
+			LOG.info("Sending binary community blocklist ({} bytes, dial {}, minDirect {}, minRange {}, maxBytes {}) to user '{}' (agent '{}')",
+				bytes.length, dialPrefix, minDirect, minRange, maxBytes, userName, userAgent);
 			resp.setContentType(BINARY_CONTENT_TYPE);
 			resp.setContentLength(bytes.length);
 			resp.getOutputStream().write(bytes);
@@ -258,11 +292,27 @@ public class BlocklistServlet extends HttpServlet {
 		}
 	}
 
-	private static byte[] encodeCommunity(DB db, int minDirect, int minRange) {
+	/**
+	 * Encodes the size-capped, region-scoped community list. Wildcards and the
+	 * whitelist are taken in full; the Heat-ranked direct numbers fill whatever
+	 * record budget remains under {@code maxBytes}. Dedup in the encoder can
+	 * only shrink the result, so the encoded file never exceeds the budget
+	 * (unless the mandatory wildcards/whitelist alone already do — the dongle's
+	 * free-space pre-check is the backstop there).
+	 */
+	private static byte[] encodeCommunity(DB db, String dialPrefix, int minDirect, int minRange, int maxBytes) {
 		long now = System.currentTimeMillis();
-		Blocklist blocklist = db.getBlockListAPI();
 		DB.CommunityBinarySources sources = db.getCommunityBinarySources(minRange, now);
-		List<Entry> entries = CommunityEntries.from(blocklist, sources, minDirect, minRange, now);
+
+		// Always-included sections first, so their record count is known before
+		// budgeting the direct numbers.
+		List<Entry> entries = CommunityEntries.wildcardsAndWhitelist(sources, minRange, now);
+
+		int budgetRecords = (maxBytes - BlocklistBinaryFormat.HEADER_SIZE) / BlocklistBinaryFormat.RECORD_SIZE;
+		int directLimit = Math.max(0, budgetRecords - entries.size());
+		List<BlockListEntry> exact = db.getCommunityExactByHeat(dialPrefix, minDirect, directLimit, now);
+		entries.addAll(CommunityEntries.exactEntries(exact, minDirect));
+
 		ByteArrayOutputStream buf = new ByteArrayOutputStream();
 		try {
 			BlocklistBinaryEncoder.write(buf, entries);
@@ -286,6 +336,35 @@ public class BlocklistServlet extends HttpServlet {
 			}
 		}
 		return allowed[allowed.length - 1];
+	}
+
+	/**
+	 * Snaps {@code v} <em>down</em> to the largest entry of {@code allowed} that
+	 * is {@code <= v}, or the smallest entry when {@code v} is below all of them
+	 * (floor-clamp). {@code allowed} must be sorted ascending and non-empty.
+	 * Used for the {@code maxBytes} budget so the encoded file never exceeds the
+	 * caller's free space while keeping the cache key on a small shared grid.
+	 */
+	static int clampDownToAllowed(int v, int[] allowed) {
+		int result = allowed[0];
+		for (int a : allowed) {
+			if (a <= v) {
+				result = a;
+			} else {
+				break;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * The account's dial prefix as a region scope, normalising an empty setting
+	 * to {@code null} (the global, unscoped list). Shared by the Heat-ranked
+	 * JSON path and the binary community path.
+	 */
+	private static String dialPrefixOf(UserSettings settings) {
+		String dialPrefix = (settings != null) ? settings.getDialPrefix() : null;
+		return (dialPrefix != null && dialPrefix.isEmpty()) ? null : dialPrefix;
 	}
 
 	/**

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/CommunityEntries.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/CommunityEntries.java
@@ -74,10 +74,31 @@ public final class CommunityEntries {
 	 */
 	public static List<Entry> from(Blocklist exactCommunity, CommunityBinarySources sources,
 			int minDirect, int minRange, long now) {
+		List<Entry> result = exactEntries(exactCommunity.getNumbers(), minDirect);
+		result.addAll(wildcardsAndWhitelist(sources, minRange, now));
+		return result;
+	}
+
+	/**
+	 * Maps exact community spam rows to blacklist entries, dropping any below
+	 * {@code minDirect} net votes and any with an unrepresentable phone ID.
+	 *
+	 * <p>
+	 * Split out so the size-capped binary path can supply a pre-truncated,
+	 * Heat-ranked, region-scoped row list (see
+	 * {@code DB#getCommunityExactByHeat}) instead of the full exact blocklist:
+	 * the {@code minDirect} filter here is then a redundant safety net, since
+	 * the DB query already gated on the same net-evidence threshold.
+	 * </p>
+	 *
+	 * @param rows      Exact-entry rows (net, decay-aware votes per #338).
+	 * @param minDirect Exact-entry threshold; a row is kept iff its net votes
+	 *                  {@code >= minDirect}. Values below {@code 1} are clamped.
+	 */
+	public static List<Entry> exactEntries(List<BlockListEntry> rows, int minDirect) {
 		int directThreshold = Math.max(minDirect, 1);
 		List<Entry> result = new ArrayList<>();
-
-		for (BlockListEntry row : exactCommunity.getNumbers()) {
+		for (BlockListEntry row : rows) {
 			if (row.getVotes() < directThreshold) {
 				continue;
 			}
@@ -87,15 +108,27 @@ public final class CommunityEntries {
 			}
 			result.add(new Entry(digits, false, true));
 		}
+		return result;
+	}
 
-		// Wildcards only when range-blocking is on (minRange >= 1), mirroring
-		// the dongle API path's `range_hit = (min_range >= 1) && ...` guard.
+	/**
+	 * The always-included community sections: wildcard prefix blocks (when
+	 * range-blocking is on) and the global legitimate-number whitelist. These
+	 * are taken in full &mdash; they are small and the dongle wants them all
+	 * &mdash; so the size cap only ever truncates the exact section
+	 * ({@link #exactEntries}).
+	 *
+	 * @param minRange Wildcard threshold; blocks are emitted only when
+	 *                 {@code minRange >= 1} and their net evidence clears it,
+	 *                 mirroring the dongle API path's {@code range_hit} guard.
+	 */
+	public static List<Entry> wildcardsAndWhitelist(CommunityBinarySources sources, int minRange, long now) {
+		List<Entry> result = new ArrayList<>();
 		if (minRange >= 1) {
 			addAggregations(result, sources.aggregation10(), minRange, now);
 			addAggregations(result, sources.aggregation100(), minRange, now);
 		}
 		addWhitelist(result, sources.whitelist());
-
 		return result;
 	}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -1764,6 +1764,50 @@ public class DB {
 	}
 
 	/**
+	 * Exact community spam entries for the size-capped binary community list:
+	 * region-scoped, Heat-ranked and truncated to {@code limit}.
+	 *
+	 * <p>
+	 * Unlike {@link #getBlockListAPI()} (which returns the full exact list for
+	 * the JSON/unbounded paths), this keeps only the top {@code limit} numbers
+	 * by current Heat so a dongle with limited flash gets the spam it is most
+	 * likely to receive. A {@code null}/empty {@code dialPrefix} falls back to
+	 * the global Heat ranking (legacy clients, unmapped regions). Numbers
+	 * dropped by the cap still resolve correctly on the dongle: a local miss
+	 * falls back to the live {@code /num} API.
+	 * </p>
+	 *
+	 * <p>
+	 * The net-evidence gate uses {@code minDirect} (the dongle's
+	 * {@code min_direct_votes}, floored at the published threshold by the
+	 * servlet), so the encoded set is a Heat-ordered subset of exactly what the
+	 * dongle's API-fallback path would decide SPAM. Returns an empty list
+	 * without querying when {@code limit <= 0}.
+	 * </p>
+	 *
+	 * @param dialPrefix Region scope, or {@code null}/empty for the global list.
+	 * @param minDirect  Exact-entry net-vote threshold.
+	 * @param limit      Maximum number of entries (the budget-derived cap).
+	 * @param now        Reference time for decaying the EMA threshold.
+	 */
+	public List<BlockListEntry> getCommunityExactByHeat(String dialPrefix, int minDirect, int limit, long now) {
+		if (limit <= 0) {
+			return List.of();
+		}
+		try (SqlSession session = openSession()) {
+			SpamReports reports = session.getMapper(SpamReports.class);
+			double maxRawSpam = maxRawSpamAt(now, minDirect);
+			List<DBNumberInfo> raw = (dialPrefix != null && !dialPrefix.isEmpty())
+					? reports.getBlocklistByDialHeat(dialPrefix, maxRawSpam, limit)
+					: reports.getBlocklistByHeat(maxRawSpam, limit);
+			return raw.stream()
+					.map(DB::toBlocklistEntry)
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
+		}
+	}
+
+	/**
 	 * Gets blocklist changes since the given version (incremental sync).
 	 * Returns entries with VERSION > sinceVersion.
 	 *

--- a/phoneblock/src/main/webapp/api/phoneblock.json
+++ b/phoneblock/src/main/webapp/api/phoneblock.json
@@ -504,6 +504,16 @@
 						"type": "integer",
 						"minimum": 0
 					}
+				},
+				{
+					"name": "maxBytes",
+					"in": "query",
+					"description": "Only for `format=binary&type=community`. Storage budget for the encoded file, in bytes — typically the on-device client's free flash. The server keeps every qualifying wildcard block and the whole whitelist (small), then truncates the exact spam numbers, keeping the highest-ranked by region-aware Heat (most currently-active spam in the account's dial region), so the file fits the budget. Numbers dropped by the cap still resolve correctly on the device, which falls back to the live `/num` API on a local miss. The value is snapped down to a fixed grid (64/128/256/384/512 KB) so it never exceeds the budget and stays cacheable; a value below the smallest bucket still receives it. Defaults to 256 KB when omitted.",
+					"required": false,
+					"schema": {
+						"type": "integer",
+						"minimum": 1
+					}
 				}
 			]
 		},

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestBinaryBlocklistCache.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestBinaryBlocklistCache.java
@@ -13,23 +13,28 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link BinaryBlocklistCache}: hit/miss behaviour keyed by the
- * {@code (minDirect, minRange)} pair, TTL expiry, manual flush.
+ * {@code (dialPrefix, minDirect, minRange, maxBytes)} tuple, TTL expiry,
+ * manual flush.
  */
 class TestBinaryBlocklistCache {
 
 	/** 16 minutes — past the 15-minute TTL. */
 	private static final long PAST_TTL_NANOS = 1_000_000_000L * 60 * 16;
 
+	/** Default region / budget for tests not exercising those dimensions. */
+	private static final String DIAL = "+49";
+	private static final int BYTES = 262144;
+
 	@Test
 	void firstLookupComputesAndStores() {
 		AtomicInteger calls = new AtomicInteger();
 		BinaryBlocklistCache cache = new BinaryBlocklistCache();
 
-		byte[] first = cache.getOrCompute(4, 4, (d, r) -> {
+		byte[] first = cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { (byte) d, (byte) r };
 		});
-		byte[] second = cache.getOrCompute(4, 4, (d, r) -> {
+		byte[] second = cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { 99 };
 		});
@@ -46,11 +51,11 @@ class TestBinaryBlocklistCache {
 		AtomicInteger calls = new AtomicInteger();
 		BinaryBlocklistCache cache = new BinaryBlocklistCache();
 
-		byte[] a = cache.getOrCompute(4, 4, (d, r) -> {
+		byte[] a = cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { (byte) r };
 		});
-		byte[] b = cache.getOrCompute(4, 8, (d, r) -> {
+		byte[] b = cache.getOrCompute(DIAL, 4, 8, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { (byte) r };
 		});
@@ -67,11 +72,11 @@ class TestBinaryBlocklistCache {
 		AtomicInteger calls = new AtomicInteger();
 		BinaryBlocklistCache cache = new BinaryBlocklistCache();
 
-		byte[] a = cache.getOrCompute(4, 10, (d, r) -> {
+		byte[] a = cache.getOrCompute(DIAL, 4, 10, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { (byte) d };
 		});
-		byte[] b = cache.getOrCompute(8, 10, (d, r) -> {
+		byte[] b = cache.getOrCompute(DIAL, 8, 10, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { (byte) d };
 		});
@@ -84,17 +89,83 @@ class TestBinaryBlocklistCache {
 	}
 
 	@Test
+	void dialPrefixIsPartOfTheKey() {
+		// Region-scoped lists differ (#340), so two dial prefixes must not share
+		// a cache entry — otherwise a German dongle could get the French list.
+		AtomicInteger calls = new AtomicInteger();
+		BinaryBlocklistCache cache = new BinaryBlocklistCache();
+
+		byte[] de = cache.getOrCompute("+49", 4, 10, BYTES, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { (byte) dp.charAt(dp.length() - 1) };
+		});
+		byte[] fr = cache.getOrCompute("+33", 4, 10, BYTES, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { (byte) dp.charAt(dp.length() - 1) };
+		});
+
+		assertEquals(2, calls.get());
+		assertNotSame(de, fr);
+		assertEquals(2, cache.size());
+	}
+
+	@Test
+	void nullDialPrefixIsItsOwnKey() {
+		// The global (unscoped) list must not collide with any region's list.
+		AtomicInteger calls = new AtomicInteger();
+		BinaryBlocklistCache cache = new BinaryBlocklistCache();
+
+		cache.getOrCompute(null, 4, 10, BYTES, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { 0 };
+		});
+		cache.getOrCompute("+49", 4, 10, BYTES, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { 1 };
+		});
+		// Repeat the global lookup: must hit the cache, not recompute.
+		cache.getOrCompute(null, 4, 10, BYTES, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { 2 };
+		});
+
+		assertEquals(2, calls.get());
+		assertEquals(2, cache.size());
+	}
+
+	@Test
+	void maxBytesIsPartOfTheKey() {
+		// A larger budget yields a longer direct section, so two budgets must
+		// cache separately — a small dongle must not be served the big file.
+		AtomicInteger calls = new AtomicInteger();
+		BinaryBlocklistCache cache = new BinaryBlocklistCache();
+
+		byte[] small = cache.getOrCompute(DIAL, 4, 10, 65536, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { (byte) (mb >> 16) };
+		});
+		byte[] big = cache.getOrCompute(DIAL, 4, 10, 524288, (dp, d, r, mb) -> {
+			calls.incrementAndGet();
+			return new byte[] { (byte) (mb >> 16) };
+		});
+
+		assertEquals(2, calls.get());
+		assertNotSame(small, big);
+		assertEquals(2, cache.size());
+	}
+
+	@Test
 	void expiredEntryIsRecomputed() {
 		AtomicInteger calls = new AtomicInteger();
 		long[] clock = { 0L };
 		BinaryBlocklistCache cache = new BinaryBlocklistCache(() -> clock[0]);
 
-		byte[] first = cache.getOrCompute(4, 4, (d, r) -> {
+		byte[] first = cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { 1 };
 		});
 		clock[0] += PAST_TTL_NANOS;
-		byte[] refreshed = cache.getOrCompute(4, 4, (d, r) -> {
+		byte[] refreshed = cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { 2 };
 		});
@@ -107,15 +178,15 @@ class TestBinaryBlocklistCache {
 	@Test
 	void flushAllDropsEverything() {
 		BinaryBlocklistCache cache = new BinaryBlocklistCache();
-		cache.getOrCompute(4, 4, (d, r) -> new byte[] { 1 });
-		cache.getOrCompute(8, 8, (d, r) -> new byte[] { 2 });
+		cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> new byte[] { 1 });
+		cache.getOrCompute(DIAL, 8, 8, BYTES, (dp, d, r, mb) -> new byte[] { 2 });
 		assertEquals(2, cache.size());
 
 		cache.flushAll();
 		assertEquals(0, cache.size());
 
 		AtomicInteger calls = new AtomicInteger();
-		cache.getOrCompute(4, 4, (d, r) -> {
+		cache.getOrCompute(DIAL, 4, 4, BYTES, (dp, d, r, mb) -> {
 			calls.incrementAndGet();
 			return new byte[] { 9 };
 		});

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestBlocklistServlet.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestBlocklistServlet.java
@@ -40,4 +40,16 @@ class TestBlocklistServlet {
 		assertEquals(500, BlocklistServlet.clampToAllowed(600, o), "above max → capped at max");
 	}
 
+	@Test
+	void clampBytesFloorsToNearestBudget() {
+		int[] o = BlocklistServlet.MAX_BYTES_OPTIONS; // {64k,128k,256k,384k,512k}
+		assertEquals(65536, BlocklistServlet.clampDownToAllowed(1000, o), "below min → min (pre-check backstops)");
+		assertEquals(65536, BlocklistServlet.clampDownToAllowed(65536, o));
+		assertEquals(65536, BlocklistServlet.clampDownToAllowed(131071, o), "just under 128k floors to 64k");
+		assertEquals(131072, BlocklistServlet.clampDownToAllowed(131072, o));
+		assertEquals(262144, BlocklistServlet.clampDownToAllowed(300000, o), "300k floors to 256k");
+		assertEquals(524288, BlocklistServlet.clampDownToAllowed(524288, o));
+		assertEquals(524288, BlocklistServlet.clampDownToAllowed(900000, o), "above max → capped at max");
+	}
+
 }

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestCommunityEntries.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestCommunityEntries.java
@@ -178,6 +178,53 @@ class TestCommunityEntries {
 		assertNull(CommunityEntries.phoneIdToE164Digits(null));
 	}
 
+	@Test
+	void exactEntriesHelperFiltersByMinDirect() {
+		// The capped binary path feeds exactEntries a pre-truncated row list;
+		// the minDirect filter is the redundant safety net.
+		List<Entry> entries = CommunityEntries.exactEntries(
+			List.of(row("+4930111", 10), row("+4930222", 3)), 5);
+
+		assertEquals(1, entries.size());
+		assertTrue(containsBlackExact(entries, "4930111"));
+		assertFalse(containsBlackExact(entries, "4930222"), "3 votes < minDirect 5 dropped");
+	}
+
+	@Test
+	void wildcardsAndWhitelistExcludesExactEntries() {
+		// The "take all" sections must contain only wildcards + whitelist, never
+		// the exact black numbers — those are budgeted separately.
+		DB.CommunityBinarySources sources = new DB.CommunityBinarySources(
+			List.of(agg("030", 5, 9.0, 0.0)),
+			List.of(),
+			Set.of("030999"));
+
+		List<Entry> entries = CommunityEntries.wildcardsAndWhitelist(sources, 1, NOW);
+
+		assertEquals(2, entries.size());
+		assertTrue(containsBlackWildcard(entries, "4930"), "wildcard prefix present");
+		assertTrue(entries.stream().anyMatch(e -> !e.black() && "4930999".equals(e.digits())),
+			"whitelist entry present as a white record");
+	}
+
+	@Test
+	void fromEqualsSplitHelpersCombined() {
+		// from() must stay a faithful combiner of the two helpers, so the
+		// existing callers/tests keep their meaning after the refactor.
+		Blocklist blocklist = community(row("+4930111", 10));
+		DB.CommunityBinarySources sources = new DB.CommunityBinarySources(
+			List.of(agg("030", 5, 9.0, 0.0)), List.of(), Set.of("030999"));
+
+		List<Entry> combined = CommunityEntries.from(blocklist, sources, 1, 1, NOW);
+
+		List<Entry> manual = CommunityEntries.exactEntries(blocklist.getNumbers(), 1);
+		manual.addAll(CommunityEntries.wildcardsAndWhitelist(sources, 1, NOW));
+
+		assertEquals(manual.size(), combined.size());
+		assertTrue(containsBlackExact(combined, "4930111"));
+		assertTrue(containsBlackWildcard(combined, "4930"));
+	}
+
 	private static boolean containsBlackExact(List<Entry> entries, String digits) {
 		return entries.stream().anyMatch(e -> !e.wildcard() && e.black() && digits.equals(e.digits()));
 	}


### PR DESCRIPTION
## Problem

The dongle's local **community cache download was unbounded**. At the dongle's lowest thresholds (`minDirect=2`, `minRange=10`) the binary community list is **~417 KB** (measured on the test instance), which does not fit the **640 KB** storage SPIFFS partition it shares with the answering-machine announcement. The daily sync failed mid-write:

```
"blocklist": { "last_ok": false, "last_error": "fwrite short at 300032 bytes", ... }
```

A second, structural issue: the binary list was **not** region-localized — it shipped the global spam list, unlike the JSON `?limit=` Heat path which is region-aware (#340).

## Approach

Records are fixed 8 bytes (+16 header), so a byte budget maps exactly to a record cap. The server now:

1. Keeps **all** wildcard blocks (gated by `minRange`) and the **whole** whitelist — small, and the dongle wants them all.
2. Fills the remaining record budget with the **region-aware Heat-ranked** direct numbers (most currently-active spam in the account's dial region).

Numbers dropped by the cap still resolve correctly — a local miss falls back to the live `/num` API.

## Changes

**Server (`phoneblock`)**
- `BlocklistServlet`: new `maxBytes` query param, floor-snapped to a shared `{64,128,256,384,512}KB` grid via `clampDownToAllowed` (never exceeds the dongle's budget, keeps the cache key bounded); derives the account `dialPrefix` for region scoping.
- `DB.getCommunityExactByHeat(dialPrefix, minDirect, limit, now)`: region-scoped, `minDirect`-gated, Heat-ranked, limited exact entries (reuses the #340 `getBlocklistByDialHeat` query).
- `CommunityEntries`: split into `exactEntries()` + `wildcardsAndWhitelist()`; `from()` kept as the combiner.
- `BinaryBlocklistCache`: key extended to `(dialPrefix, minDirect, minRange, maxBytes)`.
- OpenAPI: documents `maxBytes`.

**Firmware (`phoneblock-dongle`)**
- Sends `&maxBytes` computed from `esp_spiffs_info` free space (+ reclaimable old file − margin).
- Free-space pre-check refuses an over-budget download with a clean error instead of a half-written `.tmp`; keeps the old list intact when the new one won't fit, and only reclaims the old file first when space is tight (drops the 2× refresh peak).

## Testing

- `phoneblock`: **339 tests pass** — added `dialPrefix`/`maxBytes` cache-key tests, `clampDownToAllowed`, and `CommunityEntries` split-helper tests.
- Firmware: builds clean (`idf.py build`, exit 0).
- Not yet verified end-to-end: needs the server deployed to `pb-test` and the new firmware flashed.

## Relationship to #399

Independent of #399 (the cache enable/disable switch). Both touch `blocklist_sync.c` in non-overlapping regions, so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)