### PR TITLE
Dongle: fix two status-mail defects from the field (SNTP config, mail format)

### DIFF
--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c"
+    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -337,6 +337,80 @@ done:
     return ok;
 }
 
+// --- body assembly (shared by the daily flush and the test mail) -----
+
+// Append the status summary block — device id, uptime, call counters —
+// at body[len]. Returns the new length (clamped to cap on truncation).
+static size_t append_summary(char *body, size_t cap, size_t len,
+                             const stats_counters_t *cnt)
+{
+    if (len >= cap) return len;
+    int64_t up_s = esp_timer_get_time() / 1000000;
+    int w = snprintf(body + len, cap - len,
+        "Gerät: %s\n"
+        "Laufzeit: %lldh %lldmin\n"
+        "Anrufe gesamt: %u | SPAM blockiert: %u | durchgestellt: %u\n",
+        config_device_id(),
+        (long long)(up_s / 3600), (long long)((up_s % 3600) / 60),
+        (unsigned)cnt->total_calls, (unsigned)cnt->spam_blocked,
+        (unsigned)cnt->legitimate);
+    if (w < 0) return len;
+    len += (size_t)w;
+    return len > cap ? cap : len;
+}
+
+// Append the "Neue Meldungen im Protokoll" section: every WARN/ERROR in
+// `errs` (newest first) with at_us > since_us, formatted one per line. The
+// header is written only if at least one entry qualifies, so an empty
+// window adds nothing. Returns the new length; updates *newest_us to the
+// newest at_us appended, which the daily flush uses as its high-water mark.
+static size_t append_log_window(char *body, size_t cap, size_t len,
+                                const stats_error_t *errs, int n,
+                                int64_t since_us, int64_t *newest_us)
+{
+    // Log entries store esp_timer uptime (at_us), not wall-clock. Once the
+    // SNTP clock is valid we recover each entry's real instant —
+    // now_epoch - (now_us - at_us) — since time() and esp_timer share the
+    // same monotonic source. A mail is read minutes-to-days later, so an
+    // absolute local timestamp is far more useful than "+Ns since boot";
+    // keep the uptime form only as a pre-sync fallback.
+    int64_t now_us    = esp_timer_get_time();
+    bool    clock_ok  = time_sync_valid();
+    time_t  now_epoch = clock_ok ? (time_t)time_sync_now_epoch() : 0;
+
+    bool header = false;
+    for (int i = n - 1; i >= 0 && len < cap - 160; i--) {
+        const stats_error_t *e = &errs[i];
+        if (e->at_us <= since_us) continue;
+        char lvl = (e->level == ESP_LOG_ERROR) ? 'E'
+                 : (e->level == ESP_LOG_WARN)  ? 'W' : 0;
+        if (!lvl) continue;
+        if (!header) {
+            int hw = snprintf(body + len, cap - len,
+                              "\nNeue Meldungen im Protokoll:\n");
+            if (hw < 0) break;
+            len += (size_t)hw;
+            header = true;
+        }
+        char when[24];
+        if (clock_ok) {
+            time_t ev = now_epoch - (time_t)((now_us - e->at_us) / 1000000);
+            struct tm lt;
+            localtime_r(&ev, &lt);
+            strftime(when, sizeof(when), "%Y-%m-%d %H:%M:%S", &lt);
+        } else {
+            snprintf(when, sizeof(when), "+%llds",
+                     (long long)(e->at_us / 1000000));
+        }
+        int w = snprintf(body + len, cap - len, "%c %s %s: %s\n",
+                         lvl, when, e->tag, e->message);
+        if (w < 0 || (size_t)w >= cap - len) break;
+        len += (size_t)w;
+        if (e->at_us > *newest_us) *newest_us = e->at_us;
+    }
+    return len;
+}
+
 // --- daily evaluation -----------------------------------------------
 
 void mail_daily_flush(void)
@@ -370,17 +444,9 @@ void mail_daily_flush(void)
     char *body = malloc(MAIL_BODY_CAP);
     if (!body) return;
 
