### PR TITLE
Dongle: absolute timestamps in calls, log and status mail

### DIFF
--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include <sys/time.h>
+#include <time.h>
 #include "lwip/sockets.h"
 
 #include "esp_crt_bundle.h"
@@ -20,6 +21,7 @@
 
 #include "config.h"
 #include "stats.h"
+#include "time_sync.h"
 #include "wifi.h"
 
 static const char *TAG = "mail";
@@ -369,6 +371,16 @@ void mail_daily_flush(void)
             (unsigned)(cnt.spam_blocked - s_reported_spam));
     }
 
+    // Log entries store esp_timer uptime (at_us), not wall-clock. Once the
+    // SNTP clock is valid we can recover each entry's real instant —
+    // now_epoch - (now_us - at_us) — since time() and esp_timer share the
+    // same monotonic source. A mail is read minutes-to-days later, so an
+    // absolute local timestamp is far more useful than "+Ns since boot";
+    // we keep the uptime form only as a pre-sync fallback.
+    int64_t now_us     = esp_timer_get_time();
+    bool    clock_ok   = time_sync_valid();
+    time_t  now_epoch  = clock_ok ? (time_t)time_sync_now_epoch() : 0;
+
     // Advance the log high-water mark over every WARN/ERROR we append, so
     // the same window isn't re-mailed; the *trigger* is still a new ERROR.
     int64_t newest_us = s_reported_through_us;
@@ -381,10 +393,19 @@ void mail_daily_flush(void)
             char lvl = (e->level == ESP_LOG_ERROR) ? 'E'
                      : (e->level == ESP_LOG_WARN)  ? 'W' : 0;
             if (!lvl) continue;
