### PR TITLE
Doku: Self-Hosting-Anleitung für den Anrufbeantworter erweitert

### DIFF
--- a/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">للخبراء: الاستضافة الذاتية</h2>
 		
 		<p data-tx="t0080:5a67a3ba">هل أنت جيد حقاً مع أجهزة الكمبيوتر، هل لديك جهاز RaspberryPI أو كمبيوتر شخصي صغير آخر يعمل في المنزل على أي حال؟ إذن قم ببساطة بتثبيت جهاز الرد على المكالمات بنفسك. أفضل طريقة للقيام بذلك هي باستخدام صورة <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker المعدة . يوفر هذا أفضل حماية للبيانات لأن كل معالجة المكالمات تتم من طرفك. الإعداد في نظام الهاتف هو نفسه، فأنت تقوم بإعداد جهاز الرد الآلي عبر ملف تهيئة.</a></p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>أمر مهم عند الاستضافة الذاتية:</strong> على عكس جهاز الرد الآلي السحابي، يتم استبعاد خطوتين من الإرشادات المذكورة أعلاه: <ul> <li><strong>لا حاجة إلى DynDNS.</strong> يعمل جهاز الرد الآلي على نفس الشبكة التي يعمل عليها جهاز Fritz!Box ويتم تسجيل الدخول إليه محليًّا.</li> <li><strong>يظل خيار «السماح بتسجيل الدخول من الإنترنت» معطلاً.</strong> ولا يلزم أن يكون جهاز Fritz!Box متاحًا عبر الإنترنت لهذا الغرض – اترك الخيار معطلاً عن قصد حتى لا تفتح الموجه دون داعٍ.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. إنشاء جهاز هاتفي في جهاز Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">قم بإضافة جهاز اتصال هاتفي جديد: <em>الاتصالات الهاتفية → أجهزة الاتصال الهاتفي → إعداد جهاز جديد → هاتف (مع أو بدون جهاز الرد الآلي) → LAN/WLAN (هاتف IP)</em>. يمكنك اختيار اسم المستخدم وكلمة المرور بحرية – يجب أن يكونا متطابقين تمامًا في ملف <code>compose.yaml</code>. في قسم «المكالمات الواردة»، اختر <em>«الرد على جميع أرقام الهواتف»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. إنشاء ملف compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. المتغيرات المهمة</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">متغير</th>
+						<th data-tx="t0090:f0e3578f">المعنى</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">مفتاح API الشخصي الخاص بك، والذي يمكن إنشاؤه على <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">يجب أن تتطابق تمامًا مع رقم الهاتف عبر بروتوكول الإنترنت (IP) الذي تم إنشاؤه في جهاز Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">عنوان جهاز Fritz!Box. نصيحة: في حالة استخدام خادم DNS خاص (مثل Pi-hole/Unbound)، أدخل هنا <em>عنوان IP</em> لجهاز Fritz!Box بدلاً من <code>fritz.box</code>، وإلا فقد لا يتم تحليل اسم المضيف ويفشل التسجيل.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">إلزامي – مطلوب للاتصال عبر بروتوكولي SIP وRTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. التشغيل والتحقق</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">إذا ظهر في السجل سطر مثل <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>، فهذا يعني أن جهاز الرد الآلي قد سجل دخوله بنجاح على جهاز Fritz!Box. يمكن إجراء مكالمة تجريبية في أي وقت عبر <em>الرقم الداخلي</em> للجهاز (الذي يبدأ بـ <code>**</code>) – حيث يستقبل جهاز الرد الآلي هذه المكالمات دائمًا.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">عنوان جهاز Fritz!Box. نصيحة: في حالة استخدام خادم DNS خاص (مثل Pi-hole/Unbound)، أدخل هنا <em>عنوان IP</em> لجهاز Fritz!Box بدلاً من <code>fritz.box</code>، وإلا فقد لا يتم تحليل اسم المضيف ويفشل التسجيل.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">يستقبل أيضًا المكالمات الواردة من الهواتف الداخلية (الأرقام التي تبدأ بـ <code>*</code>) – وهو أمر ضروري لإجراء مكالمة اختبار عبر الرقم الداخلي. اضبط القيمة على <code>no</code> إذا كان جهاز الرد الآلي جزءًا من نظام الاتصال الجماعي (مثل جرس الباب الذي يجعل جميع الهواتف ترن).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">اضبط الخيار على <code>yes</code> لتشخيص الأخطاء: سيؤدي ذلك إلى تسجيل جميع اتصالات SIP في السجل.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/ar/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">For eksperter: selvhosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Er du rigtig god til computere, har du alligevel en RaspberryPI eller en anden mini-pc kørende derhjemme? Så skal du bare installere telefonsvareren selv. Den bedste måde at gøre det på er med det forberedte <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker-image</a>. Det giver den bedste databeskyttelse, fordi al opkaldshåndtering foregår i din ende. Opsætningen i telefonsystemet er den samme, du opsætter telefonsvareren via en konfigurationsfil.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Vigtigt ved selvhosting:</strong> I modsætning til cloud-telefonsvareren kan to trin i vejledningen ovenfor udelades: <ul> <li><strong>Der er ikke behov for DynDNS.</strong> Telefonsvareren kører i samme netværk som Fritz!Boxen og logger på lokalt.</li> <li><strong>"Tillad tilgang fra internettet" forbliver deaktiveret.</strong> Fritz!Box'en behøver ikke at være tilgængelig fra internettet – lad indstillingen være deaktiveret for ikke at åbne routeren unødigt.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Oprette en telefonenhed i Fritz!Box’en</h3>
+		<p data-tx="t0086:77837d1f">Opret en ny telefonenhed: <em>Telefoni → Telefonenheder → Opret ny enhed → Telefon (med og uden telefonsvarer) → LAN/WLAN (IP-telefon)</em>. Du kan selv vælge brugernavn og adgangskode – de skal være nøjagtigt de samme som angivet i <code>compose.yaml</code>. Under "Indgående opkald" skal du vælge <em>"reagere på alle telefonnumre"</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Opret file »compose.yaml«</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Vigtige variabler</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variabel</th>
+						<th data-tx="t0090:f0e3578f">Betydning</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Din personlige API-nøgle, som du kan oprette på <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">De skal stemme nøjagtigt overens med den IP-telefon, der er oprettet i Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Fritz!Box’ adresse. Tip: Hvis du bruger din egen DNS-server (f.eks. Pi-hole/Unbound), skal du her indtaste <em>IP-adressen</em> på Fritz!Box i stedet for <code>fritz.box</code>, da værtsnavnet ellers muligvis ikke bliver opløst, og registreringen mislykkes.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obligatorisk – kræves til SIP-/RTP-kommunikation.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Start og kontrol</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Hvis der vises en linje i loggen som <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, har telefonsvareren logget sig på Fritz!Box’en uden problemer. Du kan til enhver tid foretage et testopkald via enhedens <em>interne nummer</em> (begynder med <code>**</code>) – sådanne opkald tager telefonsvareren altid imod.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/da/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Fritz!Box’ adresse. Tip: Hvis du bruger din egen DNS-server (f.eks. Pi-hole/Unbound), skal du her indtaste <em>IP-adressen</em> på Fritz!Box i stedet for <code>fritz.box</code>, da værtsnavnet ellers muligvis ikke bliver opløst, og registreringen mislykkes.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Modtager også opkald fra interne telefoner (numre med <code>*</code>) – nødvendigt for testopkaldet via det interne nummer. Indstil værdien til <code>no</code>, hvis telefonsvareren er en del af en samlet ringetone (f.eks. en dørklokke, der får alle telefoner til at ringe).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Indstil til <code>yes</code> for fejlfinding: så logges al SIP-kommunikation i logfilen.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
@@ -391,29 +391,29 @@
 		Das bietet den besten Datenschutz, weil die ganze Anrufbehandlung bei Dir stattfindet.
 		Die Einrichtung in der Telefonanlage ist dieselbe, den Anrufbeantworter richtest Du über eine Konfigurationsdatei ein. 
 		</p>