-    int64_t up_s = esp_timer_get_time() / 1000000;
-    size_t  len  = 0;
-    len += snprintf(body + len, MAIL_BODY_CAP - len,
-        "Statusmeldung deines PhoneBlock-Dongles.\n\n"
-        "Gerät: %s\n"
-        "Laufzeit: %lldh %lldmin\n"
-        "Anrufe gesamt: %u | SPAM blockiert: %u | durchgestellt: %u\n",
-        config_device_id(),
-        (long long)(up_s / 3600), (long long)((up_s % 3600) / 60),
-        (unsigned)cnt.total_calls, (unsigned)cnt.spam_blocked,
-        (unsigned)cnt.legitimate);
+    size_t len = snprintf(body, MAIL_BODY_CAP,
+        "Statusmeldung deines PhoneBlock-Dongles.\n\n");
+    len = append_summary(body, MAIL_BODY_CAP, len, &cnt);
 
     if (have_new_spam && len < MAIL_BODY_CAP) {
         len += snprintf(body + len, MAIL_BODY_CAP - len,
@@ -388,46 +454,12 @@ void mail_daily_flush(void)
             (unsigned)(cnt.spam_blocked - s_reported_spam));
     }
 
-    // Log entries store esp_timer uptime (at_us), not wall-clock. Once the
-    // SNTP clock is valid we can recover each entry's real instant —
-    // now_epoch - (now_us - at_us) — since time() and esp_timer share the
-    // same monotonic source. A mail is read minutes-to-days later, so an
-    // absolute local timestamp is far more useful than "+Ns since boot";
-    // we keep the uptime form only as a pre-sync fallback.
-    int64_t now_us     = esp_timer_get_time();
-    bool    clock_ok   = time_sync_valid();
-    time_t  now_epoch  = clock_ok ? (time_t)time_sync_now_epoch() : 0;
-
     // Advance the log high-water mark over every WARN/ERROR we append, so
     // the same window isn't re-mailed; the *trigger* is still a new ERROR.
     int64_t newest_us = s_reported_through_us;
-    if (have_new_error && len < MAIL_BODY_CAP) {
-        len += snprintf(body + len, MAIL_BODY_CAP - len,
-                        "\nNeue Meldungen im Protokoll:\n");
-        for (int i = n - 1; i >= 0 && len < MAIL_BODY_CAP - 160; i--) {
-            const stats_error_t *e = &errs[i];
-            if (e->at_us <= s_reported_through_us) continue;
-            char lvl = (e->level == ESP_LOG_ERROR) ? 'E'
-                     : (e->level == ESP_LOG_WARN)  ? 'W' : 0;
-            if (!lvl) continue;
-            char when[24];
-            if (clock_ok) {
-                time_t ev = now_epoch - (time_t)((now_us - e->at_us) / 1000000);
-                struct tm lt;
-                localtime_r(&ev, &lt);
-                strftime(when, sizeof(when), "%Y-%m-%d %H:%M:%S", &lt);
-            } else {
-                snprintf(when, sizeof(when), "+%llds",
-                         (long long)(e->at_us / 1000000));
-            }
-            int w = snprintf(body + len, MAIL_BODY_CAP - len,
-                             "%c %s %s: %s\n",
-                             lvl, when, e->tag, e->message);
-            if (w < 0 || (size_t)w >= MAIL_BODY_CAP - len) break;
-            len += (size_t)w;
-            if (e->at_us > newest_us) newest_us = e->at_us;
-        }
-    }
+    if (have_new_error)
+        len = append_log_window(body, MAIL_BODY_CAP, len, errs, n,
+                                s_reported_through_us, &newest_us);
 
     const char *subject =
         (have_new_error && have_new_spam) ? "PhoneBlock-Dongle: Fehler und SPAM-Anrufe"
@@ -445,9 +477,25 @@ void mail_daily_flush(void)
 
 bool mail_send_test(void)
 {
-    return mail_send("PhoneBlock-Dongle: Test",
-                     "Dies ist eine Test-Statusmeldung deines "
-                     "PhoneBlock-Dongles.\n\n"
-                     "Wenn du diese E-Mail erhältst, ist der "
-                     "E-Mail-Versand korrekt eingerichtet.\n");
+    char *body = malloc(MAIL_BODY_CAP);
+    if (!body) return false;
+
+    // Just send *the* status mail, built exactly like the daily flush —
+    // summary plus the current WARN/ERROR log window (the whole ring, hence
+    // since_us = 0). No test-only wording: the point of the button is to
+    // see the real mail on demand.
+    stats_counters_t cnt;
+    stats_snapshot_counters(&cnt);
+    stats_error_t errs[STATS_MAX_ERRORS];
+    int     n      = stats_snapshot_errors(errs, STATS_MAX_ERRORS);
+    int64_t newest = 0;
+
+    size_t len = snprintf(body, MAIL_BODY_CAP,
+        "Statusmeldung deines PhoneBlock-Dongles.\n\n");
+    len = append_summary(body, MAIL_BODY_CAP, len, &cnt);
+    len = append_log_window(body, MAIL_BODY_CAP, len, errs, n, 0, &newest);
+
+    bool ok = mail_send("PhoneBlock-Dongle: Statusmeldung", body);
+    free(body);
+    return ok;
 }

