### PR TITLE
Dongle: wall-clock time synchronization (SNTP + timezone + daily scheduling)

### DIFF
--- a/docs/plans/2026-06-22-dongle-time-sync.md
+++ b/docs/plans/2026-06-22-dongle-time-sync.md
@@ -216,7 +216,8 @@ were parked on the "+1 h retry" recompute against real local time immediately.
 
 ### Migration of existing jobs
 
-The status `mail` job becomes `SCHED_DAILY` at a fixed local hour (08:00) — it
+The status `mail` job becomes `SCHED_DAILY` at a fixed local hour
+(`CONFIG_MAIL_DAILY_HOUR`, default 23:00, to flush the day's spam reports) — it
 is the natural consumer of the wall clock and the point of the feature. It keeps
 its boot-relative `first_delay_s` first run (a `SCHED_DAILY` job may also fire
 soon after boot), so a post-crash error still mails within minutes instead of
@@ -291,5 +292,6 @@ would re-introduce exactly that thundering herd.
    behavior change).
 2. Timezone config + browser learning + Berlin default.
 3. Scheduler `SCHED_DAILY` support + host tests.
-4. Convert the status mail job to a fixed daily send (08:00 local), keeping its
-   boot-relative first run.
+4. Convert the status mail job to a fixed daily send
+   (`CONFIG_MAIL_DAILY_HOUR`, default 23:00 local), keeping its boot-relative
+   first run.