-		<div class="notification is-warning">
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9">
 			<strong>Wichtig beim Self-Hosting:</strong> Anders als beim Cloud-Anrufbeantworter entfallen zwei Schritte aus der Anleitung oben:
 			<ul>
-				<li><strong>Kein DynDNS nötig.</strong> Der Anrufbeantworter läuft im selben Netz wie die FRITZ!Box und meldet sich lokal an.</li>
-				<li><strong>„Anmeldung aus dem Internet erlauben" bleibt deaktiviert.</strong> Die FRITZ!Box muss dafür nicht aus dem Internet erreichbar sein – lass die Option bewusst aus, um den Router nicht unnötig zu öffnen.</li>
+				<li><strong>Kein DynDNS nötig.</strong> Der Anrufbeantworter läuft im selben Netz wie die Fritz!Box und meldet sich lokal an.</li>
+				<li><strong>"Anmeldung aus dem Internet erlauben" bleibt deaktiviert.</strong> Die Fritz!Box muss dafür nicht aus dem Internet erreichbar sein – lass die Option bewusst aus, um den Router nicht unnötig zu öffnen.</li>
 			</ul>
 		</div>
 		
-		<h3>1. Telefoniegerät in der FRITZ!Box anlegen</h3>
-		<p>
-		Lege ein neues Telefoniegerät an: <em>Telefonie &rarr; Telefoniegeräte &rarr; Neues Gerät einrichten &rarr; Telefon (mit und ohne Anrufbeantworter) &rarr; LAN/WLAN (IP-Telefon)</em>. Benutzername und Kennwort wählst Du frei – sie müssen gleich identisch in der <code>compose.yaml</code> stehen. Bei „Ankommende Anrufe" wählst Du <em>„auf alle Rufnummern reagieren"</em>.
+		<h3 data-tx="t0085:b85e4fee">1. Telefoniegerät in der Fritz!Box anlegen</h3>
+		<p data-tx="t0086:77837d1f">
+		Lege ein neues Telefoniegerät an: <em>Telefonie → Telefoniegeräte → Neues Gerät einrichten → Telefon (mit und ohne Anrufbeantworter) → LAN/WLAN (IP-Telefon)</em>. Benutzername und Kennwort wählst Du frei – sie müssen gleich identisch in der <code>compose.yaml</code> stehen. Bei "Ankommende Anrufe" wählst Du <em>"auf alle Rufnummern reagieren"</em>.
 		</p>
 		
-		<h3>2. compose.yaml anlegen</h3>
+		<h3 data-tx="t0087:f0ff4af">2. compose.yaml anlegen</h3>
 		<pre>services:
   phoneblock:
-    image: phoneblock/answerbot:1.6.16
+    image: phoneblock/answerbot:latest
     container_name: phoneblock
     network_mode: host
     environment:
       - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
-      - SIP_USER=&lt;Benutzername wie in der FRITZ!Box&gt;
-      - SIP_PASSWD=&lt;Kennwort wie in der FRITZ!Box&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
       - VIA_ADDR=auto-configuration
       - VIA_ADDR_V6=auto-configuration
       - HOST_PORT=50060
@@ -426,41 +426,41 @@
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
-		<h3>3. Wichtige Variablen</h3>
+		<h3 data-tx="t0088:68a01d83">3. Wichtige Variablen</h3>
 		<div class="table-container">
 			<table class="table is-fullwidth is-striped">
 				<thead>
 					<tr>
-						<th>Variable</th>
-						<th>Bedeutung</th>
+						<th data-tx="t0089:c616aa64">Variable</th>
+						<th data-tx="t0090:f0e3578f">Bedeutung</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
 						<td><code>PHONEBLOCK_API_KEY</code></td>
-						<td>Dein persönlicher API-Key, erstellbar unter <code>phoneblock.net/phoneblock/settings</code>.</td>
+						<td data-tx="t0091:c8ab1645">Dein persönlicher API-Key, erstellbar unter <code>phoneblock.net/phoneblock/settings</code>.</td>
 					</tr>
 					<tr>
 						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
-						<td>Müssen exakt mit dem in der FRITZ!Box angelegten IP-Telefon übereinstimmen.</td>
+						<td data-tx="t0092:ea799cc3">Müssen exakt mit dem in der Fritz!Box angelegten IP-Telefon übereinstimmen.</td>
 					</tr>
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
-						<td>Adresse der FRITZ!Box. Tipp: Bei eigenem DNS-Server (z.&nbsp;B. Pi-hole/Unbound) hier die <em>IP-Adresse</em> der FRITZ!Box statt <code>fritz.box</code> eintragen, da der Hostname sonst evtl. nicht aufgelöst wird und die Registrierung fehlschlägt.</td>
+						<td data-tx="t0093:17dcf955">Adresse der Fritz!Box. Tipp: Bei eigenem DNS-Server (z. B. Pi-hole/Unbound) hier die <em>IP-Adresse</em> der Fritz!Box statt <code>fritz.box</code> eintragen, da der Hostname sonst evtl. nicht aufgelöst wird und die Registrierung fehlschlägt.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>
-						<td>Pflicht – wird für die SIP-/RTP-Kommunikation benötigt.</td>
+						<td data-tx="t0094:a961a2ea">Pflicht – wird für die SIP-/RTP-Kommunikation benötigt.</td>
 					</tr>
 				</tbody>
 			</table>
 		</div>
 		
-		<h3>4. Starten und prüfen</h3>
+		<h3 data-tx="t0095:cc612f71">4. Starten und prüfen</h3>
 		<pre>docker compose up -d
 docker logs -f phoneblock</pre>
-		<p>
-		Erscheint im Log eine Zeile wie <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, hat sich der Anrufbeantworter erfolgreich an der FRITZ!Box angemeldet. Ein Testanruf gelingt jederzeit über die <em>interne Nummer</em> des Geräts (beginnt mit <code>**</code>) – solche Anrufe nimmt der Anrufbeantworter immer an.
+		<p data-tx="t0096:dabc390b">
+		Erscheint im Log eine Zeile wie <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, hat sich der Anrufbeantworter erfolgreich an der Fritz!Box angemeldet. Ein Testanruf gelingt jederzeit über die <em>interne Nummer</em> des Geräts (beginnt mit <code>**</code>) – solche Anrufe nimmt der Anrufbeantworter immer an.
 		</p>
 		
 	</div>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
@@ -391,6 +391,77 @@
 		Das bietet den besten Datenschutz, weil die ganze Anrufbehandlung bei Dir stattfindet.
 		Die Einrichtung in der Telefonanlage ist dieselbe, den Anrufbeantworter richtest Du über eine Konfigurationsdatei ein. 
 		</p>