--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -20,6 +20,7 @@
 #include "mbedtls/ssl.h"
 
 #include "config.h"
+#include "smtp_body.h"
 #include "stats.h"
 #include "time_sync.h"
 #include "wifi.h"
@@ -150,6 +151,24 @@ static int do_handshake(smtp_conn_t *c, int64_t deadline)
         return -1;
     }
     return 0;
+}
+
+// Adapter so smtp_encode_body() can stream straight onto the TLS channel:
+// each encoded chunk is written with chan_write_all under the send
+// deadline. The LF->CRLF and dot-stuffing logic itself lives in
+// smtp_body.c, where it is host-tested.
+struct body_sink_ctx { smtp_conn_t *c; int64_t deadline; };
+
+static int body_chan_sink(void *ctx, const char *data, size_t len)
+{
+    struct body_sink_ctx *b = ctx;
+    return chan_write_all(b->c, (const unsigned char *)data, len, b->deadline);
+}
+
+static int smtp_write_body(smtp_conn_t *c, const char *body, int64_t deadline)
+{
+    struct body_sink_ctx ctx = { c, deadline };
+    return smtp_encode_body(body, body_chan_sink, &ctx);
 }
 
 // --- send -----------------------------------------------------------
@@ -296,9 +315,7 @@ static bool mail_send(const char *subject, const char *body)
                                        deadline) != 0)
             goto done;
     }
-    if (body && body[0]
-            && chan_write_all(&c, (const unsigned char *)body, strlen(body),
-                              deadline) != 0)
+    if (body && body[0] && smtp_write_body(&c, body, deadline) != 0)
         goto done;
 
     ret = smtp_cmd(&c, "\r\n.\r\n", deadline);            // end of DATA

--- a/phoneblock-dongle/firmware/main/smtp_body.c
+++ b/phoneblock-dongle/firmware/main/smtp_body.c
@@ -1,0 +1,21 @@
+#include "smtp_body.h"
+
+#include <string.h>
+
+int smtp_encode_body(const char *body, smtp_body_sink sink, void *ctx)
+{
+    for (const char *p = body; *p; ) {
+        if (*p == '.' && sink(ctx, ".", 1) != 0)
+            return -1;                       // dot-stuff this line's leading '.'
+
+        const char *nl  = strchr(p, '\n');
+        size_t      seg = nl ? (size_t)(nl - p) : strlen(p);
+        if (seg && sink(ctx, p, seg) != 0)
+            return -1;
+        if (!nl) break;                      // trailing text without a newline
+        if (sink(ctx, "\r\n", 2) != 0)
+            return -1;
+        p = nl + 1;                          // next line starts after the LF
+    }
+    return 0;
+}

--- a/phoneblock-dongle/firmware/main/smtp_body.h
+++ b/phoneblock-dongle/firmware/main/smtp_body.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stddef.h>
+
+// Sink for one chunk of encoded body bytes. Returns 0 on success, or a
+// non-zero code to abort the encode (propagated back to the caller).
+typedef int (*smtp_body_sink)(void *ctx, const char *data, size_t len);
+
+// Encode a mail body for the SMTP DATA stream and push it through `sink`
+// chunk by chunk:
+//   - bare LF -> CRLF: SMTP/MIME lines end in CRLF (RFC 5321 §2.3.8); a
+//     LF-only text/plain body renders as one run-on line in many clients.
+//   - dot-stuffing: a line starting with '.' gets a second '.' prepended
+//     (RFC 5321 §4.5.2) so body text can't be read as the "<CRLF>.<CRLF>"
+//     end-of-DATA marker.
+// Has no I/O of its own (the sink does the writing), so the wire encoding
+// is host-testable without a TLS channel. Returns 0 on success, or the
+// sink's non-zero abort code.
+int smtp_encode_body(const char *body, smtp_body_sink sink, void *ctx);