--- a/docs/plans/2026-06-22-dongle-time-sync.md
+++ b/docs/plans/2026-06-22-dongle-time-sync.md
@@ -1,0 +1,285 @@
+# Dongle Time Synchronization — Wall Clock + Timezone
+
+**Goal:** Give the dongle a real wall clock so the scheduler can run jobs at a
+*specified time of day* (e.g. "send the status mail at 08:00 local"), not just on
+relative intervals. Today everything is driven by `esp_timer_get_time()`
+(microseconds since boot); there is no calendar time and SNTP is not enabled.
+
+**Approach in one line:** Acquire UTC via SNTP with an auto-discovered server
+(DHCP option 42 → default gateway → `pool.ntp.org`), apply a POSIX timezone
+(default *Europe/Berlin*, optionally learned from the browser hitting the web
+UI), and extend the scheduler with wall-clock "time-of-day" jobs alongside the
+existing interval jobs. `esp_timer` keeps bridging drift between SNTP syncs.
+
+---
+
+## 1. New module: `time_sync.c` / `time_sync.h`
+
+Owns clock acquisition and the timezone. Registered in `main/CMakeLists.txt`.
+
+### Public API
+
+```c
+void   time_sync_start(void);          // wire SNTP, register IP-event callbacks
+bool   time_sync_valid(void);          // true once the clock was set at least once
+int64_t time_sync_now_epoch(void);     // UTC seconds since 1970, or 0 if !valid
+void   time_sync_set_timezone(const char *posix_tz); // setenv("TZ")+tzset(), persist
+```
+
+### Server discovery (priority order)
+
+Build the SNTP server list so lwIP tries, in order:
+
+1. **DHCP option 42.** Enable in `sdkconfig.defaults`:
+   ```
+   CONFIG_LWIP_DHCP_GET_NTP_SRV=y
+   ```
+   and in the SNTP config:
+   ```c
+   esp_sntp_config_t cfg = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+   cfg.start                      = false;   // wait until we have an IP
+   cfg.server_from_dhcp           = true;    // adopt option-42 servers
+   cfg.index_of_first_server      = 1;       // DHCP fills index 0, pushes fallback down
+   cfg.renew_servers_after_new_IP = true;
+   cfg.ip_event_to_renew          = IP_EVENT_STA_GOT_IP;
+   esp_netif_sntp_init(&cfg);
+   ```
+2. **Default gateway.** In the `on_got_ip` path, read `ip_info.gw` (already
+   available in `wifi.c` — see `esp_netif_get_ip_info(s_sta_netif, …)` at
+   `wifi.c:363`), format it, and register it as an explicit server via
+   `esp_sntp_setservername(1, gw_str)` (or rebuild the list). The Fritz!Box —
+   PhoneBlock's dominant target — always runs an NTP server on its LAN address,
+   so this resolves on essentially every home network even when option 42 is
+   absent.
+3. **`pool.ntp.org`.** The compile-time fallback baked into the config above;
+   only used if both LAN paths fail and outbound UDP/123 to the internet is open.
+
+`time_sync_start()` is called once from `main.c` after Wi-Fi init.
+`esp_netif_sntp_start()` is invoked from the existing `on_got_ip` handler in
+`wifi.c` (we already have an IP-event hook there). On each (re)connect, SNTP
+re-resolves the DHCP servers thanks to `renew_servers_after_new_IP`.
+
+### Applying the time
+
+Use the SNTP "time set" notification (`cfg.sync_cb`) to:
+- mark `time_sync_valid()` true,
+- log a single `ESP_LOGI` ("clock set: 2026-06-22T07:00:00Z via <server>") —
+  it lands in the web-UI Protokoll panel automatically (see firmware CLAUDE.md),
+- notify the scheduler so any wall-clock jobs recompute their next-due time.
+
+Drift between syncs is handled for free: once `settimeofday()` is called (lwIP
+SNTP does this internally), `gettimeofday()` advances off the same monotonic
+source as `esp_timer`. Set `cfg.smooth_sync = false` (step, not slew) — a few-ms
+jump is irrelevant for time-of-day scheduling and stepping converges instantly.
+
+---
+
+## 2. Timezone handling
+
+The scheduler needs **local** time. SNTP gives **UTC**, so we apply a POSIX TZ
+string with `setenv("TZ", tz, 1); tzset();`, after which `localtime_r()` yields
+local wall-clock with correct DST.
+
+**Important constraint:** ESP-IDF's newlib has **no IANA tz database**. You
+cannot pass `"Europe/Berlin"` to `tzset()`; you must pass the POSIX form
+`"CET-1CEST,M3.5.0,M10.5.0/3"`. That shapes the design below.
+
+### Default
+
+`CONFIG_DONGLE_DEFAULT_TZ` Kconfig, default `"CET-1CEST,M3.5.0,M10.5.0/3"`
+(Europe/Berlin). Applied at boot in `config_load()` even before SNTP completes,
+so the very first clock-set already lands in local time.
+
+### Persisted setting
+
+Add a `timezone` field to the config layer:
+- getter `const char *config_timezone(void);` (returns NVS value or the Kconfig
+  default),
+- `const char *timezone;` in `config_update_t` (NULL = leave unchanged),
+- NVS key `"timezone"` storing the **POSIX** string.
+
+### Learning the timezone from the browser — yes, this works
+
+The browser knows the user's zone and its full DST rules; the dongle does not.
+Flow:
+
+1. In `web/index.html`, on first load (or when `config.timezone` is still the
+   default), the page computes a POSIX TZ string from the browser and offers to
+   save it (auto-save on first setup, or a "Use this device's timezone" button).
+
+   - IANA name for display: `Intl.DateTimeFormat().resolvedOptions().timeZone`
+     → e.g. `"Europe/Berlin"`.
+   - POSIX string for the firmware: derive it in JS from the browser's own
+     offsets so it is correct for *any* zone without an on-device table.
+     Sketch:
+     ```js
+     function posixTZ() {
+       const y = new Date().getFullYear();
+       const jan = -new Date(y,0,1).getTimezoneOffset();   // minutes east of UTC
+       const jul = -new Date(y,6,1).getTimezoneOffset();
+       const std = Math.min(jan, jul), dst = Math.max(jan, jul);
+       const abbr = Intl.DateTimeFormat('en',{timeZoneName:'short'})
+                      .formatToParts(new Date()).find(p=>p.type==='timeZoneName').value;
+       const off = m => { const a=Math.abs(m); // POSIX sign is inverted
+         return (m<=0?'+':'-')+String(Math.floor(a/60)).padStart(2,'0')
+              + (a%60?':'+String(a%60).padStart(2,'0'):''); };
+       if (std === dst) return `${stdAbbr()}${off(std)}`;        // no DST
+       // With DST: emit std/dst abbrevs + offsets; transition rules (M-format)
+       // are filled from the detected northern/southern hemisphere ordering.
+       // For the European audience this reduces to the Berlin rule set; a small
+       // helper finds the last-Sunday transitions to stay correct elsewhere.
+       return buildWithRules(std, dst, abbr);
+     }
+     ```
+     This keeps DST rules authoritative (generated from the browser) and needs
+     **no IANA→POSIX table on the device**.
+
+2. The page POSTs the POSIX string (and the IANA name, for display only) to
+   `/api/config` as `timezone=<posix>`.
+
+3. `handle_config_post` validates it cheaply (length ≤ 63, prints to a
+   `time_t`/`tzset` round-trip) and calls `config_update({.timezone = …})`,
+   which persists to NVS and calls `time_sync_set_timezone()` to apply it live.
+
+**Fallbacks / robustness:**
+- If JS is disabled or the dongle is configured purely via API, the Berlin
+  default stands — never blocks setup.
+- Optional belt-and-suspenders: keep a *tiny* IANA→POSIX table for the handful
+  of Central-European zones, used only if the browser sends an IANA name but no
+  usable POSIX string. Not required if the JS generator above is shipped.
+- Reject obviously bad input server-side; on parse failure keep the previous TZ.
+
+> Privacy note: the timezone is derived locally in the browser and sent only to
+> the user's own dongle on the LAN — nothing leaves the network.
+
+---
+
+## 3. Scheduler changes (`scheduler.c`)
+
+Today every job is `interval_s ± jitter` off `esp_timer` (`next_due_us`,
+monotonic). Add a second job kind without disturbing the existing ones.
+
+### Job model
+
+Extend `sched_job_t` with a schedule kind:
+
+```c
+typedef enum { SCHED_INTERVAL, SCHED_DAILY } sched_kind_t;
+
+typedef struct {
+    const char  *name;
+    sched_kind_t kind;
+    // INTERVAL jobs: as today
+    uint32_t     interval_s;
+    uint32_t     jitter_s;
+    uint32_t     first_delay_s;
+    // DAILY jobs: local time-of-day
+    uint8_t      at_hour;     // 0..23 local
+    uint8_t      at_minute;   // 0..59 local
+    int64_t      next_due_us; // still an esp_timer instant (see below)
+    void       (*run)(void);
+} sched_job_t;
+```
+
+### Computing the next due time for `SCHED_DAILY`
+
+Keep the wait loop exactly as it is — it sleeps until the smallest
+`next_due_us` (an `esp_timer` instant). Only the *computation* of `next_due_us`
+changes for daily jobs:
+
+```c
+static int64_t next_due_daily(const sched_job_t *j, int64_t now_us) {
+    if (!time_sync_valid())
+        return now_us + (int64_t)3600 * 1000000;   // retry in 1 h until clock is set
+    time_t   utc = time(NULL);
+    struct tm lt; localtime_r(&utc, &lt);           // honours TZ + DST
+    struct tm tgt = lt;
+    tgt.tm_hour = j->at_hour; tgt.tm_min = j->at_minute; tgt.tm_sec = 0;
+    time_t when = mktime(&tgt);
+    if (when <= utc) when += 24*3600;               // already past today → tomorrow
+    int64_t delta_us = (int64_t)(when - utc) * 1000000;
+    return now_us + delta_us;                        // back into esp_timer domain
+}
+```
+
+This deliberately re-anchors the wall-clock target onto the monotonic
+`esp_timer` axis the wait loop already uses — so the existing
+`seconds_to_ticks()` sleep, manual-trigger notifications, and per-job
+rescheduling all keep working untouched. DST shifts and clock steps self-correct
+because `next_due_daily()` is recomputed from `localtime_r` after every run.
+
+### Recompute on clock set
+
+When SNTP first sets the clock (or after a large step), `time_sync` notifies the
+scheduler (reuse the existing task-notification mechanism) so daily jobs that
+were parked on the "+1 h retry" recompute against real local time immediately.
+
+### Migration of existing jobs
+
+Leave `selftest`, `fw_update`, `sync`, `mail`, `blocklist` as `SCHED_INTERVAL`
+for now — behavior unchanged. The *enabling* outcome of this work is that we
+*can* convert any of them (most naturally the status `mail`) to `SCHED_DAILY`
+once the clock is trusted. Converting `mail` to a fixed morning send is the
+obvious first consumer and a good acceptance test.
+
+---
+
+## 4. Web UI / status surface
+
+- `/api/status` (`handle_status`): add a `time` object — `{ valid, epoch_s,
+  iso8601_local, tz }` — so the dashboard can show "Uhrzeit: 22.06.2026 09:00
+  (Europe/Berlin)" and so QA can confirm sync without a serial console.
+- `web/index.html`: show current device time + a timezone field (pre-filled from
+  the browser via the generator in §2), POSTing to `/api/config`.
+- All new user-facing strings: German inline in the template per the I18N rules;
+  any Java-side strings are out of scope (this is firmware + embedded HTML).
+
+---
+
+## 5. Config / build wiring
+
+- `main/Kconfig.projbuild`: `CONFIG_DONGLE_DEFAULT_TZ` (default Berlin POSIX
+  string).
+- `sdkconfig.defaults`: `CONFIG_LWIP_DHCP_GET_NTP_SRV=y`.
+- `config.h/.c`: `config_timezone()` getter + `timezone` in `config_update_t`
+  + NVS key (no schema migration needed — NVS is key/value, unknown-key-absent
+  falls back to the Kconfig default, matching the existing pattern).
+- `main/CMakeLists.txt`: add `time_sync.c` to `SRCS`.
+- `main.c`: call `time_sync_start()` after Wi-Fi/netif init; `wifi.c` `on_got_ip`
+  calls `esp_netif_sntp_start()`.
+
+---
+
+## 6. Testing
+
+- **Host tests** (existing harness pattern, cf. `tr064_parse`/`log_capture`):
+  - `next_due_daily()` pure logic: target later today, target already passed →
+    tomorrow, across a DST boundary, and `!time_sync_valid()` → +1 h retry.
+  - POSIX-TZ validation in the config handler (accept Berlin string, reject
+    overly long / garbage).
+- **QEMU / on-device:**
+  - Boot with no DHCP option 42 → confirm it falls back to the gateway and the
+    clock sets (log line + `/api/status.time.valid`).
+  - Set a daily job to "now+2 min", confirm it fires once at the wall-clock
+    minute and reschedules to +24 h.
+  - Change timezone via the web UI → `/api/status` reflects new local time and a
+    daily job's next-due shifts accordingly.
+
+---
+
+## 7. Out of scope / non-goals
+
+- No battery-backed external RTC (always-online, mains-powered device; the
+  internal RTC has no backup and is not used as a source of truth).
+- No sub-second accuracy guarantees; time-of-day granularity is the target.
+- TR-064 router-time acquisition is **not** in this plan (SNTP-to-gateway gives
+  the same LAN-local source more simply); it remains a possible future fallback
+  if a deployment surfaces a router that serves no NTP.
+
+## Rollout order
+
+1. `time_sync` module + SNTP discovery + `/api/status.time` (observable, no
+   behavior change).
+2. Timezone config + browser learning + Berlin default.
+3. Scheduler `SCHED_DAILY` support + host tests.
+4. (Optional, follow-up) Convert the status mail job to a fixed daily send.

--- a/docs/plans/2026-06-22-dongle-time-sync.md
+++ b/docs/plans/2026-06-22-dongle-time-sync.md
@@ -216,11 +216,20 @@ were parked on the "+1 h retry" recompute against real local time immediately.
 
 ### Migration of existing jobs
 
-Leave `selftest`, `fw_update`, `sync`, `mail`, `blocklist` as `SCHED_INTERVAL`
-for now — behavior unchanged. The *enabling* outcome of this work is that we
-*can* convert any of them (most naturally the status `mail`) to `SCHED_DAILY`
-once the clock is trusted. Converting `mail` to a fixed morning send is the
-obvious first consumer and a good acceptance test.
+The status `mail` job becomes `SCHED_DAILY` at a fixed local hour (08:00) — it
+is the natural consumer of the wall clock and the point of the feature. It keeps
+its boot-relative `first_delay_s` first run (a `SCHED_DAILY` job may also fire
+soon after boot), so a post-crash error still mails within minutes instead of
+waiting for the next daily slot. The mail goes through the *user's own SMTP*
+server, so unlike the other jobs there is no shared endpoint to spread across —
+a fixed, predictable morning time is exactly what a user wants. The send is a
+no-op unless there is a new error / new spam, so a quiet day mails nothing.
+
+The server-facing jobs (`selftest`, `fw_update`, `sync`, `blocklist`) stay
+`SCHED_INTERVAL`: they are best-effort and deliberately spread across the fleet
+by boot time + jitter, so a fleet-wide power blip doesn't align every dongle
+onto the same minute hammering phoneblock.net / the CDN. Wall-clock alignment
+would re-introduce exactly that thundering herd.
 
 ---
 