+		<div class="notification is-warning">
+			<strong>Wichtig beim Self-Hosting:</strong> Anders als beim Cloud-Anrufbeantworter entfallen zwei Schritte aus der Anleitung oben:
+			<ul>
+				<li><strong>Kein DynDNS nötig.</strong> Der Anrufbeantworter läuft im selben Netz wie die FRITZ!Box und meldet sich lokal an.</li>
+				<li><strong>„Anmeldung aus dem Internet erlauben" bleibt deaktiviert.</strong> Die FRITZ!Box muss dafür nicht aus dem Internet erreichbar sein – lass die Option bewusst aus, um den Router nicht unnötig zu öffnen.</li>
+			</ul>
+		</div>
+		
+		<h3>1. Telefoniegerät in der FRITZ!Box anlegen</h3>
+		<p>
+		Lege ein neues Telefoniegerät an: <em>Telefonie &rarr; Telefoniegeräte &rarr; Neues Gerät einrichten &rarr; Telefon (mit und ohne Anrufbeantworter) &rarr; LAN/WLAN (IP-Telefon)</em>. Benutzername und Kennwort wählst Du frei – sie müssen gleich identisch in der <code>compose.yaml</code> stehen. Bei „Ankommende Anrufe" wählst Du <em>„auf alle Rufnummern reagieren"</em>.
+		</p>
+		
+		<h3>2. compose.yaml anlegen</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:1.6.16
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der FRITZ!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der FRITZ!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3>3. Wichtige Variablen</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th>Variable</th>
+						<th>Bedeutung</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td>Dein persönlicher API-Key, erstellbar unter <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td>Müssen exakt mit dem in der FRITZ!Box angelegten IP-Telefon übereinstimmen.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td>Adresse der FRITZ!Box. Tipp: Bei eigenem DNS-Server (z.&nbsp;B. Pi-hole/Unbound) hier die <em>IP-Adresse</em> der FRITZ!Box statt <code>fritz.box</code> eintragen, da der Hostname sonst evtl. nicht aufgelöst wird und die Registrierung fehlschlägt.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td>Pflicht – wird für die SIP-/RTP-Kommunikation benötigt.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3>4. Starten und prüfen</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p>
+		Erscheint im Log eine Zeile wie <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, hat sich der Anrufbeantworter erfolgreich an der FRITZ!Box angemeldet. Ein Testanruf gelingt jederzeit über die <em>interne Nummer</em> des Geräts (beginnt mit <code>**</code>) – solche Anrufe nimmt der Anrufbeantworter immer an.
+		</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
@@ -425,6 +425,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
@@ -423,11 +423,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -452,6 +448,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Adresse der Fritz!Box. Tipp: Bei eigenem DNS-Server (z. B. Pi-hole/Unbound) hier die <em>IP-Adresse</em> der Fritz!Box statt <code>fritz.box</code> eintragen, da der Hostname sonst evtl. nicht aufgelöst wird und die Registrierung fehlschlägt.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Nimmt auch Anrufe interner Telefone (Nummern mit <code>*</code>) an – nötig für den Testanruf über die interne Nummer. Setze den Wert auf <code>no</code>, wenn der Anrufbeantworter Teil eines Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Zur Fehlersuche auf <code>yes</code> setzen: protokolliert dann die gesamte SIP-Kommunikation im Log.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/anrufbeantworter.html
@@ -423,6 +423,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Για ειδικούς: self-hosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Είστε πραγματικά καλός με τους υπολογιστές, έχετε ένα RaspberryPI ή ένα άλλο μίνι PC που τρέχει στο σπίτι ούτως ή άλλως; Τότε απλά εγκαταστήστε τον τηλεφωνητή μόνοι σας. Ο καλύτερος τρόπος για να το κάνετε αυτό είναι με την προετοιμασμένη εικόνα <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker image</a>. Αυτό προσφέρει την καλύτερη προστασία των δεδομένων, επειδή όλος ο χειρισμός των κλήσεων πραγματοποιείται στο δικό σας μέρος. Η ρύθμιση στο τηλεφωνικό σύστημα είναι η ίδια, ρυθμίζετε τον αυτόματο τηλεφωνητή μέσω ενός αρχείου ρυθμίσεων.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Σημαντικό για την αυτο-φιλοξενία:</strong> Σε αντίθεση με τον τηλεφωνητή στο cloud, δύο βήματα από τις παραπάνω οδηγίες δεν ισχύουν: <ul> <li><strong>Δεν απαιτείται DynDNS.</strong> Ο τηλεφωνητής λειτουργεί στο ίδιο δίκτυο με το Fritz!Box και συνδέεται τοπικά.</li> <li><strong>Η επιλογή «Να επιτρέπεται η σύνδεση από το Διαδίκτυο» παραμένει απενεργοποιημένη.</strong> Το Fritz!Box δεν χρειάζεται να είναι προσβάσιμο από το Διαδίκτυο – άφησε σκόπιμα την επιλογή απενεργοποιημένη, ώστε να μην ανοίξεις τον δρομολογητή χωρίς λόγο.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Δημιουργία τηλεφωνικής συσκευής στο Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Προσθέστε μια νέα συσκευή τηλεφωνίας: <em>Τηλεφωνία → Συσκευές τηλεφωνίας → Ρύθμιση νέας συσκευής → Τηλέφωνο (με ή χωρίς τηλεφωνητή) → LAN/WLAN (IP τηλέφωνο)</em>. Μπορείς να επιλέξεις ελεύθερα το όνομα χρήστη και τον κωδικό πρόσβασης – πρέπει να είναι ακριβώς τα ίδια με αυτά που αναγράφονται στο αρχείο <code>compose.yaml</code>. Στην ενότητα «Εισερχόμενες κλήσεις», επιλέξτε <em>«απόκριση σε όλους τους αριθμούς»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Δημιουργία του αρχείου compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Σημαντικές μεταβλητές</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Μεταβλητή</th>
+						<th data-tx="t0090:f0e3578f">Σημασία</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Το προσωπικό σου κλειδί API, το οποίο μπορείς να δημιουργήσεις στη διεύθυνση <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Πρέπει να ταιριάζουν ακριβώς με το IP τηλέφωνο που έχει δημιουργηθεί στο Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Διεύθυνση του Fritz!Box. Συμβουλή: Εάν χρησιμοποιείτε δικό σας διακομιστή DNS (π.χ. Pi-hole/Unbound), εισάγετε εδώ τη <em>διεύθυνση IP</em> του Fritz!Box αντί για <code>fritz.box</code>, καθώς διαφορετικά το όνομα κεντρικού υπολογιστή ενδέχεται να μην αναγνωριστεί και η εγγραφή να αποτύχει.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Υποχρεωτικό – απαιτείται για την επικοινωνία μέσω SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Εκκίνηση και έλεγχος</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Αν στο αρχείο καταγραφής εμφανιστεί μια γραμμή όπως <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, αυτό σημαίνει ότι ο τηλεφωνητής έχει συνδεθεί με επιτυχία στο Fritz!Box. Μπορείτε να πραγματοποιήσετε μια δοκιμαστική κλήση ανά πάσα στιγμή μέσω του <em>εσωτερικού αριθμού</em> της συσκευής (που ξεκινά με <code>**</code>) – ο τηλεφωνητής δέχεται πάντα τέτοιες κλήσεις.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/el/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Διεύθυνση του Fritz!Box. Συμβουλή: Εάν χρησιμοποιείτε δικό σας διακομιστή DNS (π.χ. Pi-hole/Unbound), εισάγετε εδώ τη <em>διεύθυνση IP</em> του Fritz!Box αντί για <code>fritz.box</code>, καθώς διαφορετικά το όνομα κεντρικού υπολογιστή ενδέχεται να μην αναγνωριστεί και η εγγραφή να αποτύχει.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Δέχεται επίσης κλήσεις από εσωτερικά τηλέφωνα (αριθμοί με <code>*</code>) – απαραίτητο για τη δοκιμαστική κλήση μέσω του εσωτερικού αριθμού. Ορίστε την τιμή σε <code>no</code>, εάν ο τηλεφωνητής αποτελεί μέρος μιας ομαδικής κλήσης (π.χ. ένα κουδούνι πόρτας που κάνει όλα τα τηλέφωνα να χτυπήσουν).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Για τον εντοπισμό σφαλμάτων, ορίστε την τιμή σε <code>yes</code>: έτσι θα καταγράφεται στο αρχείο καταγραφής ολόκληρη η επικοινωνία SIP.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">For experts: self-hosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Are you really good with computers, do you have a RaspberryPI or another mini PC running at home anyway? Then simply install the answering machine yourself. The best way to do this is with the prepared <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker image</a>. This offers the best data protection because all call handling takes place at your end. The setup in the telephone system is the same, you set up the answering machine via a configuration file.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Important for self-hosting:</strong> Unlike with the cloud answering machine, two steps in the instructions above are not necessary: <ul> <li><strong>No DynDNS required.</strong> The answering machine runs on the same network as the Fritz!Box and logs in locally.</li> <li><strong>"Allow login from the Internet" remains disabled.</strong> The Fritz!Box does not need to be accessible from the Internet for this—leave the option disabled on purpose so as not to unnecessarily open up the router.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Set up a phone in the Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Set up a new phone: <em>Telephony → Phone Devices → Set Up New Device → Phone (with or without an answering machine) → LAN/Wi-Fi (IP Phone)</em>. You can choose any username and password you like—they must be exactly the same as those specified in the <code>compose.yaml</code> file. Under "Incoming Calls," select <em>"Respond to all phone numbers"</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Create a `compose.yaml` file</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Important Variables</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variable</th>
+						<th data-tx="t0090:f0e3578f">Meaning</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Your personal API key, which you can create at <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">They must match exactly the IP phone set up in the Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Fritz!Box address. Tip: If you're using your own DNS server (e.g., Pi-hole/Unbound), enter the <em>IP address</em> of the Fritz!Box here instead of <code>fritz.box</code>, otherwise the hostname may not be resolved and the registration will fail.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Required – needed for SIP/RTP communication.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Start and check</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">If a line such as <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code> appears in the log, the answering machine has successfully registered with the Fritz!Box. You can make a test call at any time using the device’s <em>internal number</em> (which starts with <code>**</code>)—the answering machine always answers such calls.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Fritz!Box address. Tip: If you're using your own DNS server (e.g., Pi-hole/Unbound), enter the <em>IP address</em> of the Fritz!Box here instead of <code>fritz.box</code>, otherwise the hostname may not be resolved and the registration will fail.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Also accepts calls from internal phones (numbers starting with <code>*</code>) – required for the test call using the internal number. Set the value to <code>no</code> if the answering machine is part of a group call (e.g., a doorbell that rings all phones).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Set to <code>yes</code> for troubleshooting: this will log all SIP communication.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/en-US/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Para expertos: autoalojamiento</h2>
 		
 		<p data-tx="t0080:5a67a3ba">¿Eres realmente bueno con los ordenadores, tienes una RaspberryPI u otro mini PC funcionando en casa de todos modos? Entonces simplemente instale el contestador automático usted mismo. La mejor manera de hacerlo es con la imagen preparada <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker</a>. Esto ofrece la mejor protección de datos porque todo el manejo de llamadas se lleva a cabo en su extremo. La configuración en el sistema telefónico es la misma, se configura el contestador automático a través de un archivo de configuración.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Importante para el autoalojamiento:</strong> A diferencia del contestador automático en la nube, en las instrucciones anteriores se omiten dos pasos: <ul> <li><strong>No es necesario utilizar DynDNS.</strong> El contestador automático funciona en la misma red que el Fritz!Box y se conecta de forma local.</li> <li><strong>La opción «Permitir el inicio de sesión desde Internet» permanece desactivada.</strong> Para ello, no es necesario que se pueda acceder al Fritz!Box desde Internet; deja la opción desactivada a propósito para no abrir el router innecesariamente.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Configurar un teléfono en el Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Configura un nuevo dispositivo de telefonía: <em>Telefonía → Dispositivos de telefonía → Configurar nuevo dispositivo → Teléfono (con o sin contestador) → LAN/WLAN (teléfono IP)</em>. Puedes elegir libremente el nombre de usuario y la contraseña; deben coincidir exactamente con los que figuran en el archivo <code>compose.yaml</code>. En «Llamadas entrantes», selecciona <em>«responder a todos los números de teléfono»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Crear el archivo «compose.yaml»</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Variables importantes</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variable</th>
