### PR TITLE
Dongle: fix blocklist sync "rename: I/O error"

### DIFF
--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include "freertos/FreeRTOS.h"
@@ -84,16 +83,6 @@ static void refresh_sizes_locked(void)
 // Streaming HTTPS download into a temp file.
 // ---------------------------------------------------------------------------
 
-// Size of a file in bytes, or 0 if it does not exist / cannot be stat'd.
-static int64_t file_size_bytes(const char *path)
-{
-    struct stat st;
-    if (stat(path, &st) != 0) {
-        return 0;
-    }
-    return (int64_t) st.st_size;
-}
-
 // Free bytes on the storage SPIFFS partition, or -1 if it cannot be read.
 static int64_t spiffs_free_bytes(void)
 {
@@ -105,25 +94,25 @@ static int64_t spiffs_free_bytes(void)
 }
 
 // Storage budget the dongle offers the community file: current free space
-// plus the bytes the existing community file frees when replaced, minus a
-// margin for SPIFFS overhead and the small personal list. Sent to the server
-// as &maxBytes so it caps the encoded file to what actually fits here.
+// minus a margin for SPIFFS overhead and the small personal list. The old
+// community file is deleted before the download starts (see sync_one), so
+// its bytes are already part of this free count — no need to add them back.
+// Sent to the server as &maxBytes so it caps the encoded file to what fits.
 static int64_t community_budget_bytes(void)
 {
     int64_t freeb = spiffs_free_bytes();
     if (freeb < 0) {
         return DEFAULT_COMMUNITY_BUDGET;
     }
-    int64_t budget = freeb + file_size_bytes(BLOCKLIST_COMMUNITY_PATH) - BLOCKLIST_FS_MARGIN;
+    int64_t budget = freeb - BLOCKLIST_FS_MARGIN;
     return budget > 0 ? budget : 0;
 }
 