@@ -282,4 +291,5 @@ obvious first consumer and a good acceptance test.
    behavior change).
 2. Timezone config + browser learning + Berlin default.
 3. Scheduler `SCHED_DAILY` support + host tests.
-4. (Optional, follow-up) Convert the status mail job to a fixed daily send.
+4. Convert the status mail job to a fixed daily send (08:00 local), keeping its
+   boot-relative first run.

--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
+    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/Kconfig.projbuild
+++ b/phoneblock-dongle/firmware/main/Kconfig.projbuild
@@ -29,6 +29,21 @@ menu "PhoneBlock Dongle"
             must be the POSIX form ("CET-1CEST,...") — an IANA name like
             "Europe/Berlin" would NOT work with tzset().
 
+    config MAIL_DAILY_HOUR
+        int "Daily status-mail hour (local time, 0-23)"
+        default 23
+        range 0 23
+        help
+            Local hour at which the daily status mail is sent. Default 23
+            (23:00) so it flushes the day's spam reports / errors at the
+            end of the day. The mail also fires shortly after boot (to
+            surface a post-crash error promptly) and is a no-op unless
+            there is something new to report, so a quiet day mails nothing.
+
+            Needs the wall clock (time_sync.c); until SNTP sets it, the
+            job retries hourly and snaps to this hour once the time is
+            known.
+
     config PHONEBLOCK_OTA_BASE_URL
         string "OTA update base URL"
         default "https://cdn.phoneblock.net/dongle/firmware"

--- a/phoneblock-dongle/firmware/main/Kconfig.projbuild
+++ b/phoneblock-dongle/firmware/main/Kconfig.projbuild
@@ -16,6 +16,19 @@ menu "PhoneBlock Dongle"
             the test instance only work there, and vice versa. The token
             prefix (pbt_) is the same in both cases.
 
+    config DONGLE_DEFAULT_TZ
+        string "Default POSIX timezone"
+        default "CET-1CEST,M3.5.0,M10.5.0/3"
+        help
+            POSIX TZ string applied to the wall clock until the user
+            overrides it from the web UI (which can learn the zone from
+            the browser). The default is Europe/Berlin
+            ("CET-1CEST,M3.5.0,M10.5.0/3").
+
+            Note: ESP-IDF's newlib has no IANA timezone database, so this
+            must be the POSIX form ("CET-1CEST,...") — an IANA name like
+            "Europe/Berlin" would NOT work with tzset().
+
     config PHONEBLOCK_OTA_BASE_URL
         string "OTA update base URL"
         default "https://cdn.phoneblock.net/dongle/firmware"

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -57,6 +57,7 @@ static const char *NS   = "phoneblock";
 #define K_MAIL_ON_ERROR "mail_on_error"
 #define K_MAIL_ON_SPAM  "mail_on_spam"
 #define K_DEVICE_ID     "device_id"
+#define K_TIMEZONE      "timezone"
 
 // Direct-vote default mirrors DB.MIN_VOTES on the server (the
 // confidence floor the public blocklist export already enforces).
@@ -127,6 +128,7 @@ typedef struct {
     char mail_on_error[4];   // "1" = mail on ERROR/crash (default off)
     char mail_on_spam[4];    // "1" = mail when spam calls were caught (default off)
     char last_failed_ota[32];   // semver, plus headroom for "-rcN" suffixes
+    char timezone[64];       // POSIX TZ string (empty = use Kconfig default)
 } config_cache_t;
 
 static config_cache_t s_config;
@@ -278,6 +280,7 @@ void config_load(void)
         s_config.mail_on_error[0] = '\0';
         s_config.mail_on_spam[0]  = '\0';
         s_config.last_failed_ota[0] = '\0';
+        copy_default(s_config.timezone, sizeof(s_config.timezone), CONFIG_DONGLE_DEFAULT_TZ);
         return;
     }
     if (err != ESP_OK) {
@@ -363,6 +366,8 @@ void config_load(void)
              s_config.mail_on_spam, sizeof(s_config.mail_on_spam));
     load_str(h, K_LAST_FAIL_OTA, "",
              s_config.last_failed_ota, sizeof(s_config.last_failed_ota));
+    load_str(h, K_TIMEZONE, CONFIG_DONGLE_DEFAULT_TZ,
+             s_config.timezone, sizeof(s_config.timezone));
     nvs_close(h);
 
     ESP_LOGI(TAG, "loaded config: sip=%s@%s:%d, pb=%s",
@@ -413,6 +418,12 @@ bool        config_auth_enabled(void)
 }
 const char *config_auth_user(void)        { return s_config.auth_user; }
 const char *config_auth_persist(void)     { return s_config.auth_persist; }
+const char *config_timezone(void)
+{
+    // Never hand out an empty string: a blank NVS value would leave the
+    // wall clock on UTC. Fall back to the Kconfig default in that case.
+    return s_config.timezone[0] ? s_config.timezone : CONFIG_DONGLE_DEFAULT_TZ;
+}
 bool        config_auto_update_enabled(void)
 {
     // Default on (empty / unrecognised → enabled) so a fresh device
@@ -686,6 +697,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.mail_on_error, sizeof(s_config.mail_on_error));
     if (err == ESP_OK) err = set_str_if(h, K_MAIL_ON_SPAM, u->mail_on_spam,
                                         s_config.mail_on_spam, sizeof(s_config.mail_on_spam));
+    if (err == ESP_OK) err = set_str_if(h, K_TIMEZONE, u->timezone,
+                                        s_config.timezone, sizeof(s_config.timezone));
 
     if (err == ESP_OK) err = nvs_commit(h);
     nvs_close(h);

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -91,6 +91,11 @@ bool        config_log_info(void);
 // browser will be able to log in (avoids the lockout case).
 bool        config_auth_enabled(void);
 
+// POSIX TZ string for the wall clock (see time_sync.c). NVS value if the
+// user set one via the web UI, else the CONFIG_DONGLE_DEFAULT_TZ Kconfig
+// default (Europe/Berlin). Always non-empty.
+const char *config_timezone(void);
+
 // PhoneBlock user-name pinned at first activation of the access
 // gate. Subsequent logins are accepted only when the JWT subject
 // returned by the server matches this string. Empty when the gate
@@ -321,6 +326,9 @@ typedef struct {
     // "1" = enable, "0" = disable, NULL = leave unchanged. Default off.
     const char *mail_on_error;
     const char *mail_on_spam;
+    // POSIX TZ string for the wall clock. NULL = leave unchanged. The
+    // caller is expected to validate it before writing (see web.c).
+    const char *timezone;
 } config_update_t;
 
 esp_err_t config_update(const config_update_t *u);

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -30,6 +30,7 @@
 #include "sip_register.h"
 #include "stats.h"
 #include "status_led.h"
+#include "time_sync.h"
 #include "web.h"
 #include "wifi.h"
 
@@ -192,6 +193,13 @@ void app_main(void)
     // Start the LED early so the user sees "CONNECTING" (or
     // "PAIRING" a few hundred ms later) before WiFi blocks us.
     status_led_start();
+
+    // Set up SNTP + timezone before the network comes up: the connect
+    // calls below block until the first IP, and time_sync starts the
+    // clock from that GOT_IP event — registering its handler afterwards
+    // would miss it. Needs config_load() (timezone) and the event loop,
+    // both already done above.
+    time_sync_start();
 
     // On real hardware we drive WiFi ourselves so first-boot pairing
     // via WPS-PBC works without baked credentials. example_connect

--- a/phoneblock-dongle/firmware/main/sched_time.c
+++ b/phoneblock-dongle/firmware/main/sched_time.c
@@ -1,0 +1,26 @@
+#include "sched_time.h"
+
+long seconds_until_daily(time_t now, int at_hour, int at_minute)
+{
+    struct tm lt;
+    localtime_r(&now, &lt);
+
+    struct tm tgt = lt;
+    tgt.tm_hour  = at_hour;
+    tgt.tm_min   = at_minute;
+    tgt.tm_sec   = 0;
+    tgt.tm_isdst = -1;          // let mktime resolve DST for the target
+
+    time_t when = mktime(&tgt);
+    if (when <= now) {
+        // Already reached today — aim for tomorrow. Bump the day and let
+        // mktime renormalise (handles month/year rollover and a DST jump
+        // on the boundary day, which a naive +86400 would get wrong).
+        tgt.tm_mday += 1;
+        tgt.tm_isdst = -1;
+        when = mktime(&tgt);
+    }
+
+    long delta = (long)(when - now);
+    return delta > 0 ? delta : 1;   // never hand back a non-positive delay
+}