+						<th data-tx="t0090:f0e3578f">Significado</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Tu clave API personal, que puedes crear en <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Deben coincidir exactamente con el teléfono IP configurado en el Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Dirección de la Fritz!Box. Consejo: si utilizas un servidor DNS propio (por ejemplo, Pi-hole/Unbound), introduce aquí la <em>dirección IP</em> del Fritz!Box en lugar de <code>fritz.box</code>, ya que, de lo contrario, es posible que el nombre de host no se resuelva y el registro falle.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obligatorio: necesario para la comunicación SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Poner en marcha y comprobar</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Si en el registro aparece una línea como <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, significa que el contestador automático se ha registrado correctamente en el Fritz!Box. Se puede realizar una llamada de prueba en cualquier momento al <em>número interno</em> del dispositivo (que empieza por <code>**</code>); el contestador automático siempre responde a este tipo de llamadas.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/es/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Dirección de la Fritz!Box. Consejo: si utilizas un servidor DNS propio (por ejemplo, Pi-hole/Unbound), introduce aquí la <em>dirección IP</em> del Fritz!Box en lugar de <code>fritz.box</code>, ya que, de lo contrario, es posible que el nombre de host no se resuelva y el registro falle.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">También acepta llamadas de teléfonos internos (números con <code>*</code>); esto es necesario para realizar la llamada de prueba a través del número interno. Establece el valor en <code>no</code> si el contestador automático forma parte de una llamada colectiva (por ejemplo, un timbre de puerta que hace sonar todos los teléfonos).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Para la resolución de problemas, establece el valor en <code>yes</code>: de este modo, se registrará toda la comunicación SIP en el registro.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Adresse de la Fritz!Box. Astuce : si vous utilisez votre propre serveur DNS (par exemple Pi-hole/Unbound), saisissez ici l'<em>adresse IP</em> de la Fritz!Box à la place de <code>fritz.box</code>, car sinon le nom d'hôte risque de ne pas être résolu et l'enregistrement échouera.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Accepte également les appels provenant de téléphones internes (numéros commençant par <code>*</code>) – nécessaire pour l'appel test via le numéro interne. Définissez la valeur sur <code>no</code> si le répondeur fait partie d'un système d'appel groupé (par exemple, une sonnette qui fait sonner tous les téléphones).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Pour le dépannage, réglez sur <code>yes</code> : cela permet alors d'enregistrer l'intégralité des communications SIP dans le journal.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/fr/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Pour les experts : héberger soi-même</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Tu t'y connais vraiment en informatique, tu as un RaspberryPI ou un autre mini-PC qui tourne de toute façon à la maison ? Alors installe le répondeur téléphonique toi-même. Le mieux est de le faire avec l'image <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker</a> préparée à l'avance. Cela offre la meilleure protection des données, car tout le traitement des appels se fait chez toi. La configuration dans le système téléphonique est la même, tu installes le répondeur via un fichier de configuration.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Point important concernant l'auto-hébergement :</strong> Contrairement à la messagerie vocale dans le cloud, deux étapes de la procédure ci-dessus ne sont pas nécessaires : <ul> <li><strong>Pas besoin de DynDNS.</strong> Le répondeur fonctionne sur le même réseau que la Fritz!Box et se connecte en local.</li> <li><strong>L'option « Autoriser la connexion depuis Internet » reste désactivée.</strong> La Fritz!Box n'a pas besoin d'être accessible depuis Internet pour cela – désactivez délibérément cette option afin de ne pas ouvrir inutilement le routeur.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Configurer un appareil téléphonique dans la Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Configurez un nouvel appareil téléphonique : <em>Téléphonie → Appareils téléphoniques → Configurer un nouvel appareil → Téléphone (avec ou sans répondeur) → LAN/Wi-Fi (téléphone IP)</em>. Tu peux choisir librement ton nom d'utilisateur et ton mot de passe ; ils doivent être exactement identiques dans le fichier <code>compose.yaml</code>. Dans la section « Appels entrants », sélectionne <em>« Répondre à tous les numéros »</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Créer le fichier compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Variables importantes</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variable</th>
+						<th data-tx="t0090:f0e3578f">Signification</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Ta clé API personnelle, que tu peux créer sur <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Ils doivent correspondre exactement au numéro de téléphone IP configuré dans la Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Adresse de la Fritz!Box. Astuce : si vous utilisez votre propre serveur DNS (par exemple Pi-hole/Unbound), saisissez ici l'<em>adresse IP</em> de la Fritz!Box à la place de <code>fritz.box</code>, car sinon le nom d'hôte risque de ne pas être résolu et l'enregistrement échouera.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obligatoire – nécessaire pour la communication SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Démarrer et vérifier</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Si une ligne telle que <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code> apparaît dans le journal, cela signifie que le répondeur s'est connecté avec succès à la Fritz!Box. Il est possible d'effectuer un appel test à tout moment via le <em>numéro interne</em> de l'appareil (commençant par <code>**&lt;/x3 ») – le répondeur accepte toujours ce type d'appels.</code></p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Per gli esperti: self-hosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Siete davvero bravi con i computer, avete un RaspberryPI o un altro mini PC in funzione a casa? Allora installate semplicemente la segreteria telefonica da soli. Il modo migliore per farlo è con l'immagine <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker</a> preparata. In questo modo si ottiene la migliore protezione dei dati, perché tutta la gestione delle chiamate avviene da parte dell'utente. L'impostazione nel sistema telefonico è la stessa, la segreteria telefonica viene impostata tramite un file di configurazione.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Importante per l'hosting autonomo:</strong> A differenza della segreteria telefonica su cloud, nella procedura sopra indicata vengono omessi due passaggi: <ul> <li><strong>Non è necessario il DynDNS.</strong> La segreteria telefonica funziona sulla stessa rete del Fritz!Box e si registra localmente.</li> <li><strong>L'opzione «Consenti l'accesso da Internet» rimane disattivata.</strong> Il Fritz!Box non deve essere accessibile da Internet: lascia l'opzione disattivata di proposito per non esporre inutilmente il router.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Configurare il dispositivo telefonico nel Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Crea un nuovo dispositivo telefonico: <em>Telefonia → Dispositivi telefonici → Configura nuovo dispositivo → Telefono (con o senza segreteria telefonica) → LAN/Wi-Fi (telefono IP)</em>. Puoi scegliere liberamente nome utente e password: devono essere identici nel file <code>compose.yaml</code>. Alla voce «Chiamate in arrivo», seleziona <em>«rispondere a tutti i numeri»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Creare il file compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Variabili importanti</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variabile</th>
+						<th data-tx="t0090:f0e3578f">Significato</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">La tua chiave API personale, che puoi generare su <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Devono corrispondere esattamente al telefono IP configurato nel Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Indirizzo del Fritz!Box. Suggerimento: se si utilizza un server DNS proprio (ad es. Pi-hole/Unbound), inserire qui l'<em>indirizzo IP</em> del Fritz!Box al posto di <code>fritz.box</code>, poiché altrimenti il nome host potrebbe non essere risolto e la registrazione potrebbe non andare a buon fine.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obbligatorio – necessario per la comunicazione SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Avvio e verifica</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Se nel log compare una riga del tipo <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, significa che la segreteria telefonica si è registrata con successo sul Fritz!Box. È possibile effettuare una chiamata di prova in qualsiasi momento utilizzando il <em>numero interno</em> del dispositivo (che inizia con <code>**</code>): la segreteria telefonica risponde sempre a questo tipo di chiamate.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/it/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Indirizzo del Fritz!Box. Suggerimento: se si utilizza un server DNS proprio (ad es. Pi-hole/Unbound), inserire qui l'<em>indirizzo IP</em> del Fritz!Box al posto di <code>fritz.box</code>, poiché altrimenti il nome host potrebbe non essere risolto e la registrazione potrebbe non andare a buon fine.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Accetta anche le chiamate provenienti da telefoni interni (numeri con <code>*</code>) – necessario per la chiamata di prova tramite il numero interno. Imposta il valore su <code>no</code> se la segreteria telefonica fa parte di un sistema di chiamata collettiva (ad es. un campanello che fa squillare tutti i telefoni).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Per la ricerca degli errori, impostare su <code>yes</code>: in questo modo tutte le comunicazioni SIP verranno registrate nel log.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">For eksperter: selvhosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Er du veldig flink med datamaskiner, har du en RaspberryPI eller en annen mini-PC hjemme uansett? Da er det bare å installere telefonsvareren selv. Den beste måten å gjøre dette på er med det forberedte <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker-imaget</a>. Dette gir den beste databeskyttelsen fordi all samtalehåndtering skjer hos deg. Oppsettet i telefonsystemet er det samme, du setter opp telefonsvareren via en konfigurasjonsfil.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Viktig ved egen hosting:</strong> I motsetning til ved bruk av en skybasert telefonsvarer, kan to trinn i veiledningen ovenfor utelates: <ul> <li><strong>Ingen DynDNS nødvendig.</strong> Telefonsvareren kjører i samme nettverk som Fritz!Boxen og logger seg på lokalt.</li> <li><strong>«Tillat pålogging fra Internett» forblir deaktivert.</strong> Fritz!Box-en trenger ikke å være tilgjengelig fra Internett – la alternativet være deaktivert for å unngå å åpne ruteren unødvendig.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Opprette en telefonenhet i Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Opprett en ny telefonenhet: <em>Telefoni → Telefonenheter → Konfigurer ny enhet → Telefon (med eller uten telefonsvarer) → LAN/WLAN (IP-telefon)</em>. Du kan velge brukernavn og passord fritt – de må være identiske i <code>compose.yaml</code>. Under «Innkommende anrop» velger du <em>«svar på alle telefonnumre»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Opprett compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Viktige variabler</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variabel</th>
+						<th data-tx="t0090:f0e3578f">Betydning</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Din personlige API-nøkkel, som du kan opprette på <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Må stemme nøyaktig overens med IP-telefonen som er opprettet i Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Adressen til Fritz!Box. Tips: Hvis du bruker din egen DNS-server (f.eks. Pi-hole/Unbound), må du her oppgi <em>IP-adressen</em> til Fritz!Box i stedet for <code>fritz.box</code>, da vertsnavnet ellers kanskje ikke blir oppløst og registreringen mislykkes.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obligatorisk – kreves for SIP-/RTP-kommunikasjon.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Start og sjekk</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Hvis det vises en linje i loggen som <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, har telefonsvareren logget seg på Fritz!Boxen. Du kan når som helst foreta en testanrop via enhetens <em>interne nummer</em> (begynner med <code>**</code>) – telefonsvareren tar alltid imot slike anrop.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nb/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Adressen til Fritz!Box. Tips: Hvis du bruker din egen DNS-server (f.eks. Pi-hole/Unbound), må du her oppgi <em>IP-adressen</em> til Fritz!Box i stedet for <code>fritz.box</code>, da vertsnavnet ellers kanskje ikke blir oppløst og registreringen mislykkes.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Tar også imot anrop fra interne telefoner (numre med <code>*</code>) – nødvendig for testanropet via det interne nummeret. Sett verdien til <code>no</code> hvis telefonsvareren er en del av en samleanrop (f.eks. en dørklokke som får alle telefoner til å ringe).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Sett til <code>yes</code> for feilsøking: da loggføres all SIP-kommunikasjon i loggen.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Adres van de Fritz!Box. Tip: Als je een eigen DNS-server hebt (bijv. Pi-hole/Unbound) voer hier het <em>IP-adres</em> van de Fritz!Box in plaats van <code>fritz.box</code> in, omdat de hostnaam anders mogelijk niet wordt omgezet en de registratie mislukt.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Neemt ook oproepen van interne telefoons (nummers met <code>*</code>) aan – dit is nodig voor de testoproep via het interne nummer. Stel de waarde in op <code>no</code> als het antwoordapparaat deel uitmaakt van een collectieve oproep (bijvoorbeeld een deurbel die alle telefoons laat overgaan).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Stel in op <code>yes</code> om fouten op te sporen: hierdoor wordt alle SIP-communicatie in het logboek vastgelegd.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Voor experts: zelf hosten</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Ben je echt goed met computers, heb je thuis toch al een RaspberryPI of een andere mini PC draaien? Installeer het antwoordapparaat dan gewoon zelf. De beste manier om dit te doen is met de voorbereide <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker image</a>. Dit biedt de beste gegevensbescherming omdat alle gespreksafhandeling aan jouw kant plaatsvindt. De setup in de telefooncentrale is hetzelfde, je stelt het antwoordapparaat in via een configuratiebestand.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Belangrijk bij zelfhosting:</strong> In tegenstelling tot bij het cloud-antwoordapparaat vallen twee stappen uit de bovenstaande handleiding weg: <ul> <li><strong>Geen DynDNS nodig.</strong> Het antwoordapparaat draait in hetzelfde netwerk als de Fritz!Box en meldt zich lokaal aan.</li> <li><strong>"Toegang vanaf het internet toestaan" blijft uitgeschakeld.</strong> De Fritz!Box hoeft hiervoor niet bereikbaar te zijn via het internet – laat de optie bewust uitgeschakeld om de router niet onnodig open te stellen.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Een telefoontoestel in de Fritz!Box aanmaken</h3>
+		<p data-tx="t0086:77837d1f">Voeg een nieuw telefoontoestel toe: <em>Telefonie → Telefoontoestellen → Nieuw toestel instellen → Telefoon (met en zonder antwoordapparaat) → LAN/WLAN (IP-telefoon)</em>. Je kunt zelf een gebruikersnaam en wachtwoord kiezen – deze moeten exact hetzelfde zijn als in het bestand <code>compose.yaml</code>. Bij "Inkomende oproepen" selecteer je <em>"reageren op alle nummers"</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Maak het bestand `compose.yaml` aan</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Belangrijke variabelen</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variabele</th>
+						<th data-tx="t0090:f0e3578f">Betekenis</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Je persoonlijke API-sleutel, die je kunt aanmaken op <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Deze moeten exact overeenkomen met de IP-telefoon die in de Fritz!Box is aangemaakt.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Adres van de Fritz!Box. Tip: Als je een eigen DNS-server hebt (bijv. Pi-hole/Unbound) voer hier het <em>IP-adres</em> van de Fritz!Box in plaats van <code>fritz.box</code> in, omdat de hostnaam anders mogelijk niet wordt omgezet en de registratie mislukt.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Verplicht – vereist voor SIP-/RTP-communicatie.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Opstarten en controleren</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Als er in het logboek een regel verschijnt zoals <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, dan heeft het antwoordapparaat zich met succes aangemeld bij de Fritz!Box. Een testoproep kan op elk moment worden gedaan via het <em>interne nummer</em> van het apparaat (begint met <code>**</code>) – dergelijke oproepen worden altijd door het antwoordapparaat aangenomen.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nl/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Dla ekspertów: hosting własny</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Jesteś naprawdę dobry w komputerach, masz RaspberryPI lub inny mini PC działający w domu? W takim razie po prostu zainstaluj automatyczną sekretarkę samodzielnie. Najlepszym sposobem na to jest użycie przygotowanego obrazu <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker</a>. Zapewnia to najlepszą ochronę danych, ponieważ cała obsługa połączeń odbywa się po stronie użytkownika. Konfiguracja w systemie telefonicznym jest taka sama, automatyczną sekretarkę konfiguruje się za pomocą pliku konfiguracyjnego.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Ważne w przypadku samodzielnego hostingu:</strong> W odróżnieniu od poczty głosowej w chmurze, w powyższej instrukcji pominięto dwa kroki: <ul> <li><strong>Nie jest potrzebna usługa DynDNS.</strong> Automatyczna sekretarka działa w tej samej sieci co router Fritz!Box i loguje się lokalnie.</li> <li><strong>Opcja „Zezwól na logowanie z Internetu” pozostaje wyłączona.</strong> Fritz!Box nie musi być w tym celu dostępny z Internetu – celowo pozostaw tę opcję wyłączoną, aby nie otwierać routera bez potrzeby.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Skonfigurowanie urządzenia telefonicznego w Fritz!Boxie</h3>
+		<p data-tx="t0086:77837d1f">Dodaj nowe urządzenie telefoniczne: <em>Telefonia → Urządzenia telefoniczne → Skonfiguruj nowe urządzenie → Telefon (z automatyczną sekretarką lub bez) → LAN/Wi-Fi (telefon IP)</em>. Nazwę użytkownika i hasło możesz wybrać dowolnie – muszą one być identyczne w pliku <code>compose.yaml</code>. W sekcji „Połączenia przychodzące” wybierz opcję <em>„odpowiadać na wszystkie numery”</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Utwórz plik compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Istotne zmienne</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Zmienna</th>
+						<th data-tx="t0090:f0e3578f">Znaczenie</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Twój osobisty klucz API, który można utworzyć na stronie <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Muszą dokładnie odpowiadać numerowi telefonu IP skonfigurowanemu w routerze Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Adres urządzenia Fritz!Box. Wskazówka: Jeśli korzystasz z własnego serwera DNS (np. Pi-hole/Unbound) należy w tym miejscu wpisać <em>adres IP</em> urządzenia Fritz!Box zamiast <code>fritz.box</code>, ponieważ w przeciwnym razie nazwa hosta może nie zostać rozpoznana, a rejestracja zakończy się niepowodzeniem.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obowiązkowe – wymagane do komunikacji SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Uruchomienie i sprawdzenie</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Jeśli w dzienniku pojawi się wiersz w postaci <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, oznacza to, że automatyczna sekretarka pomyślnie zalogowała się do urządzenia Fritz!Box. Połączenie testowe można wykonać w dowolnym momencie, dzwoniąc na <em>numer wewnętrzny</em> urządzenia (zaczynający się od <code>**</code>) – automatyczna sekretarka zawsze odbiera takie połączenia.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/pl/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Adres urządzenia Fritz!Box. Wskazówka: Jeśli korzystasz z własnego serwera DNS (np. Pi-hole/Unbound) należy w tym miejscu wpisać <em>adres IP</em> urządzenia Fritz!Box zamiast <code>fritz.box</code>, ponieważ w przeciwnym razie nazwa hosta może nie zostać rozpoznana, a rejestracja zakończy się niepowodzeniem.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Odbiera również połączenia z telefonów wewnętrznych (numery z przedrostkiem <code>*</code>) – jest to konieczne do wykonania połączenia testowego z numeru wewnętrznego. Ustaw wartość na <code>no</code>, jeśli automatyczna sekretarka jest częścią systemu powiadamiania zbiorowego (np. dzwonek do drzwi, który powoduje dzwonienie wszystkich telefonów).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Aby przeprowadzić diagnostykę, należy ustawić opcję <code>yes</code>: spowoduje to rejestrowanie całej komunikacji SIP w dzienniku.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Fritz!Boxens adress. Tips: Om du använder en egen DNS-server (t.ex. Pi-hole/Unbound) ska du här ange <em>IP-adressen</em> till Fritz!Box istället för <code>fritz.box</code>, eftersom värdnamnet annars eventuellt inte kan lösas upp och registreringen misslyckas.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Tar även emot samtal från interna telefoner (nummer som börjar med <code>*</code>) – detta krävs för testsamtalet via det interna numret. Ställ in värdet på <code>no</code> om telefonsvararen ingår i en samlingssignal (t.ex. en dörrklocka som får alla telefoner att ringa).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Ställ in på <code>yes</code> för felsökning: då loggas all SIP-kommunikation i loggfilen.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/sv/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">För experter: självhosting</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Är du riktigt duktig på datorer, har du en RaspberryPI eller någon annan minidator hemma i alla fall? Då är det bara att installera telefonsvararen själv. Det bästa sättet att göra detta är med den förberedda <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker-bilden</a>. Detta ger det bästa dataskyddet eftersom all samtalshantering sker på din sida. Inställningen i telefonsystemet är densamma, du ställer in telefonsvararen via en konfigurationsfil.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Viktigt vid egenhosting:</strong> Till skillnad från molnbaserade telefonsvarare utelämnas två steg i anvisningarna ovan: <ul> <li><strong>Inget DynDNS behövs.</strong> Telefonsvararen körs i samma nätverk som Fritz!Boxen och ansluter lokalt.</li> <li><strong>”Tillåt inloggning från internet” förblir inaktiverat.</strong> Fritz!Boxen behöver inte vara tillgänglig från internet för detta – lämna alternativet avsiktligt avmarkerat för att inte öppna routern i onödan.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Skapa en telefonenhet i Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Lägg till en ny telefonenhet: <em>Telefoni → Telefonenheter → Konfigurera ny enhet → Telefon (med eller utan telefonsvarare) → LAN/WLAN (IP-telefon)</em>. Du väljer själv användarnamn och lösenord – de måste vara identiska i filen <code>compose.yaml</code>. Under ”Inkommande samtal” väljer du <em>”svara på alla telefonnummer”</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Skapa filen compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Viktiga variabler</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Variabel</th>
+						<th data-tx="t0090:f0e3578f">Betydelse</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Din personliga API-nyckel, som du kan skapa på <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Måste stämma exakt överens med den IP-telefon som har skapats i Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Fritz!Boxens adress. Tips: Om du använder en egen DNS-server (t.ex. Pi-hole/Unbound) ska du här ange <em>IP-adressen</em> till Fritz!Box istället för <code>fritz.box</code>, eftersom värdnamnet annars eventuellt inte kan lösas upp och registreringen misslyckas.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Obligatoriskt – krävs för SIP-/RTP-kommunikation.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Starta och kontrollera</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Om en rad som <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code> visas i loggen, har telefonsvararen loggat in på Fritz!Boxen utan problem. Ett testsamtal kan när som helst ringas via enhetens <em>interna nummer</em> (börjar med <code>**</code>) – sådana samtal tar telefonsvararen alltid emot.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">Для експертів: самостійне розміщення</h2>
 		
 		<p data-tx="t0080:5a67a3ba">Ви дійсно добре розбираєтеся в комп'ютерах, у вас вдома працює RaspberryPI або інший міні-ПК? Тоді просто встановіть автовідповідач самостійно. Найкраще це зробити за допомогою підготовленого <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker-образу</a>. Це забезпечує найкращий захист даних, оскільки вся обробка дзвінків відбувається на вашому боці. Налаштування у телефонній системі відбувається так само, ви налаштовуєте автовідповідач за допомогою конфігураційного файлу.</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>Важливо при самостійному хостингу:</strong> На відміну від хмарного автовідповідача, у наведених вище інструкціях можна пропустити два кроки: <ul> <li><strong>DynDNS не потрібен.</strong> Автоответчик працює в тій самій мережі, що й Fritz!Box, і підключається локально.</li> <li><strong>Параметр «Дозволити підключення з Інтернету» залишається вимкненим.</strong> Для цього Fritz!Box не має бути доступним з Інтернету — навмисно залиш цю опцію вимкненою, щоб не відкривати маршрутизатор без необхідності.</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. Створити телефонний пристрій у Fritz!Box</h3>