+            char when[24];
+            if (clock_ok) {
+                time_t ev = now_epoch - (time_t)((now_us - e->at_us) / 1000000);
+                struct tm lt;
+                localtime_r(&ev, &lt);
+                strftime(when, sizeof(when), "%Y-%m-%d %H:%M:%S", &lt);
+            } else {
+                snprintf(when, sizeof(when), "+%llds",
+                         (long long)(e->at_us / 1000000));
+            }
             int w = snprintf(body + len, MAIL_BODY_CAP - len,
-                             "%c +%llds %s: %s\n",
-                             lvl, (long long)(e->at_us / 1000000),
-                             e->tag, e->message);
+                             "%c %s %s: %s\n",
+                             lvl, when, e->tag, e->message);
             if (w < 0 || (size_t)w >= MAIL_BODY_CAP - len) break;
             len += (size_t)w;
             if (e->at_us > newest_us) newest_us = e->at_us;

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -148,7 +148,7 @@ const I18N = {
     'status.info': 'Firmware {fw} · IP {ip} · Uptime {uptime} · API-Latenz {api}',
     'status.calls.title': 'Letzte Anrufe',
     'status.calls.empty': 'noch keine Anrufe',
-    'status.calls.col.when': 'vor',
+    'status.calls.col.when': 'Wann',
     'status.calls.col.number': 'Nummer',
     'status.calls.col.name': 'Name',
     'status.calls.col.verdict': 'Urteil',
@@ -174,12 +174,13 @@ const I18N = {
     'status.system.col.stack': 'Stack frei',
     'status.clock.now': 'Uhrzeit: {time}',
     'status.clock.pending': 'Uhrzeit: wird synchronisiert …',
+    'status.time.today': 'heute {time}',
+    'status.time.yesterday': 'gestern {time}',
     'status.tz.current': 'Zeitzone: {tz}',
     'status.tz.apply': 'Auf {zone} umstellen',
     'status.tz.saved': 'Zeitzone gespeichert.',
     'status.errors.title': 'Protokoll',
     'status.errors.empty': 'keine Einträge',
-    'status.errors.ago': 'vor {age}',
     'status.errors.clear': 'Protokoll leeren',
     'status.errors.capture_info': 'Auch Infos protokollieren',
     'status.errors.capture_info.hint': 'Für die Fehlersuche: zeigt zusätzlich Info-Meldungen (z. B. versuchter Server:Port). Füllt das Protokoll schnell — danach wieder ausschalten.',
@@ -400,7 +401,7 @@ const I18N = {
     'status.info': 'Firmware {fw} · IP {ip} · Uptime {uptime} · API latency {api}',
     'status.calls.title': 'Recent calls',
     'status.calls.empty': 'no calls yet',
-    'status.calls.col.when': 'ago',
+    'status.calls.col.when': 'When',
     'status.calls.col.number': 'Number',
     'status.calls.col.name': 'Name',
     'status.calls.col.verdict': 'Verdict',
@@ -426,12 +427,13 @@ const I18N = {
     'status.system.col.stack': 'Stack free',
     'status.clock.now': 'Time: {time}',
     'status.clock.pending': 'Time: synchronising …',
+    'status.time.today': 'today {time}',
+    'status.time.yesterday': 'yesterday {time}',
     'status.tz.current': 'Timezone: {tz}',
     'status.tz.apply': 'Switch to {zone}',
     'status.tz.saved': 'Timezone saved.',
     'status.errors.title': 'Log',
     'status.errors.empty': 'no entries',
-    'status.errors.ago': '{age} ago',
     'status.errors.clear': 'Clear log',
     'status.errors.capture_info': 'Also log info messages',
     'status.errors.capture_info.hint': 'For troubleshooting: also shows info messages (e.g. the server:port tried). Fills the log quickly — switch off again afterwards.',
@@ -652,7 +654,7 @@ const I18N = {
     'status.info': 'Firmware {fw} · IP {ip} · Uptime {uptime} · Latence API {api}',
     'status.calls.title': 'Derniers appels',
     'status.calls.empty': 'aucun appel pour l’instant',
-    'status.calls.col.when': 'il y a',
+    'status.calls.col.when': 'Quand',
     'status.calls.col.number': 'Numéro',
     'status.calls.col.name': 'Nom',
     'status.calls.col.verdict': 'Verdict',
@@ -664,9 +666,10 @@ const I18N = {
     'status.system.col.task': 'Tâche',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pile libre',
+    'status.time.today': "aujourd'hui {time}",
+    'status.time.yesterday': 'hier {time}',
     'status.errors.title': 'Journal',
     'status.errors.empty': 'aucune entrée',
-    'status.errors.ago': 'il y a {age}',
     'status.errors.clear': 'Vider le journal',
     'status.errors.capture_info': 'Journaliser aussi les infos',
     'status.errors.capture_info.hint': "Pour le dépannage : affiche aussi les messages d'info (par ex. le serveur:port essayé). Remplit vite le journal — à désactiver ensuite.",
@@ -887,7 +890,7 @@ const I18N = {
     'status.info': 'Firmware {fw} · IP {ip} · Uptime {uptime} · Latencia API {api}',
     'status.calls.title': 'Últimas llamadas',
     'status.calls.empty': 'aún sin llamadas',
-    'status.calls.col.when': 'hace',
+    'status.calls.col.when': 'Cuándo',
     'status.calls.col.number': 'Número',
     'status.calls.col.name': 'Nombre',
     'status.calls.col.verdict': 'Veredicto',
@@ -899,9 +902,10 @@ const I18N = {
     'status.system.col.task': 'Tarea',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pila libre',
+    'status.time.today': 'hoy {time}',
+    'status.time.yesterday': 'ayer {time}',
     'status.errors.title': 'Registro',
     'status.errors.empty': 'sin entradas',
-    'status.errors.ago': 'hace {age}',
     'status.errors.clear': 'Vaciar registro',
     'status.errors.capture_info': 'Registrar también los mensajes info',
     'status.errors.capture_info.hint': 'Para diagnóstico: muestra también mensajes info (p. ej. el servidor:puerto intentado). Llena el registro rápido; desactívalo después.',
@@ -1151,6 +1155,27 @@ function fmtSec(s){
   if (s < 3600) return Math.round(s/60) + ' min';
   if (s < 86400) return Math.round(s/3600) + ' h';
   return Math.round(s/86400) + ' T';
+}
+
+// Absolute point in time for an event the dongle reported as `ageS`
+// seconds old. We reconstruct the instant from the *browser's* own wall
+// clock (now - age) rather than the device clock: the browser always has
+// an accurate time and the correct local zone, so the rendering works
+// even before the dongle's SNTP sync and never disagrees with the user's
+// own "today"/"yesterday". `withSeconds` adds second precision for the
+// fine-grained log; the call list stays at minute precision.
+function fmtClock(ageS, withSeconds){
+  const locale = (typeof navigator !== 'undefined' && navigator.language) || LANG;
+  const d = new Date(Date.now() - Math.max(0, ageS) * 1000);
+  const time = d.toLocaleTimeString(locale, withSeconds
+    ? {hour: '2-digit', minute: '2-digit', second: '2-digit'}
+    : {hour: '2-digit', minute: '2-digit'});
+  const midnight = x => { const c = new Date(x); c.setHours(0, 0, 0, 0); return c.getTime(); };
+  const today = midnight(Date.now());
+  const day   = midnight(d);
+  if (day === today)             return t('status.time.today',     {time});
+  if (day === today - 86400000)  return t('status.time.yesterday', {time});
+  return d.toLocaleDateString(locale, {day: 'numeric', month: 'numeric'}) + ' ' + time;
 }
 
 async function fetchJson(url){
@@ -2166,7 +2191,7 @@ async function refreshAll(){
       // verdict colour (green / red), which already matches the
       // outcome the user gets.
       const verdictCls = c.suspected ? 'SUSPECT' : c.verdict;
-      return '<tr><td>' + esc(fmtSec(c.age_s)) + '</td>'
+      return '<tr><td>' + esc(fmtClock(c.age_s, false)) + '</td>'
         + '<td>' + numCol + '</td>'
         + '<td>' + nameCol + '</td>'
         + '<td class="v-' + esc(verdictCls) + '">' + esc(verdictLabel(c)) + '</td></tr>';
@@ -2290,7 +2315,7 @@ async function refreshAll(){
         + ';background:' + bg + '"><strong style="color:' + col + '">['
         + esc(e.tag) + ']</strong> ' + esc(e.message)
         + ' <span class="muted">'
-        + esc(t('status.errors.ago', {age: fmtSec(e.age_s)})) + '</span></div>';
+        + esc(fmtClock(e.age_s, true)) + '</span></div>';
     }).join('');
   } else {
     list.innerHTML = '<p class="muted">' + esc(t('status.errors.empty')) + '</p>';

--- a/phoneblock-dongle/firmware/release-notes/1.4.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.4.0.md
@@ -27,6 +27,12 @@
 
 ## Changed
 
+- **Real timestamps instead of "3 min ago".** Now that the dongle knows
+  the actual time, the recent-calls list and the diagnostics log show
+  when something happened — "today 14:32", "yesterday 13:42" — instead of
+  a boot-relative age. The daily status e-mail likewise dates each log
+  line with its local time rather than seconds since the last restart.
+
 - **Tidier settings page.** The configuration areas are now collapsible
   cards, keeping the "is it working" status and recent calls up top and
   the configure-once settings tucked away.


### PR DESCRIPTION
Now that the dongle has a real wall clock (SNTP, 1.4.0), the boot-relative
"vor X min" displays are a workaround we can drop in favour of human-readable
timestamps.

## Web UI (recent calls + diagnostics log)
Render the absolute instant of each event instead of a relative age:
- **today 14:32 / yesterday 13:42**, else **5.6. 14:32** (date + time)
- Calls at minute precision, the log at second precision.

The instant is reconstructed **in the browser** from the device-reported age
(`age_s`) and the browser's own wall clock (`now - age`). Rationale: the
browser always has an accurate time and the correct local zone, so it works
even before the dongle's SNTP sync and always agrees with the user's own
"today"/"yesterday". `fmtSec` stays for genuine durations (uptime, time since
registration, last sync). The "vor"/"ago" column header becomes
"Wann"/"When"/"Quand"/"Cuándo"; the now-dead `status.errors.ago` key is removed.

## Status mail
No browser there, so the timestamp is formatted on the device. Each log line
gets its real local time via `now_epoch - (now_us - at_us)` (valid because
`time()` and `esp_timer` share the monotonic source); falls back to the old
`+Ns` uptime only before the first SNTP sync. A mail is read minutes-to-days
later, so an absolute timestamp is far more useful than seconds-since-boot.

## Tested on hardware
Flashed onto the live test dongle. The log panel renders e.g. `heute 20:45:30`
from live `/api/errors` data; the call-list branches verified to render
`heute 15:46` (was "vor 5h"), `gestern 14:46`, `19.6. 20:46`. Firmware boots
clean, SIP registers, clock valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