--- a/phoneblock-dongle/firmware/main/sched_time.h
+++ b/phoneblock-dongle/firmware/main/sched_time.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <time.h>
+
+// Whole seconds from `now` (a UTC time_t) until the next occurrence of
+// the local wall-clock time at_hour:at_minute:00. Always returns a value
+// > 0 — if the target is "right now", the next occurrence is tomorrow.
+//
+// Honours the active timezone (set via setenv("TZ")+tzset()), including
+// DST transitions, through localtime_r/mktime. A day that loses or gains
+// an hour at a DST boundary therefore yields 23 h / 25 h, not a naive 24 h.
+//
+// Pure libc, no ESP-IDF dependency, so the scheduler's hardest bit of
+// arithmetic is exercised by the host test harness (test_sched_time.c).
+long seconds_until_daily(time_t now, int at_hour, int at_minute);

--- a/phoneblock-dongle/firmware/main/scheduler.c
+++ b/phoneblock-dongle/firmware/main/scheduler.c
@@ -53,11 +53,12 @@ typedef struct {
     // INTERVAL jobs:
     uint32_t    interval_s;
     uint32_t    jitter_s;
-    // First run delay in seconds: 0 = a full (jittered) interval out
-    // (the default — don't act at boot). A small value makes the first
-    // run happen soon after boot, used by the mail job so a post-crash
-    // status mail goes out promptly once the network is up rather than
-    // up to a day later. INTERVAL-only.
+    // First run delay in seconds: 0 = wait a full interval / until the
+    // first scheduled time (the default — don't act at boot). A small
+    // value makes the first run happen soon after boot regardless of
+    // kind, used by the mail job so a post-crash status mail goes out
+    // promptly rather than waiting for the next daily slot. Applies to
+    // both INTERVAL and DAILY jobs.
     uint32_t    first_delay_s;
     // DAILY jobs: local wall-clock time of day to fire at.
     uint8_t     at_hour;       // 0..23
@@ -74,23 +75,35 @@ static void run_blocklist(void) { blocklist_sync_run(); }
 
 // First mail evaluation 5 min after boot: long enough for Wi-Fi/DHCP to
 // settle, short enough that a crash-reboot's ERROR is mailed promptly.
+// Kept even though the mail job is now wall-clock daily — the fixed daily
+// slot alone would let a post-crash error wait up to a day.
 #define MAIL_FIRST_DELAY_S       (5 * 60)
+
+// Local hour the daily status mail is sent at (08:00). The mail goes
+// through the user's own SMTP server, so there is no fleet-wide endpoint
+// to spread the load across — a fixed, predictable morning time is what a
+// user wants. The send is a no-op unless there is a new error / new spam
+// since the last one (see mail_daily_flush), so a quiet day mails nothing.
+#define MAIL_DAILY_HOUR          8
 
 // First blocklist download 2 min after boot so a provisioned dongle
 // repopulates its local cache without waiting a full day; long enough for
 // Wi-Fi/DHCP/TLS to settle. The job short-circuits without a token.
 #define BLOCKLIST_FIRST_DELAY_S  (2 * 60)
 
-// All current jobs are interval-based (best-effort daily housekeeping,
-// deliberately spread across the fleet by boot time + jitter rather than
-// aligned to a wall-clock hour). The SCHED_DAILY path exists so future
-// user-facing "run at HH:MM local" features have a clock to schedule on;
-// it is exercised by the host test (sched_time.c).
+// The server-facing housekeeping jobs stay interval-based: they are
+// best-effort and deliberately spread across the fleet by boot time +
+// jitter, so a fleet-wide power blip doesn't align every dongle onto the
+// same minute hammering phoneblock.net / the CDN. The status mail is
+// wall-clock daily instead — it goes through the user's own SMTP (no
+// shared endpoint to spread) and a fixed morning time is what a user
+// wants. Daily jobs fall back to a retry until the clock is set and keep
+// their boot-relative first run via first_delay_s.
 static sched_job_t s_jobs[] = {
     { .name = "selftest",  .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_selftest },
     { .name = "fw_update", .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_fw_update },
     { .name = "sync",      .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_sync },
-    { .name = "mail",      .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .first_delay_s = MAIL_FIRST_DELAY_S,      .run = run_mail },
+    { .name = "mail",      .kind = SCHED_DAILY,    .at_hour = MAIL_DAILY_HOUR, .first_delay_s = MAIL_FIRST_DELAY_S, .run = run_mail },
     { .name = "blocklist", .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .first_delay_s = BLOCKLIST_FIRST_DELAY_S, .run = run_blocklist },
 };
 #define JOB_COUNT (sizeof(s_jobs) / sizeof(s_jobs[0]))

--- a/phoneblock-dongle/firmware/main/scheduler.c
+++ b/phoneblock-dongle/firmware/main/scheduler.c
@@ -79,12 +79,14 @@ static void run_blocklist(void) { blocklist_sync_run(); }
 // slot alone would let a post-crash error wait up to a day.
 #define MAIL_FIRST_DELAY_S       (5 * 60)
 
-// Local hour the daily status mail is sent at (08:00). The mail goes
-// through the user's own SMTP server, so there is no fleet-wide endpoint
-// to spread the load across — a fixed, predictable morning time is what a
-// user wants. The send is a no-op unless there is a new error / new spam
-// since the last one (see mail_daily_flush), so a quiet day mails nothing.
-#define MAIL_DAILY_HOUR          8
+// Local hour the daily status mail is sent at (build-time configurable,
+// CONFIG_MAIL_DAILY_HOUR, default 23:00 to flush the day's spam reports /
+// errors at day's end). The mail goes through the user's own SMTP server,
+// so there is no fleet-wide endpoint to spread the load across — a fixed,
+// predictable time is what a user wants. The send is a no-op unless there
+// is a new error / new spam since the last one (see mail_daily_flush), so
+// a quiet day mails nothing.
+#define MAIL_DAILY_HOUR          CONFIG_MAIL_DAILY_HOUR
 
 // First blocklist download 2 min after boot so a provisioned dongle
 // repopulates its local cache without waiting a full day; long enough for

--- a/phoneblock-dongle/firmware/main/scheduler.c
+++ b/phoneblock-dongle/firmware/main/scheduler.c
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -13,9 +14,11 @@
 #include "blocklist_sync.h"
 #include "firmware_update.h"
 #include "mail.h"
+#include "sched_time.h"
 #include "selftest.h"
 #include "sync.h"
 #include "ticks_util.h"
+#include "time_sync.h"
 
 static const char *TAG = "scheduler";
 
@@ -28,19 +31,37 @@ static const char *TAG = "scheduler";
 #define NOTIFY_SYNC      (1u << 0)
 // Task-notification bit for an on-demand binary-blocklist download.
 #define NOTIFY_BLOCKLIST (1u << 1)
+// Task-notification bit raised by time_sync.c once the wall clock is set.
+#define NOTIFY_TIME      (1u << 2)
+
+// While the wall clock is not yet set, a daily job cannot know when its
+// local time-of-day next falls. Re-check this often so it fires promptly
+// once SNTP succeeds (NOTIFY_TIME also wakes us, so this is just a
+// backstop for the case the notification is somehow missed).
+#define DAILY_CLOCK_WAIT_S  (60 * 60)
 
 static TaskHandle_t s_task = NULL;
 
+// INTERVAL: fire every interval_s (±jitter) off the monotonic clock — the
+// original behaviour, robust without a wall clock and spread across a
+// fleet. DAILY: fire at a fixed local time-of-day (needs the wall clock).
+typedef enum { SCHED_INTERVAL, SCHED_DAILY } sched_kind_t;
+
 typedef struct {
-    const char *name;
+    const char  *name;
+    sched_kind_t kind;
+    // INTERVAL jobs:
     uint32_t    interval_s;
     uint32_t    jitter_s;
     // First run delay in seconds: 0 = a full (jittered) interval out
     // (the default — don't act at boot). A small value makes the first
     // run happen soon after boot, used by the mail job so a post-crash
     // status mail goes out promptly once the network is up rather than
-    // up to a day later.
+    // up to a day later. INTERVAL-only.
     uint32_t    first_delay_s;
+    // DAILY jobs: local wall-clock time of day to fire at.
+    uint8_t     at_hour;       // 0..23
+    uint8_t     at_minute;     // 0..59
     int64_t     next_due_us;   // esp_timer time of the next scheduled run
     void      (*run)(void);
 } sched_job_t;
@@ -60,20 +81,42 @@ static void run_blocklist(void) { blocklist_sync_run(); }
 // Wi-Fi/DHCP/TLS to settle. The job short-circuits without a token.
 #define BLOCKLIST_FIRST_DELAY_S  (2 * 60)
 
+// All current jobs are interval-based (best-effort daily housekeeping,
+// deliberately spread across the fleet by boot time + jitter rather than
+// aligned to a wall-clock hour). The SCHED_DAILY path exists so future
+// user-facing "run at HH:MM local" features have a clock to schedule on;
+// it is exercised by the host test (sched_time.c).
 static sched_job_t s_jobs[] = {
-    { "selftest",  DAY_S, JITTER_S, 0,                       0, run_selftest },
-    { "fw_update", DAY_S, JITTER_S, 0,                       0, run_fw_update },
-    { "sync",      DAY_S, JITTER_S, 0,                       0, run_sync },
-    { "mail",      DAY_S, JITTER_S, MAIL_FIRST_DELAY_S,      0, run_mail },
-    { "blocklist", DAY_S, JITTER_S, BLOCKLIST_FIRST_DELAY_S, 0, run_blocklist },
+    { .name = "selftest",  .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_selftest },
+    { .name = "fw_update", .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_fw_update },
+    { .name = "sync",      .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .run = run_sync },
+    { .name = "mail",      .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .first_delay_s = MAIL_FIRST_DELAY_S,      .run = run_mail },
+    { .name = "blocklist", .kind = SCHED_INTERVAL, .interval_s = DAY_S, .jitter_s = JITTER_S, .first_delay_s = BLOCKLIST_FIRST_DELAY_S, .run = run_blocklist },
 };
 #define JOB_COUNT (sizeof(s_jobs) / sizeof(s_jobs[0]))
 
-static int64_t next_due(const sched_job_t *j, int64_t now)
+static int64_t next_due_interval(const sched_job_t *j, int64_t now)
 {
     uint32_t jitter  = esp_random() % (2u * j->jitter_s);
     uint32_t delay_s = j->interval_s - j->jitter_s + jitter;
     return now + (int64_t)delay_s * 1000000;
+}
+
+// Next-due time for a daily job, re-anchored onto the esp_timer axis the
+// wait loop sleeps on. Until the wall clock is set, park on a short retry
+// (NOTIFY_TIME wakes us the moment SNTP succeeds; this is the backstop).
+static int64_t next_due_daily(const sched_job_t *j, int64_t now_us)
+{
+    if (!time_sync_valid())
+        return now_us + (int64_t)DAILY_CLOCK_WAIT_S * 1000000;
+    long secs = seconds_until_daily(time(NULL), j->at_hour, j->at_minute);
+    return now_us + (int64_t)secs * 1000000;
+}
+
+static int64_t next_due(const sched_job_t *j, int64_t now)
+{
+    return j->kind == SCHED_DAILY ? next_due_daily(j, now)
+                                  : next_due_interval(j, now);
 }
 
 static void scheduler_task(void *arg)
@@ -138,6 +181,17 @@ static void scheduler_task(void *arg)
                                                      esp_timer_get_time());
         }
 