+		<p data-tx="t0086:77837d1f">Створи новий телефонний пристрій: <em>Телефонія → Телефонні пристрої → Налаштувати новий пристрій → Телефон (з автовідповідачем або без нього) → LAN/WLAN (IP-телефон)</em>. Ім'я користувача та пароль ти обираєш на власний розсуд — вони повинні бути ідентичними у файлі <code>compose.yaml</code>. У розділі «Вхідні дзвінки» вибери <em>«відповідати на всі номери»</em>.</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. Створити файл compose.yaml</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. Важливі змінні</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">Змінна</th>
+						<th data-tx="t0090:f0e3578f">Значення</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">Твій особистий ключ API, який можна створити на сайті <code>phoneblock.net/phoneblock/settings</code>.</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">Повинні точно збігатися з IP-телефоном, налаштованим у Fritz!Box.</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Адреса Fritz!Box. Порада: якщо ви використовуєте власний DNS-сервер (наприклад, Pi-hole/Unbound), введіть тут <em>IP-адресу</em> Fritz!Box замість <code>fritz.box</code>, оскільки в іншому випадку ім’я хоста може не розпізнатися, і реєстрація завершиться невдачею.</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">Обов’язкове поле — необхідне для зв’язку за протоколами SIP/RTP.</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. Запуск та перевірка</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">Якщо в журналі з’являється рядок на кшталт <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code>, це означає, що автовідповідач успішно зареєструвався на Fritz!Box. Тестовий дзвінок можна здійснити в будь-який час на <em>внутрішній номер</em> пристрою (починається з <code>**</code>) — автовідповідач завжди приймає такі дзвінки.</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/uk/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Адреса Fritz!Box. Порада: якщо ви використовуєте власний DNS-сервер (наприклад, Pi-hole/Unbound), введіть тут <em>IP-адресу</em> Fritz!Box замість <code>fritz.box</code>, оскільки в іншому випадку ім’я хоста може не розпізнатися, і реєстрація завершиться невдачею.</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">Також приймає дзвінки з внутрішніх телефонів (номери з <code>*</code>) — це необхідно для тестового дзвінка на внутрішній номер. Встановіть значення <code>no</code>, якщо автовідповідач є частиною групового виклику (наприклад, дверний дзвінок, який змушує дзвонити всі телефони).</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">Для діагностики помилок встановіть значення <code>yes</code>: у цьому випадку у журналі буде записано весь обмін даними SIP.</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
@@ -296,6 +296,8 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
+      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
+      - LOG_ALL_PACKETS=no
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
@@ -298,6 +298,9 @@
       - CONVERSATION=/opt/phoneblock/conversation
       # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
