### PR TITLE
Dongle: drop SIP CRLF keep-alive log noise, quote dynamic log values

### DIFF
--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1438,7 +1438,14 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
     }
 
     char method[16];
-    parse_method(pkt, len, method, sizeof(method));
+    int method_len = parse_method(pkt, len, method, sizeof(method));
+
+    // A SIP CRLF keep-alive ("\r\n\r\n") has no method — parse_method returns
+    // an empty string. Silently ignore it instead of logging a confusing
+    // "method not implemented" with a blank name.
+    if (method_len == 0) {
+        return;
+    }
 
     if (strcmp(method, "OPTIONS") == 0) {
         send_response(c, from, pkt, len, 200, "OK", NULL, NULL);
@@ -1451,7 +1458,7 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
     } else if (strcmp(method, "CANCEL") == 0) {
         handle_cancel(c, pkt, len, from);
     } else {
-        ESP_LOGW(TAG, "method %s not implemented yet", method);
+        ESP_LOGW(TAG, "method \"%s\" not implemented yet", method);
     }
 }
 

--- a/phoneblock-dongle/firmware/main/web_auth.c
+++ b/phoneblock-dongle/firmware/main/web_auth.c
@@ -489,7 +489,7 @@ esp_err_t web_auth_handle_login_link(httpd_req_t *req)
     // a hostile link inside the dongle UI could trick the user into a
     // login flow that lands on a third-party site.
     if (next[0] != '/' || next[1] == '/') {
-        ESP_LOGW(TAG, "auth/login-link: refusing 'next' = %s", next);
+        ESP_LOGW(TAG, "auth/login-link: refusing 'next' = \"%s\"", next);
         httpd_resp_set_status(req, "400 Bad Request");
         httpd_resp_set_type(req, "text/html; charset=utf-8");
         httpd_resp_sendstr(req,


### PR DESCRIPTION
## Summary

Triggered by a field report whose dongle logs were flooded with `method  not implemented yet` (blank method name).

- **Drop SIP CRLF keep-alive noise.** `handle_incoming()` parsed the empty-method SIP keep-alive packets (`\r\n\r\n`) as an unknown method and logged a WARN every few seconds — flushing the 32-entry WARN ring mirrored to the dongle's web "Protokoll" panel. These are now silently ignored when `parse_method()` yields a zero-length method.
- **Quote dynamic string values in logs** where an empty/whitespace value would otherwise be invisible (HTML collapses double spaces): the unknown-method name in `sip_register.c` and the rejected `next` login-redirect target in `web_auth.c`. The rest of the firmware's `%s` log sites were triaged and found safe (constants, always-populated hosts/IPs, `esp_err_to_name()` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)