+        // The wall clock just became valid (or stepped to a new time).
+        // Daily jobs parked on the clock-wait retry — or computed against
+        // a now-stale time — must recompute against real local time.
+        if (notify & NOTIFY_TIME) {
+            ESP_LOGI(TAG, "wall clock synced — rescheduling daily jobs");
+            for (size_t i = 0; i < JOB_COUNT; i++)
+                if (s_jobs[i].kind == SCHED_DAILY)
+                    s_jobs[i].next_due_us =
+                        next_due_daily(&s_jobs[i], esp_timer_get_time());
+        }
+
         // Fire every job whose scheduled time has come, then reschedule
         // it. esp_timer_get_time() is re-read after each run so a job's
         // own duration counts against its next interval.
@@ -163,6 +217,14 @@ bool scheduler_request_blocklist_sync(void)
     if (!s_task) return false;
     xTaskNotify(s_task, NOTIFY_BLOCKLIST, eSetBits);
     return true;
+}
+
+void scheduler_notify_time_synced(void)
+{
+    // No-op before the task exists: scheduler_task() computes daily due
+    // times from the live clock when it starts, so an early clock-set
+    // needs no notification.
+    if (s_task) xTaskNotify(s_task, NOTIFY_TIME, eSetBits);
 }
 
 void scheduler_start(void)

--- a/phoneblock-dongle/firmware/main/scheduler.h
+++ b/phoneblock-dongle/firmware/main/scheduler.h
@@ -37,3 +37,11 @@ bool scheduler_request_sync(void);
 // The "is a download already in progress" guard lives in
 // blocklist_sync_trigger_now(), the public entry point the web UI calls.
 bool scheduler_request_blocklist_sync(void);
+
+// Notify the scheduler that the wall clock has just been set (or stepped),
+// so any time-of-day ("daily") jobs recompute their next run against real
+// local time instead of the placeholder retry they parked on while the
+// clock was still unknown. Called from time_sync.c. Safe to call before
+// the scheduler task exists — it is then a no-op (the task computes due
+// times from the live clock when it starts).
+void scheduler_notify_time_synced(void);

--- a/phoneblock-dongle/firmware/main/time_sync.c
+++ b/phoneblock-dongle/firmware/main/time_sync.c
@@ -1,0 +1,128 @@
+#include "time_sync.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_netif.h"
+#include "esp_netif_sntp.h"
+#include "esp_sntp.h"
+
+#include "config.h"
+#include "scheduler.h"
+
+static const char *TAG = "time_sync";
+
+// Set true once SNTP has stepped the clock at least once. Written from the
+// SNTP sync callback (lwIP's SNTP task context), read everywhere — a plain
+// bool is fine for a one-way latch on a 32-bit MCU.
+static volatile bool s_valid = false;
+
+// Guards the one-shot esp_netif_sntp_start() in the GOT_IP handler.
+static bool s_started = false;
+
+// Backs the "default gateway" slot in the SNTP server list. lwIP stores
+// the pointer we hand it and resolves the name lazily at request time, so
+// rewriting this buffer in place once we learn the gateway (before the
+// first request) is enough — no re-registration needed. Pre-seeded with
+// the internet fallback so a request before the first GOT_IP still has a
+// usable name.
+static char s_gw_server[40] = "pool.ntp.org";
+
+static void on_time_set(struct timeval *tv)
+{
+    (void)tv;
+    bool first = !s_valid;
+    s_valid = true;
+
+    time_t now = time(NULL);
+    struct tm lt;
+    localtime_r(&now, &lt);
+    char buf[32];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &lt);
+    ESP_LOGI(TAG, "clock set: %s (local)", buf);
+
+    if (first) {
+        // Daily jobs parked on the "clock not valid yet" retry need to
+        // recompute against real local time now that we have it.
+        scheduler_notify_time_synced();
+    }
+}
+
+static void on_got_ip(void *arg, esp_event_base_t base, int32_t id, void *data)
+{
+    (void)arg; (void)base; (void)id;
+    ip_event_got_ip_t *e = data;
+    // Point the gateway slot at the router we just learned. esp_ip4addr_ntoa
+    // writes into the static buffer the SNTP server list already references.
+    esp_ip4addr_ntoa(&e->ip_info.gw, s_gw_server, sizeof(s_gw_server));
+
+    if (!s_started) {
+        s_started = true;
+        esp_err_t err = esp_netif_sntp_start();
+        // INVALID_STATE just means it is already running (e.g. the renew
+        // handler beat us to it) — not an error worth surfacing.
+        if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+            ESP_LOGW(TAG, "esp_netif_sntp_start: %s", esp_err_to_name(err));
+        }
+    }
+}
+
+void time_sync_set_timezone(const char *posix_tz)
+{
+    if (!posix_tz || !posix_tz[0]) return;
+    setenv("TZ", posix_tz, 1);
+    tzset();
+    ESP_LOGI(TAG, "timezone set: %s", posix_tz);
+}
+
+void time_sync_start(void)
+{
+    static bool inited = false;
+    if (inited) return;
+    inited = true;
+
+    // Apply the persisted timezone up front so the very first clock-set
+    // already lands in local time.
+    time_sync_set_timezone(config_timezone());
+
+    // Static list [gateway, pool.ntp.org]; with server_from_dhcp the
+    // DHCP-supplied servers are inserted at index 0, pushing these to 1/2.
+    // Effective order: DHCP option 42 -> gateway -> pool.ntp.org.
+    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(2,
+            ESP_SNTP_SERVER_LIST(s_gw_server, "pool.ntp.org"));
+    config.start                      = false;  // wait for the first IP
+    config.server_from_dhcp           = true;   // adopt option-42 servers
+    config.index_of_first_server      = 1;      // DHCP fills index 0
+    config.renew_servers_after_new_IP = true;   // refresh on reconnect
+    config.ip_event_to_renew          = IP_EVENT_STA_GOT_IP;
+    config.sync_cb                    = on_time_set;
+    config.smooth_sync                = false;  // step, don't slew
+
+    esp_err_t err = esp_netif_sntp_init(&config);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_netif_sntp_init: %s", esp_err_to_name(err));
+        return;
+    }
+
+    // Learn the gateway and kick off SNTP on the first IP. Register before
+    // the network comes up so the (blocking) connect's GOT_IP is not
+    // missed. Cover the Wi-Fi (production) and Ethernet (QEMU) paths; both
+    // carry ip_event_got_ip_t.
+    ESP_ERROR_CHECK(esp_event_handler_register(
+            IP_EVENT, IP_EVENT_STA_GOT_IP, on_got_ip, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(
+            IP_EVENT, IP_EVENT_ETH_GOT_IP, on_got_ip, NULL));
+}
+
+bool time_sync_valid(void)
+{
+    return s_valid;
+}
+
+int64_t time_sync_now_epoch(void)
+{
+    if (!s_valid) return 0;
+    return (int64_t)time(NULL);
+}