+      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
+      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
+      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		

--- a/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
@@ -272,6 +272,67 @@
 		<h2 data-tx="t0079:b65f7797" id="experts">供专家使用：自助托管</h2>
 		
 		<p data-tx="t0080:5a67a3ba">你真的会用电脑吗？你家里有 RaspberryPI 或其他微型电脑吗？那就自己安装答录机吧。最好的方法是使用准备好的 <a href="https://hub.docker.com/r/phoneblock/answerbot">Docker 镜像</a>。这样可以提供最好的数据保护，因为所有呼叫处理都是在您的终端进行的。电话系统中的设置是一样的，您可以通过配置文件来设置应答机。</p>
+		<div class="notification is-warning" data-tx="t0084:4bc9a0f9"><strong>自主托管时的注意事项：</strong> 与云语音信箱不同，上述操作指南中的两个步骤可以省略：<ul> <li><strong>无需使用DynDNS。</strong> 答录机与 Fritz!Box 位于同一网络中，并通过本地方式登录。</li> <li><strong>“允许从互联网登录”选项保持禁用状态。</strong> 为此，Fritz!Box 无需对互联网开放——请有意保留该选项的禁用状态，以免不必要地开放路由器。</li> </ul></div>
+		
+		<h3 data-tx="t0085:b85e4fee">1. 在 Fritz!Box 中添加电话设备</h3>
+		<p data-tx="t0086:77837d1f">添加新的电话设备：<em>电话 → 电话设备 → 设置新设备 → 电话（带或不带答录机） → LAN/WLAN（IP电话）</em>。 用户名和密码可自行设定——它们必须与<code>compose.yaml</code>中的内容完全一致。在“来电”选项中，请选择<em>“响应所有号码”</em>。</p>
+		
+		<h3 data-tx="t0087:f0ff4af">2. 创建 compose.yaml 文件</h3>
+		<pre>services:
+  phoneblock:
+    image: phoneblock/answerbot:latest
+    container_name: phoneblock
+    network_mode: host
+    environment:
+      - PHONEBLOCK_API_KEY=&lt;dein API-Key&gt;
+      - SIP_USER=&lt;Benutzername wie in der Fritz!Box&gt;
+      - SIP_PASSWD=&lt;Kennwort wie in der Fritz!Box&gt;
+      - VIA_ADDR=auto-configuration
+      - VIA_ADDR_V6=auto-configuration
+      - HOST_PORT=50060
+      - REGISTRAR=192.168.178.1
+      - ROUTE=192.168.178.1;lr
+      - REALM=fritz.box
+      - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
+      - RECORDINGS=none
+      - CONVERSATION=/opt/phoneblock/conversation
+      - ACCEPT_LOCAL=yes
+    restart: unless-stopped</pre>
+		
+		<h3 data-tx="t0088:68a01d83">3. 重要变量</h3>
+		<div class="table-container">
+			<table class="table is-fullwidth is-striped">
+				<thead>
+					<tr>
+						<th data-tx="t0089:c616aa64">变量</th>
+						<th data-tx="t0090:f0e3578f">含义</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><code>PHONEBLOCK_API_KEY</code></td>
+						<td data-tx="t0091:c8ab1645">您的个人 API 密钥，可在 <code>phoneblock.net/phoneblock/settings</code> 处生成。</td>
+					</tr>
+					<tr>
+						<td><code>SIP_USER</code> / <code>SIP_PASSWD</code></td>
+						<td data-tx="t0092:ea799cc3">必须与在Fritz!Box中设置的IP电话完全一致。</td>
+					</tr>
+					<tr>
+						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
+						<td data-tx="t0093:17dcf955">Fritz!Box 的地址。提示：如果使用自有 DNS 服务器（例如 Pi-hole/Unbound），请在此处输入 Fritz!Box 的 <em>IP 地址</em> 代替 <code>fritz.box</code>，否则主机名可能无法解析，导致注册失败。</td>
+					</tr>
+					<tr>
+						<td><code>network_mode: host</code></td>
+						<td data-tx="t0094:a961a2ea">必填项——SIP/RTP通信所需。</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		
+		<h3 data-tx="t0095:cc612f71">4. 启动和检查</h3>
+		<pre>docker compose up -d
+docker logs -f phoneblock</pre>
+		<p data-tx="t0096:dabc390b">如果日志中出现类似 <code>Registration of '&lt;sip:...&gt;' 200 OK, expires in 300s</code> 的记录，则说明答录机已成功在 Fritz!Box 上注册。 您可以随时拨打该设备的<em>内部号码</em>（以<code>**</code>开头）进行测试——答录机始终会接听此类来电。</p>
 		
 	</div>
 </section>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/anrufbeantworter.html