-// Downloads `url` into `tmp_path`. `final_path` is the file `tmp_path` will be
-// renamed onto by the caller; its current bytes are reclaimable, so they count
-// toward the space available for this download. On any error returns false and
-// writes a message to `err`.
+// Downloads `url` into `tmp_path`. The caller has already removed the live
+// file this temp will be renamed onto, so the whole free partition is
+// available here. On any error returns false and writes a message to `err`.
 static bool download_to_tmp(const char *url, const char *tmp_path,
-                            const char *final_path, char *err, size_t err_cap)
+                            char *err, size_t err_cap)
 {
     FILE *out = fopen(tmp_path, "wb");
     if (out == NULL) {
@@ -171,29 +160,20 @@ static bool download_to_tmp(const char *url, const char *tmp_path,
         return false;
     }
 
-    // Storage pre-check. Turn a mid-write ENOSPC (which leaves a half-written
-    // .tmp) into a clean, actionable error before any bytes land. The file we
-    // are about to replace is reclaimable: if the body fits beside it, keep it
-    // until the atomic rename; if not but it fits once the old one is freed,
-    // reclaim it now (losing the old-file fallback for this download window);
-    // if it does not fit even then, refuse and leave the old file intact.
+    // Storage pre-check: refuse a body that won't fit before any bytes land,
+    // turning a mid-write ENOSPC (which strands a half-written .tmp) into a
+    // clean, actionable error. The old live file was already removed by the
+    // caller, so the free count is exactly what this download has to work with.
     if (content_length > 0) {
         int64_t freeb = spiffs_free_bytes();
-        if (freeb >= 0) {
-            int64_t need = content_length + BLOCKLIST_FS_MARGIN;
-            if (need > freeb) {
-                int64_t reclaim = file_size_bytes(final_path);
-                if (need > freeb + reclaim) {
-                    snprintf(err, err_cap, "too large: %lld B needs > %lld B free",
-                             (long long) content_length, (long long) (freeb + reclaim));
-                    esp_http_client_close(client);
-                    esp_http_client_cleanup(client);
-                    fclose(out);
-                    unlink(tmp_path);
-                    return false;
-                }
-                unlink(final_path);
-            }
+        if (freeb >= 0 && content_length + BLOCKLIST_FS_MARGIN > freeb) {
+            snprintf(err, err_cap, "too large: %lld B needs > %lld B free",
+                     (long long) content_length, (long long) freeb);
+            esp_http_client_close(client);
+            esp_http_client_cleanup(client);
+            fclose(out);
+            unlink(tmp_path);
+            return false;
         }
     }
 
@@ -260,6 +240,17 @@ static bool tmp_parses_ok(const char *tmp_path)
 static bool sync_one(const char *type, const char *path, const char *tmp_path,
                      char *err, size_t err_cap)
 {
+    // Drop the old cached file up front, before downloading the new one.
+    // SPIFFS has no atomic replace — rename() onto an existing name returns
+    // SPIFFS_ERR_CONFLICTING_NAME, which the VFS maps to the catch-all EIO,
+    // so a temp+rename swap fails with "rename …: I/O error" on every run
+    // after the first. Removing the live file first makes the rename target
+    // absent (so it succeeds) and means only one copy is ever on flash, so
+    // the download never needs double the space. The cost is no on-flash
+    // fallback during the download window: if the sync fails, the call-time
+    // path falls back to the PhoneBlock API until the next successful run.
+    unlink(path);
+
     char url[256];
     int n = snprintf(url, sizeof(url), "%s/api/blocklist?format=binary&type=%s",
                      config_phoneblock_base_url(), type);
@@ -282,7 +273,7 @@ static bool sync_one(const char *type, const char *path, const char *tmp_path,
 
     unlink(tmp_path);
 
-    if (!download_to_tmp(url, tmp_path, path, err, err_cap)) {
+    if (!download_to_tmp(url, tmp_path, err, err_cap)) {
         unlink(tmp_path);
         return false;
     }

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -12,6 +12,7 @@
 #include "esp_http_server.h"
 #include "esp_ota_ops.h"
 #include "esp_partition.h"
+#include "esp_spiffs.h"       // esp_spiffs_info for the data-partition readout
 #include "esp_system.h"       // esp_restart
 #include "esp_wifi.h"         // esp_wifi_restore for factory-reset
 #include "freertos/FreeRTOS.h"
@@ -248,6 +249,19 @@ static void add_system_load(cJSON *root)
     cJSON *sys = cJSON_AddObjectToObject(root, "system");
     cJSON_AddNumberToObject(sys, "free_heap",     (double)esp_get_free_heap_size());
     cJSON_AddNumberToObject(sys, "min_free_heap", (double)esp_get_minimum_free_heap_size());
+
+    // Data-partition (SPIFFS "storage") usage. The blocklist cache, the
+    // announcement blob and the temp files used during sync all share this
+    // one mount; a nearly-full partition is the working hypothesis for the
+    // "rename …: I/O error" the blocklist sync reports, so surface the live
+    // free-byte count here for field diagnosis. Same label as
+    // announcement.c / blocklist_sync.c.
+    size_t fs_total = 0, fs_used = 0;
+    if (esp_spiffs_info("storage", &fs_total, &fs_used) == ESP_OK) {
+        cJSON_AddNumberToObject(sys, "fs_total", (double)fs_total);
+        cJSON_AddNumberToObject(sys, "fs_used",  (double)fs_used);
+        cJSON_AddNumberToObject(sys, "fs_free",  (double)(fs_total - fs_used));
+    }
 
 #if CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
     UBaseType_t cap = uxTaskGetNumberOfTasks() + 4;   // headroom for mid-sample spawns

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -170,6 +170,7 @@ const I18N = {
     'status.thresholds.invalid': 'Ungültiger Wert.',
     'status.system.title': 'System',
     'status.system.heap': 'Freier Speicher: {free} (Minimum: {min})',
+    'status.system.fs': 'Datenpartition: {free} frei von {total} ({used} belegt)',
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack frei',
@@ -432,6 +433,7 @@ const I18N = {
     'status.thresholds.invalid': 'Invalid value.',
     'status.system.title': 'System',
     'status.system.heap': 'Free memory: {free} (minimum: {min})',
+    'status.system.fs': 'Data partition: {free} free of {total} ({used} used)',
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack free',
@@ -681,6 +683,7 @@ const I18N = {
     'status.calls.log_known.help': 'Si désactivé, les appels provenant de numéros du carnet d’adresses et les codes internes (**, *…) n’apparaissent pas dans la liste — les compteurs ci-dessus restent mis à jour.',
     'status.system.title': 'Système',
     'status.system.heap': 'Mémoire libre : {free} (minimum : {min})',
+    'status.system.fs': 'Partition de données : {free} libres sur {total} ({used} utilisés)',
     'status.system.col.task': 'Tâche',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pile libre',
@@ -930,6 +933,7 @@ const I18N = {
     'status.calls.log_known.help': 'Si está desactivado, las llamadas de números de la agenda y los códigos internos (**, *…) no aparecen en la lista — los contadores de arriba se siguen actualizando.',
     'status.system.title': 'Sistema',
     'status.system.heap': 'Memoria libre: {free} (mínimo: {min})',
+    'status.system.fs': 'Partición de datos: {free} libres de {total} ({used} usados)',
     'status.system.col.task': 'Tarea',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pila libre',
@@ -1387,7 +1391,8 @@ function renderStatus(){
     + '</details>'
     + '<details id="systemSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.system.title')) + '</summary>'
-    + '<p id="systemHeap" class="muted" style="font-size:.85rem;margin:.2rem 0 .6rem"></p>'
+    + '<p id="systemHeap" class="muted" style="font-size:.85rem;margin:.2rem 0 .2rem"></p>'
+    + '<p id="systemFs" class="muted" style="font-size:.85rem;margin:0 0 .6rem"></p>'
     + '<table style="width:100%;border-collapse:collapse;font-size:.8rem"><thead><tr>'
     + '<th style="text-align:left">'   + esc(t('status.system.col.task'))  + '</th>'
     + '<th style="text-align:right">'  + esc(t('status.system.col.cpu'))   + '</th>'
@@ -2116,6 +2121,15 @@ async function refreshAll(){
     $('systemHeap').textContent = t('status.system.heap', {
       free: kb(s.system.free_heap), min: kb(s.system.min_free_heap),
     });
+    if (s.system.fs_total != null) {
+      $('systemFs').style.display = '';
+      $('systemFs').textContent = t('status.system.fs', {
+        free: kb(s.system.fs_free), total: kb(s.system.fs_total),
+        used: kb(s.system.fs_used),
+      });
+    } else {
+      $('systemFs').style.display = 'none';
+    }
     const tb = $('systemTasks');
     tb.innerHTML = '';
     const tasks = (s.system.tasks || []).slice()


### PR DESCRIPTION
## Problem

The dongle's local blocklist cache failed to refresh on every sync after the first, reporting:

```
[blsync] community sync failed: rename community: I/O error
[blsync] personal sync failed: rename personal: I/O error
```

Reproduced live on a test device — **not** a space problem: the data partition had 423 KB of 473 KB free.

## Root cause

SPIFFS `rename()` refuses to overwrite an existing destination. When the target name already exists, `SPIFFS_rename()` returns `SPIFFS_ERR_CONFLICTING_NAME` (`spiffs_hydrogen.c`), which the SPIFFS VFS has no case for and maps to the catch-all `EIO` (`esp_spiffs.c`).

`sync_one()` downloaded into a `.tmp` and then `rename()`'d it over the live file. So the **first** sync (no file yet) succeeded and **every** sync afterwards failed. The pre-existing storage pre-check only unlinked the live file early when the new download wouldn't otherwise fit — so the failure surfaced precisely when free space was *ample*.

## Fix

Delete the live file up front, before the download. The rename target is then always absent (so the swap succeeds) and only one copy is ever on flash, so the download never needs double the space. This also lets the reclaim branch, the `final_path` plumbing, the `file_size_bytes()` helper, and the "free + old-file-size" term in `community_budget_bytes()` go away.

Tradeoff (documented in code): no on-flash fallback during the download window — a failed sync leaves no cache until the next run, and call-time lookups fall back to the PhoneBlock API meanwhile.

## Diagnostic (second commit)

Adds the SPIFFS "storage" partition's total/used/free to `/api/status` (`system.fs_*`) and a "Datenpartition" line under the System card (de/en/fr/es). This is what disproved the space hypothesis from the field and is a useful permanent readout for the shared blocklist/announcement mount.

## Verification

Built and flashed onto a live device via OTA. From the failing precondition (both cache files already present), a triggered sync now completes with `last_ok=true` and no error; `fs_used` stays flat, confirming only one copy is on flash at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)