--- a/phoneblock-dongle/firmware/main/time_sync.h
+++ b/phoneblock-dongle/firmware/main/time_sync.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Wall-clock time synchronisation for the dongle.
+//
+// The dongle has no battery-backed RTC; esp_timer only gives uptime
+// (microseconds since boot). This module acquires real UTC over SNTP and
+// applies a POSIX timezone, so the scheduler can fire jobs at a specified
+// local time of day rather than only on boot-relative intervals.
+//
+// SNTP server discovery order (lwIP tries them front to back):
+//   1. DHCP option 42 — the server(s) the DHCP server advertises. On a
+//      Fritz!Box LAN that is the router itself. Requires
+//      CONFIG_LWIP_DHCP_GET_NTP_SRV=y.
+//   2. The default gateway — the home router, which virtually always
+//      serves NTP even when it does not populate option 42.
+//   3. pool.ntp.org — internet fallback if both LAN paths fail.
+//
+// Once SNTP sets the clock, gettimeofday()/time() advance off the same
+// monotonic source as esp_timer, so drift between syncs is bridged for
+// free.
+
+// Initialise SNTP and apply the persisted timezone. Idempotent. Call once
+// from app_main *before* the network comes up (it registers the GOT_IP
+// handler that actually starts SNTP on the first lease).
+void time_sync_start(void);
+
+// True once the clock has been set from an SNTP server at least once.
+bool time_sync_valid(void);
+
+// UTC seconds since the epoch, or 0 when !time_sync_valid().
+int64_t time_sync_now_epoch(void);
+
+// Apply a POSIX TZ string at runtime: setenv("TZ")+tzset(). Called by the
+// web settings handler after persisting a new timezone so the change
+// takes effect without a reboot. A NULL/empty argument is ignored.
+//
+// Note: must be a POSIX TZ string ("CET-1CEST,M3.5.0,M10.5.0/3"), not an
+// IANA name ("Europe/Berlin") — ESP-IDF's newlib ships no zone database.
+void time_sync_set_timezone(const char *posix_tz);

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "esp_log.h"
 #include "esp_random.h"
@@ -29,6 +30,7 @@
 #include "sip_register.h"
 #include "stats.h"
 #include "sync.h"
+#include "time_sync.h"
 #include "tr064.h"
 #include "web_auth.h"
 
@@ -417,6 +419,23 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON_AddBoolToObject  (au,   "logged_in",   web_auth_is_logged_in(req));
     cJSON_AddStringToObject(au,   "user",        config_auth_user());
 
+    cJSON *tm = cJSON_AddObjectToObject(root, "time");
+    bool clock_ok = time_sync_valid();
+    cJSON_AddBoolToObject  (tm,   "valid",   clock_ok);
+    cJSON_AddStringToObject(tm,   "tz",      config_timezone());
+    if (clock_ok) {
+        time_t tnow = time(NULL);
+        struct tm lt;
+        localtime_r(&tnow, &lt);
+        char iso[32];
+        strftime(iso, sizeof(iso), "%Y-%m-%dT%H:%M:%S", &lt);
+        cJSON_AddNumberToObject(tm, "epoch_s", (double)tnow);
+        cJSON_AddStringToObject(tm, "local",   iso);
+    } else {
+        cJSON_AddNumberToObject(tm, "epoch_s", 0);
+        cJSON_AddStringToObject(tm, "local",   "");
+    }
+
     cJSON *fw = cJSON_AddObjectToObject(root, "firmware");
     cJSON_AddBoolToObject  (fw,   "auto_update",  config_auto_update_enabled());
     cJSON_AddStringToObject(fw,   "channel",      config_ota_channel());
@@ -577,6 +596,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char smtp_to[64]      = "";
     char mail_err_s[4]    = "";
     char mail_spam_s[4]   = "";
+    char tz_s[64]         = "";
 
     bool have_sip_host  = form_get(body, "sip_host",  sip_host,  sizeof(sip_host));
     bool have_sip_user  = form_get(body, "sip_user",  sip_user,  sizeof(sip_user));
@@ -615,7 +635,24 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_smtp_to    = form_get(body, "smtp_to",       smtp_to,     sizeof(smtp_to));
     bool have_mail_err   = form_get(body, "mail_on_error", mail_err_s,  sizeof(mail_err_s));
     bool have_mail_spam  = form_get(body, "mail_on_spam",  mail_spam_s, sizeof(mail_spam_s));
+    bool have_tz         = form_get(body, "timezone",      tz_s,        sizeof(tz_s));
     free(body);
+
+    // POSIX TZ string (e.g. "CET-1CEST,M3.5.0,M10.5.0/3"): accept only a
+    // sane length of printable ASCII so a malformed POST can never feed
+    // garbage into setenv/tzset. An empty / rejected value leaves the
+    // stored timezone untouched. The browser derives this from its own
+    // DST rules — newlib has no IANA database to map "Europe/Berlin".
+    const char *timezone = NULL;
+    if (have_tz) {
+        size_t n = strlen(tz_s);
+        bool ok = n >= 2 && n < sizeof(tz_s);
+        for (size_t i = 0; ok && i < n; i++) {
+            unsigned char ch = (unsigned char)tz_s[i];
+            if (ch < 0x20 || ch >= 0x7f) ok = false;
+        }
+        if (ok) timezone = tz_s;
+    }
 
     const char *new_host = have_sip_host && sip_host[0] ? sip_host : NULL;
     // A changed registrar (provider / manual edit moving to a different
@@ -714,6 +751,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .smtp_to       = have_smtp_to   ? smtp_to   : NULL,
         .mail_on_error = have_mail_err  ? mail_err_s  : NULL,
         .mail_on_spam  = have_mail_spam ? mail_spam_s : NULL,
+        .timezone      = timezone,
     };
 
     // Snapshot the PhoneBlock token before the update so we can detect
@@ -727,6 +765,12 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     if (err != ESP_OK) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "nvs write failed");
         return ESP_OK;