@@ -296,11 +296,7 @@
       - MEDIA=audio 4080 RTP/AVP { 8 PCMA 8000 160 }
       - RECORDINGS=none
       - CONVERSATION=/opt/phoneblock/conversation
-      # Zur Fehlersuche auf "yes" setzen: protokolliert die gesamte SIP-Kommunikation.
       - LOG_ALL_PACKETS=no
-      # Nimmt auch Anrufe interner Telefone (Nummern mit "*") an – nötig für den Testanruf
-      # über die interne Nummer. Auf "no" setzen, wenn der Anrufbeantworter Teil eines
-      # Sammelrufs ist (z. B. eine Türklingel, die alle Telefone klingeln lässt).
       - ACCEPT_LOCAL=yes
     restart: unless-stopped</pre>
 		
@@ -325,6 +321,14 @@
 					<tr>
 						<td><code>REGISTRAR</code> / <code>ROUTE</code></td>
 						<td data-tx="t0093:17dcf955">Fritz!Box 的地址。提示：如果使用自有 DNS 服务器（例如 Pi-hole/Unbound），请在此处输入 Fritz!Box 的 <em>IP 地址</em> 代替 <code>fritz.box</code>，否则主机名可能无法解析，导致注册失败。</td>
+					</tr>
+					<tr>
+						<td><code>ACCEPT_LOCAL</code></td>
+						<td data-tx="t0097:3aeb6350">也接听内线电话（以<code>*</code>开头的号码）——这是通过内线号码进行测试呼叫所必需的。 如果答录机属于集体呼叫系统的一部分（例如，能让所有电话同时响起的门铃），请将该值设置为 <code>no</code>。</td>
+					</tr>
+					<tr>
+						<td><code>LOG_ALL_PACKETS</code></td>
+						<td data-tx="t0098:231f7ac9">为进行故障排查，请将该选项设置为 <code>yes</code>：这样会将所有的SIP通信记录到日志中。</td>
 					</tr>
 					<tr>
 						<td><code>network_mode: host</code></td>


### PR DESCRIPTION
Der bisherige Abschnitt "Für Experten: Selbst hosten" verweist nur knapp auf das Docker-Image. Self-Hoster folgen dann aber unnötig den DynDNS- und "Anmeldung aus dem Internet erlauben"-Schritten aus der Cloud-Anleitung und öffnen ihre FRITZ!Box ohne Not nach außen.

Diese Änderung ergänzt den Abschnitt um:
- klaren Hinweis, dass DynDNS und Internet-Anmeldung beim Self-Hosting entfallen
- ein vollständiges compose.yaml-Beispiel
- eine Variablen-Tabelle inkl. Hinweis, bei eigenem DNS (Pi-hole/Unbound) REGISTRAR/ROUTE per IP statt fritz.box zu setzen
- einen Verifikationsschritt (200 OK im Log) und Testanruf über die interne Nummer

Hinweis: Die neuen Elemente haben noch keine data-tx-Übersetzungs-Keys – die müssten über das Projekt-Tooling generiert werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