--- a/phoneblock-dongle/firmware/main/time_sync.c
+++ b/phoneblock-dongle/firmware/main/time_sync.c
@@ -14,6 +14,24 @@
 
 static const char *TAG = "time_sync";
 
+// Static SNTP servers we register: the default gateway and pool.ntp.org.
+#define TIME_SYNC_STATIC_SERVERS 2
+
+// Total SNTP slots lwIP must hold: the two static servers above plus the
+// DHCP option-42 server that fills index 0 (see the config below). lwIP is
+// built with a fixed-size server array (CONFIG_LWIP_SNTP_MAX_SERVERS); ask
+// esp_netif_sntp_init() for more than fit and it fails at runtime with
+// ESP_ERR_INVALID_ARG and SNTP never starts. A stale sdkconfig that
+// predated CONFIG_LWIP_SNTP_MAX_SERVERS=3 (sdkconfig.defaults) shipped
+// exactly that crash to the field — silently, because the failure is only
+// visible in the log. Turn it into a build failure so a too-small value
+// (e.g. a stale sdkconfig that didn't pick up the default) can't ship:
+// run `idf.py fullclean` so sdkconfig.defaults takes effect, or raise it.
+#if !defined(CONFIG_LWIP_SNTP_MAX_SERVERS) || \
+    CONFIG_LWIP_SNTP_MAX_SERVERS < (TIME_SYNC_STATIC_SERVERS + 1)
+#error "CONFIG_LWIP_SNTP_MAX_SERVERS must be >= 3 for time_sync's server list; run 'idf.py fullclean' so sdkconfig.defaults applies, or raise it."
+#endif
+
 // Set true once SNTP has stepped the clock at least once. Written from the
 // SNTP sync callback (lwIP's SNTP task context), read everywhere — a plain
 // bool is fine for a one-way latch on a 32-bit MCU.
@@ -90,7 +108,8 @@ void time_sync_start(void)
     // Static list [gateway, pool.ntp.org]; with server_from_dhcp the
     // DHCP-supplied servers are inserted at index 0, pushing these to 1/2.
     // Effective order: DHCP option 42 -> gateway -> pool.ntp.org.