+    }
+
+    // Apply a changed timezone to the running clock immediately so daily
+    // jobs and the dashboard reflect it without a reboot.
+    if (timezone) {
+        time_sync_set_timezone(config_timezone());
     }
 
     if (strcmp(old_token, config_phoneblock_token()) != 0

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -174,6 +174,11 @@ const I18N = {
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack frei',
+    'status.clock.now': 'Uhrzeit: {time}',
+    'status.clock.pending': 'Uhrzeit: wird synchronisiert …',
+    'status.tz.current': 'Zeitzone: {tz}',
+    'status.tz.apply': 'Auf {zone} umstellen',
+    'status.tz.saved': 'Zeitzone gespeichert.',
     'status.errors.title': 'Protokoll',
     'status.errors.empty': 'keine Einträge',
     'status.errors.ago': 'vor {age}',
@@ -437,6 +442,11 @@ const I18N = {
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack free',
+    'status.clock.now': 'Time: {time}',
+    'status.clock.pending': 'Time: synchronising …',
+    'status.tz.current': 'Timezone: {tz}',
+    'status.tz.apply': 'Switch to {zone}',
+    'status.tz.saved': 'Timezone saved.',
     'status.errors.title': 'Log',
     'status.errors.empty': 'no entries',
     'status.errors.ago': '{age} ago',
@@ -1210,6 +1220,104 @@ async function fetchJson(url){
   catch(e){ return null; }
 }
 
+// --- timezone (learn from the browser, push to the dongle) ----------
+// The dongle's newlib has no IANA database, so it needs a POSIX TZ string
+// ("CET-1CEST,M3.5.0,M10.5.0/3"), not "Europe/Berlin". Curated strings for
+// the zones we serve give a canonical result for the European majority
+// (matching the firmware default exactly → no spurious "change?" button);
+// browserPosixTZ() derives one from the browser's own DST rules otherwise.
+const CET = 'CET-1CEST,M3.5.0,M10.5.0/3';
+const EET = 'EET-2EEST,M3.5.0/3,M10.5.0/4';
+const BST = 'GMT0BST,M3.5.0/1,M10.5.0';
+const TZ_TABLE = {
+  'Europe/Berlin':CET,'Europe/Vienna':CET,'Europe/Zurich':CET,'Europe/Paris':CET,
+  'Europe/Madrid':CET,'Europe/Rome':CET,'Europe/Amsterdam':CET,'Europe/Brussels':CET,
+  'Europe/Luxembourg':CET,'Europe/Warsaw':CET,'Europe/Prague':CET,'Europe/Budapest':CET,
+  'Europe/Copenhagen':CET,'Europe/Stockholm':CET,'Europe/Oslo':CET,'Europe/Belgrade':CET,
+  'Europe/Ljubljana':CET,'Europe/Bratislava':CET,'Europe/Zagreb':CET,'Europe/Sarajevo':CET,
+  'Europe/London':BST,'Europe/Dublin':BST,'Europe/Lisbon':'WET0WEST,M3.5.0/1,M10.5.0',
+  'Europe/Athens':EET,'Europe/Helsinki':EET,'Europe/Bucharest':EET,'Europe/Kiev':EET,
+  'Europe/Kyiv':EET,'Europe/Riga':EET,'Europe/Sofia':EET,'Europe/Tallinn':EET,'Europe/Vilnius':EET,
+  'Europe/Moscow':'MSK-3','Europe/Istanbul':'<+03>-3','UTC':'UTC0','Etc/UTC':'UTC0',
+};
+
+function detectZone(){
+  try { return Intl.DateTimeFormat().resolvedOptions().timeZone || ''; }
+  catch(_){ return ''; }
+}
+
+function browserPosixTZ(){
+  const z = detectZone();
+  if (TZ_TABLE[z]) return TZ_TABLE[z];
+  try {
+    const y = new Date().getFullYear();
+    const offAt = d => -d.getTimezoneOffset();          // minutes east of UTC
+    const jan = offAt(new Date(y,0,1,12)), jul = offAt(new Date(y,6,1,12));
+    const std = Math.min(jan,jul), dst = Math.max(jan,jul);
+    const fmt = mins => {                                // POSIX: west positive
+      const tot = -mins, sign = tot<0?'-':'+', a = Math.abs(tot);
+      const hh = Math.floor(a/60), mm = a%60;
+      return sign + hh + (mm ? ':'+String(mm).padStart(2,'0') : '');
+    };
+    const abbr = m => {
+      try {
+        const p = new Intl.DateTimeFormat('en',{timeZoneName:'short'})
+          .formatToParts(new Date(y,m,1)).find(x=>x.type==='timeZoneName');
+        return p && /^[A-Za-z]{2,5}$/.test(p.value) ? p.value : null;
+      } catch(_){ return null; }
+    };
+    const stdName = abbr(0) || ('<'+fmt(std)+'>');
+    if (std === dst) return stdName + fmt(std);          // no DST
+    const dstName = abbr(6) || ('<'+fmt(dst)+'>');
+    let prev = offAt(new Date(y,0,1,12)); const tr = [];
+    for (let m=0;m<12;m++){
+      const dim = new Date(y,m+1,0).getDate();
+      for (let d=1;d<=dim;d++){
+        const cur = offAt(new Date(y,m,d,12));
+        if (cur !== prev){ tr.push({date:new Date(y,m,d), inc:cur>prev}); prev=cur; }
+      }
+    }
+    const spring = tr.find(x=>x.inc), fall = tr.find(x=>!x.inc);
+    if (!spring || !fall) return null;
+    const rule = dt => {
+      const m = dt.getMonth()+1, dow = dt.getDay(), dom = dt.getDate();
+      const dim = new Date(dt.getFullYear(),m,0).getDate();
+      let wk = Math.ceil(dom/7); if (dom+7 > dim) wk = 5;   // 5 = last
+      return 'M'+m+'.'+wk+'.'+dow;
+    };
+    return stdName+fmt(std)+dstName+fmt(dst)+','+rule(spring.date)+','+rule(fall.date);
+  } catch(_){ return null; }
+}
+
+let g_tzPosix;   // computed once, lazily
+function applyTz(deviceTz){
+  const cur = $('tzCurrent'), btn = $('tzApply');
+  if (!cur || !btn) return;
+  cur.textContent = t('status.tz.current', { tz: deviceTz || '–' });
+  if (g_tzPosix === undefined) g_tzPosix = browserPosixTZ();
+  if (g_tzPosix && deviceTz && g_tzPosix !== deviceTz){
+    btn.style.display = '';
+    btn.textContent = t('status.tz.apply', { zone: detectZone() || g_tzPosix });
+    btn.onclick = async () => {
+      btn.disabled = true;
+      const body = new URLSearchParams();
+      body.append('timezone', g_tzPosix);
+      try {
+        const r = await fetch('/api/config', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: body.toString(),
+        });
+        if (r.ok) cur.textContent = t('status.tz.saved');
+      } catch(_){ /* next poll reconciles */ }
+      btn.disabled = false;
+      refreshAll();   // re-reads the device tz; hides the button once applied
+    };
+  } else {
+    btn.style.display = 'none';
+  }
+}
+
 async function postForm(url, form){
   const body = new URLSearchParams();
   for (const [k, v] of new FormData(form).entries()) body.append(k, v);
@@ -1398,6 +1506,11 @@ function renderStatus(){
     + '<th style="text-align:right">'  + esc(t('status.system.col.cpu'))   + '</th>'
     + '<th style="text-align:right">'  + esc(t('status.system.col.stack')) + '</th>'
     + '</tr></thead><tbody id="systemTasks"></tbody></table>'
+    + '<p id="clockInfo" class="muted" style="font-size:.85rem;margin:.8rem 0 .2rem"></p>'
+    + '<p id="tzInfo" class="muted" style="font-size:.8rem;margin:.2rem 0">'
+    +   '<span id="tzCurrent"></span>'
+    +   '<button id="tzApply" class="btn-ghost" style="display:none;margin-left:.6rem;padding:.2rem .6rem;font-size:.75rem;text-transform:none;letter-spacing:0"></button>'
+    + '</p>'
     + '</details>'
     + '<details id="thresholdsSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.thresholds.title')) + '</summary>'
@@ -2142,6 +2255,15 @@ async function refreshAll(){
       + '<td style="text-align:right">' + tk.stack_free + '</td>';
       tb.appendChild(tr);
     }
+  }
+
+  // Wall clock + timezone.
+  if (s.time) {
+    const ci = $('clockInfo');
+    if (ci) ci.textContent = s.time.valid
+      ? t('status.clock.now', { time: (s.time.local || '').replace('T', ' ') })
+      : t('status.clock.pending');
+    applyTz(s.time.tz || '');
   }
 
   // Calls

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -83,6 +83,12 @@ CONFIG_LWIP_MAX_SOCKETS=16
 # would only ever reach the internet fallback.
 CONFIG_LWIP_DHCP_GET_NTP_SRV=y
 
+# Room for the three SNTP servers time_sync.c configures (DHCP option 42
+# at index 0, the default gateway, and the pool.ntp.org fallback). The
+# lwIP default is 1, which makes esp_netif_sntp_init() fail outright with
+# ESP_ERR_INVALID_ARG ("Tried to configure more servers than enabled").
+CONFIG_LWIP_SNTP_MAX_SERVERS=3
+
 # 4 MB of SPI flash: the ESP32 modules we ship with have 4 MB onboard
 # (the EGBO PICO-D4 packages flash in the SoC; WROOM-32 dev boards
 # use an external 4 MB chip). The IDF default is 2 MB, which cuts

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -76,6 +76,13 @@ CONFIG_HTTPD_MAX_URI_LEN=1024
 # then fails with "Failed to create socket" / ESP_ERR_HTTP_CONNECT.
 CONFIG_LWIP_MAX_SOCKETS=16
 
+# Learn NTP servers from DHCP option 42. The dongle's wall clock
+# (time_sync.c) prefers the server(s) the DHCP server hands out — on a
+# Fritz!Box LAN that is the router itself — over the hard-coded
+# pool.ntp.org fallback. Without this, lwIP discards option 42 and we
+# would only ever reach the internet fallback.
+CONFIG_LWIP_DHCP_GET_NTP_SRV=y
+
 # 4 MB of SPI flash: the ESP32 modules we ship with have 4 MB onboard
 # (the EGBO PICO-D4 packages flash in the SoC; WROOM-32 dev boards
 # use an external 4 MB chip). The IDF default is 2 MB, which cuts

--- a/phoneblock-dongle/firmware/test/.gitignore
+++ b/phoneblock-dongle/firmware/test/.gitignore
@@ -5,4 +5,7 @@ test_sip_auth
 test_tr064_parse
 test_api_scan
 test_log_capture
+test_improv_proto
+test_blocklist_lookup
+test_sched_time
 cjson.o

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_blocklist_lookup
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -40,6 +40,9 @@ test_api_scan: test_api_scan.c ../main/api_scan.c ../main/api_scan.h cjson.o
 
 test_blocklist_lookup: test_blocklist_lookup.c ../main/blocklist_lookup.c ../main/blocklist_lookup.h
 	$(CC) $(CFLAGS) test_blocklist_lookup.c ../main/blocklist_lookup.c -o $@
+
+test_sched_time: test_sched_time.c ../main/sched_time.c ../main/sched_time.h
+	$(CC) $(CFLAGS) test_sched_time.c ../main/sched_time.c -o $@
 
 test: $(BINS)
 	@set -e; for b in $(BINS); do echo "→ $$b"; ./$$b; done

--- a/phoneblock-dongle/firmware/test/test_sched_time.c
+++ b/phoneblock-dongle/firmware/test/test_sched_time.c
@@ -1,0 +1,60 @@
+// Host test for sched_time.c — the daily "next run" arithmetic the
+// scheduler relies on. Pure libc; uses the Europe/Berlin POSIX rule so the
+// DST-boundary cases are exercised exactly as on-device.
+#define _DEFAULT_SOURCE
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "sched_time.h"
+
+#define BERLIN_TZ "CET-1CEST,M3.5.0,M10.5.0/3"
+
+// Construct a UTC time_t from calendar components (timegm ignores TZ).
+static time_t utc(int y, int mon, int d, int h, int mi, int s)
+{
+    struct tm tm = {0};
+    tm.tm_year = y - 1900;
+    tm.tm_mon  = mon - 1;
+    tm.tm_mday = d;
+    tm.tm_hour = h;
+    tm.tm_min  = mi;
+    tm.tm_sec  = s;
+    return timegm(&tm);
+}
+
+int main(void)
+{
+    setenv("TZ", BERLIN_TZ, 1);
+    tzset();
+
+    // Winter (CET = UTC+1). 2026-01-15 09:00 UTC = 10:00 local.
+    // Target 12:00 local today -> 2 h away.
+    assert(seconds_until_daily(utc(2026, 1, 15, 9, 0, 0), 12, 0) == 2 * 3600);
+
+    // Target already passed today (08:00 local, now 10:00 local) ->
+    // tomorrow 08:00 local. 10:00 -> next 08:00 = 22 h.
+    assert(seconds_until_daily(utc(2026, 1, 15, 9, 0, 0), 8, 0) == 22 * 3600);
+
+    // Target exactly "now" (10:00 local) -> tomorrow, a normal 24 h day.
+    assert(seconds_until_daily(utc(2026, 1, 15, 9, 0, 0), 10, 0) == 24 * 3600);
+
+    // Spring forward: DST starts Sun 2026-03-29 (clocks 02:00->03:00).
+    // now 2026-03-28 11:00 UTC = 12:00 local (still CET). Target 12:00 ->
+    // tomorrow 2026-03-29 12:00 CEST = 10:00 UTC. The intervening day is
+    // 23 h long, so the delta is 23 h, not 24 h.
+    assert(seconds_until_daily(utc(2026, 3, 28, 11, 0, 0), 12, 0) == 23 * 3600);
+
+    // Fall back: DST ends Sun 2026-10-25 (clocks 03:00->02:00).
+    // now 2026-10-24 10:00 UTC = 12:00 local (CEST). Target 12:00 ->
+    // tomorrow 2026-10-25 12:00 CET = 11:00 UTC. That day is 25 h long, so
+    // the delta is 25 h.
+    assert(seconds_until_daily(utc(2026, 10, 24, 10, 0, 0), 12, 0) == 25 * 3600);
+
+    // Result is always strictly positive.
+    assert(seconds_until_daily(utc(2026, 6, 1, 0, 0, 0), 0, 0) > 0);
+
+    printf("test_sched_time: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Why

The dongle had only uptime (`esp_timer`), no real clock, so the scheduler could only run jobs on boot-relative intervals — never at a specified time of day.

## What

- **Clock acquisition (`time_sync.c`)** — acquire UTC over SNTP and apply a POSIX timezone. Server discovery order: **DHCP option 42** (`CONFIG_LWIP_DHCP_GET_NTP_SRV`) → **default gateway** (the home router; on a Fritz!Box LAN it serves NTP) → **`pool.ntp.org`**. SNTP starts from the first `GOT_IP` event, so `time_sync_start()` registers before the network comes up.
- **Timezone** — defaults to Europe/Berlin (`CONFIG_DONGLE_DEFAULT_TZ`, a POSIX string since newlib has no IANA database), persisted in NVS. The web UI shows the device clock and can **learn the zone from the browser**: the page derives a POSIX TZ string (curated table for European zones, generated from the browser's own DST rules otherwise) and POSTs it to `/api/config`, which validates and applies it live. `/api/status` gains a `time` object (`valid`, `epoch_s`, `local`, `tz`), shown in the System panel.
- **Scheduling** — new `SCHED_DAILY` job kind. `next_due_daily()` computes the local time-of-day target via `localtime_r`/`mktime` and re-anchors it onto the `esp_timer` axis the wait loop already uses, so the existing sleep / manual-trigger / reschedule logic is unchanged. Until the clock is set, daily jobs park on a 1 h retry; `time_sync` raises `NOTIFY_TIME` the moment SNTP succeeds so they recompute. Pure date arithmetic lives in `sched_time.c`, host-tested (incl. spring-forward 23 h / fall-back 25 h DST boundaries).
- **Status mail → daily** — the mail job becomes the first consumer of the wall clock: `SCHED_DAILY` at `CONFIG_MAIL_DAILY_HOUR` (**default 23:00**, to flush the day's spam reports / errors at day's end). It keeps its 5-min-after-boot first run, so a post-crash error still mails within minutes. Mail goes through the user's own SMTP, so there's no shared endpoint to spread — unlike the server-facing jobs (`selftest`/`fw_update`/`sync`/`blocklist`), which stay interval-based to keep the fleet spread across phoneblock.net / the CDN.

## Testing

- Host test suite passes (`make test`), including new `test_sched_time` (today/tomorrow rollover + DST boundaries).
- Firmware builds clean (`idf.py build`, no warnings in touched files).
- Deployed to a physical dongle via OTA and verified `/api/status.time` is present with the Berlin default.

Design notes in `docs/plans/2026-06-22-dongle-time-sync.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)