-    esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(2,
+    esp_sntp_config_t config =
+        ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(TIME_SYNC_STATIC_SERVERS,
             ESP_SNTP_SERVER_LIST(s_gw_server, "pool.ntp.org"));
     config.start                      = false;  // wait for the first IP
     config.server_from_dhcp           = true;   // adopt option-42 servers

--- a/phoneblock-dongle/firmware/test/.gitignore
+++ b/phoneblock-dongle/firmware/test/.gitignore
@@ -8,4 +8,5 @@ test_log_capture
 test_improv_proto
 test_blocklist_lookup
 test_sched_time
+test_smtp_body
 cjson.o

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_sched_time
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_sched_time test_smtp_body
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -40,6 +40,9 @@ test_api_scan: test_api_scan.c ../main/api_scan.c ../main/api_scan.h cjson.o
 
 test_sched_time: test_sched_time.c ../main/sched_time.c ../main/sched_time.h
 	$(CC) $(CFLAGS) test_sched_time.c ../main/sched_time.c -o $@
+
+test_smtp_body: test_smtp_body.c ../main/smtp_body.c ../main/smtp_body.h
+	$(CC) $(CFLAGS) test_smtp_body.c ../main/smtp_body.c -o $@
 
 test: $(BINS)
 	@set -e; for b in $(BINS); do echo "→ $$b"; ./$$b; done

--- a/phoneblock-dongle/firmware/test/test_smtp_body.c
+++ b/phoneblock-dongle/firmware/test/test_smtp_body.c
@@ -1,0 +1,80 @@
+// Host test for smtp_body.c — the SMTP DATA wire encoding of the status
+// mail body: bare LF -> CRLF and dot-stuffing of leading dots. Pure libc.
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "smtp_body.h"
+
+// Sink that appends encoded chunks into a fixed buffer.
+struct buf { char data[512]; size_t len; };
+
+static int buf_sink(void *ctx, const char *data, size_t len)
+{
+    struct buf *b = ctx;
+    assert(b->len + len < sizeof(b->data));
+    memcpy(b->data + b->len, data, len);
+    b->len += len;
+    b->data[b->len] = '\0';
+    return 0;
+}
+
+// Encode `in` and assert the result equals `want`.
+static void check(const char *in, const char *want)
+{
+    struct buf b = { .len = 0 };
+    b.data[0] = '\0';
+    assert(smtp_encode_body(in, buf_sink, &b) == 0);
+    if (strcmp(b.data, want) != 0) {
+        fprintf(stderr, "smtp_encode_body(%s):\n  got:  %s\n  want: %s\n",
+                in, b.data, want);
+        assert(0);
+    }
+}
+
+// A sink that fails on its Nth call, to check abort propagation.
+struct failing { int calls; int fail_on; };
+static int failing_sink(void *ctx, const char *data, size_t len)
+{
+    (void)data; (void)len;
+    struct failing *f = ctx;
+    return (++f->calls == f->fail_on) ? -1 : 0;
+}
+
+int main(void)
+{
+    // Empty body -> no output.
+    check("", "");
+
+    // Single line, no trailing newline -> passed through verbatim, no CRLF.
+    check("hello", "hello");
+
+    // Bare LF becomes CRLF.
+    check("a\nb", "a\r\nb");
+
+    // Trailing newline -> trailing CRLF.
+    check("line\n", "line\r\n");
+
+    // The real status-mail shape: several lines, blank line in between.
+    check("Statusmeldung\n\nGeraet: x\n",
+          "Statusmeldung\r\n\r\nGeraet: x\r\n");
+
+    // Dot-stuffing: a line starting with '.' gets an extra leading '.'.
+    check(".hidden\n", "..hidden\r\n");
+
+    // A line that is only a dot -> "..".
+    check(".\n", "..\r\n");
+
+    // Dot not at line start is left alone.
+    check("a.b\n", "a.b\r\n");
+
+    // Leading dot after a newline is stuffed too (per-line, not just first).
+    check("ok\n.danger\n", "ok\r\n..danger\r\n");
+
+    // Sink abort code is propagated.
+    struct failing f = { .calls = 0, .fail_on = 1 };
+    assert(smtp_encode_body("x\ny", failing_sink, &f) == -1);
+
+    printf("test_smtp_body: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Two defects surfaced by a status mail from a field dongle:

```
... Neue Meldungen im Protokoll: E +0s esp_netif_sntp: sntp_init_api(48):
Tried to configure more servers than enabled in lwip. Please update
CONFIG_SNTP_MAX_SERVERS E +0s esp_netif_sntp: esp_netif_sntp_init(119):
Failed initialize SNTP service E +0s time_sync: esp_netif_sntp_init:
ESP_ERR_INVALID_ARG ...
```

### 1. SNTP never started (`CONFIG_LWIP_SNTP_MAX_SERVERS` too small)
`time_sync` needs 3 SNTP slots (gateway + pool.ntp.org + DHCP option-42 at index 0). `sdkconfig.defaults` sets `CONFIG_LWIP_SNTP_MAX_SERVERS=3`, but `sdkconfig.defaults` only seeds a **fresh** `sdkconfig` — a build over a stale `sdkconfig` (no `fullclean` after the default was added) keeps lwIP's default of 1 and ships broken firmware **silently**. That's what reached the field.

**Fix:** a compile-time guard (`#error`) derived from a `TIME_SYNC_STATIC_SERVERS` constant (also fed to the config macro so they can't drift). A misconfigured build now **fails loudly** instead of crashing on a customer's dongle — you can no longer ship the stale-sdkconfig bug. Verified: guard passes at 3, fires at 1 and when undefined.

### 2. Status mail rendered as one run-on line
The body is built with bare `\n`, but SMTP/MIME requires CRLF (RFC 5321 §2.3.8); a LF-only `text/plain` body collapses to a single line in many clients.

**Fix:** `smtp_write_body()` streams the body translating `\n`→CRLF and dot-stuffing leading `.` (RFC 5321 §4.5.2). The body stays readable `\n`-built plain text; the wire encoding now lives in the SMTP layer.

### Workflow note
Branch-first off `dongle-1.4.x` per CLAUDE.md. `mail.c`/`time_sync.c` don't diverge from `master`, so the master-side cherry-pick is clean (separate PR).

### Validation
Full `idf.py build` (exit 0) + host test suite (39 checks + sched_time + signing roundtrip, all green).