### PR TITLE
Dongle: order rc pre-releases so beta channel updates (#416)

### DIFF
--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
+    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "sync.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -25,6 +25,7 @@
 #include "sdkconfig.h"
 
 #include "config.h"
+#include "version_cmp.h"
 
 static const char *TAG = "fwup";
 
@@ -164,29 +165,6 @@ static void copy_str(char *dst, size_t cap, const char *src)
     size_t n = strnlen(src, cap - 1);
     memcpy(dst, src, n);
     dst[n] = '\0';
-}
-
-// Lightweight semver-ish comparison for our own version strings
-// (Project version from CMakeLists.txt, e.g. "1.5.3" or "1.5.3-rc1").
-// Returns <0 / 0 / >0 like strcmp. Numeric major.minor.patch compare,
-// then any pre-release suffix ("-rc1", "-dev", …) is treated as
-// strictly less than the same release without the suffix — enough
-// to keep "1.5.3-rc1" from displacing a freshly flashed "1.5.3".
-// Two pre-release suffixes are treated as equal; we don't have rc
-// orderings to worry about today.
-static int semver_cmp(const char *a, const char *b)
-{
-    int aMaj = 0, aMin = 0, aPat = 0;
-    int bMaj = 0, bMin = 0, bPat = 0;
-    sscanf(a, "%d.%d.%d", &aMaj, &aMin, &aPat);
-    sscanf(b, "%d.%d.%d", &bMaj, &bMin, &bPat);
-    if (aMaj != bMaj) return aMaj < bMaj ? -1 : 1;
-    if (aMin != bMin) return aMin < bMin ? -1 : 1;
-    if (aPat != bPat) return aPat < bPat ? -1 : 1;
-    int aPre = strchr(a, '-') ? 1 : 0;
-    int bPre = strchr(b, '-') ? 1 : 0;
-    if (aPre != bPre) return aPre ? -1 : 1;
-    return 0;
 }
 
 static void reboot_task(void *arg)
@@ -425,7 +403,7 @@ static void resolve_manifest(bool force, const char *current_version,
     copy_str(d->new_version, sizeof(d->new_version), new_version);
     copy_str(d->app_url,     sizeof(d->app_url),     new_url);
 
-    int vcmp = semver_cmp(new_version, current_version);
+    int vcmp = version_cmp(new_version, current_version);
     if (vcmp == 0) {
         cJSON_Delete(root);
         d->result = FW_UPDATE_NO_NEW;

--- a/phoneblock-dongle/firmware/main/version_cmp.c
+++ b/phoneblock-dongle/firmware/main/version_cmp.c
@@ -1,0 +1,58 @@
+#include "version_cmp.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+// Natural compare of two pre-release identifiers (the part after the
+// first '-', e.g. "rc1", "rc2", "rc10", "dev"). Non-digit runs compare
+// byte-wise; digit runs compare numerically (leading zeros ignored), so
+// "rc2" < "rc10" rather than the lexicographic "rc10" < "rc2". Returns
+// <0 / 0 / >0 like strcmp.
+static int prerelease_cmp(const char *a, const char *b)
+{
+    while (*a && *b) {
+        if (isdigit((unsigned char)*a) && isdigit((unsigned char)*b)) {
+            while (*a == '0') a++;
+            while (*b == '0') b++;
+            const char *as = a, *bs = b;
+            while (isdigit((unsigned char)*a)) a++;
+            while (isdigit((unsigned char)*b)) b++;
+            size_t alen = (size_t)(a - as), blen = (size_t)(b - bs);
+            if (alen != blen) return alen < blen ? -1 : 1;
+            int c = strncmp(as, bs, alen);
+            if (c != 0) return c < 0 ? -1 : 1;
+        } else {
+            if (*a != *b) {
+                return (unsigned char)*a < (unsigned char)*b ? -1 : 1;
+            }
+            a++;
+            b++;
+        }
+    }
+    if (*a) return 1;
+    if (*b) return -1;
+    return 0;
+}
+
+int version_cmp(const char *a, const char *b)
+{
+    int aMaj = 0, aMin = 0, aPat = 0;
+    int bMaj = 0, bMin = 0, bPat = 0;
+    sscanf(a, "%d.%d.%d", &aMaj, &aMin, &aPat);
+    sscanf(b, "%d.%d.%d", &bMaj, &bMin, &bPat);
+    if (aMaj != bMaj) return aMaj < bMaj ? -1 : 1;
+    if (aMin != bMin) return aMin < bMin ? -1 : 1;
+    if (aPat != bPat) return aPat < bPat ? -1 : 1;
+
+    const char *aPre = strchr(a, '-');
+    const char *bPre = strchr(b, '-');
+    // A final release (no suffix) sorts above any pre-release of the
+    // same x.y.z.
+    if (!aPre && !bPre) return 0;
+    if (!aPre) return 1;
+    if (!bPre) return -1;
+    // Both are pre-releases of the same x.y.z: order by the identifier
+    // ("rc1" < "rc2" < "rc10").
+    return prerelease_cmp(aPre + 1, bPre + 1);
+}

--- a/phoneblock-dongle/firmware/main/version_cmp.h
+++ b/phoneblock-dongle/firmware/main/version_cmp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Lightweight semver-ish comparison for our own firmware version strings
+// (project version from CMakeLists.txt, e.g. "1.5.3" or "1.5.3-rc1").
+// Returns <0 / 0 / >0 like strcmp.
+//
+// Numeric major.minor.patch compare first. When those are equal, a
+// pre-release suffix ("-rc1", "-dev", …) sorts strictly *below* the same
+// release without a suffix, so "1.5.3-rc1" never displaces a released
+// "1.5.3". Two pre-release suffixes of the same x.y.z are ordered by their
+// identifier with a natural compare, so "1.4.0-rc1" < "1.4.0-rc2" <
+// "1.4.0-rc10" — this is what lets the beta channel hand out successive
+// rc builds of the same version (issue #416).
+//
+// Pure libc, no ESP-IDF dependency, so it is exercised by the host test
+// harness (test_version_cmp.c).
+int version_cmp(const char *a, const char *b);

--- a/phoneblock-dongle/firmware/test/.gitignore
+++ b/phoneblock-dongle/firmware/test/.gitignore
@@ -1,12 +1,4 @@
-test_sip_parse
-test_sip_frame
-test_sip_srv
-test_sip_auth
-test_tr064_parse
-test_api_scan
-test_log_capture
-test_improv_proto
-test_blocklist_lookup
-test_sched_time
-test_smtp_body
-cjson.o
+# Compiled host-test binaries and objects (sources are kept).
+test_*
+!test_*.c
+*.o

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_version_cmp
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -46,6 +46,9 @@ test_sched_time: test_sched_time.c ../main/sched_time.c ../main/sched_time.h
 
 test_smtp_body: test_smtp_body.c ../main/smtp_body.c ../main/smtp_body.h
 	$(CC) $(CFLAGS) test_smtp_body.c ../main/smtp_body.c -o $@
+
+test_version_cmp: test_version_cmp.c ../main/version_cmp.c ../main/version_cmp.h
+	$(CC) $(CFLAGS) test_version_cmp.c ../main/version_cmp.c -o $@
 
 test: $(BINS)
 	@set -e; for b in $(BINS); do echo "→ $$b"; ./$$b; done

--- a/phoneblock-dongle/firmware/test/test_version_cmp.c
+++ b/phoneblock-dongle/firmware/test/test_version_cmp.c
@@ -1,0 +1,44 @@
+// Host test for version_cmp.c — the firmware version ordering that the
+// OTA manifest decision relies on. Pure libc.
+#include <assert.h>
+#include <stdio.h>
+
+#include "version_cmp.h"
+
+// Sign of version_cmp, so the assertions read as -1 / 0 / +1.
+static int sgn(int v) { return (v > 0) - (v < 0); }
+
+int main(void)
+{
+    // --- major.minor.patch ordering ---
+    assert(sgn(version_cmp("1.4.1", "1.4.0")) == 1);
+    assert(sgn(version_cmp("1.4.0", "1.4.1")) == -1);
+    assert(sgn(version_cmp("2.0.0", "1.9.9")) == 1);
+    assert(sgn(version_cmp("1.5.0", "1.4.9")) == 1);
+    assert(sgn(version_cmp("1.4.0", "1.4.0")) == 0);
+
+    // --- issue #416: successive rc builds of the same x.y.z must order ---
+    // The beta channel hands out 1.4.0-rc1, then 1.4.0-rc2; a dongle on
+    // rc1 must see rc2 as newer (previously this returned 0 → no update).
+    assert(sgn(version_cmp("1.4.0-rc2", "1.4.0-rc1")) == 1);
+    assert(sgn(version_cmp("1.4.0-rc1", "1.4.0-rc2")) == -1);
+    assert(sgn(version_cmp("1.4.0-rc1", "1.4.0-rc1")) == 0);
+    // Natural (numeric) ordering, not lexicographic: rc2 < rc10.
+    assert(sgn(version_cmp("1.4.0-rc10", "1.4.0-rc2")) == 1);
+    assert(sgn(version_cmp("1.4.0-rc2", "1.4.0-rc10")) == -1);
+
+    // --- a pre-release sorts below the same released version ---
+    assert(sgn(version_cmp("1.4.0-rc1", "1.4.0")) == -1);
+    assert(sgn(version_cmp("1.4.0", "1.4.0-rc1")) == 1);
+
+    // --- a released build still beats a pre-release of a lower version ---
+    assert(sgn(version_cmp("1.4.0", "1.3.9-rc5")) == 1);
+    // ...and a pre-release of a higher version beats a lower release.
+    assert(sgn(version_cmp("1.5.0-rc1", "1.4.9")) == 1);
+
+    // --- non-numeric pre-release identifiers fall back to byte order ---
+    assert(sgn(version_cmp("1.4.0-rc1", "1.4.0-dev")) == 1); // 'd' < 'r'
+
+    printf("test_version_cmp: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #416. Master variant of #417 (cherry-pick onto `master`, which has diverged from `dongle-1.4.x` — the `blocklist_*` sources differ in `CMakeLists.txt` / test `Makefile`, resolved keeping both sides).

## Problem
A dongle on the **beta channel** never picked up a newer rc build of the same `x.y.z` (e.g. `1.4.0-rc1` → `1.4.0-rc2`) — not on the scheduled check, nor on "Auf Aktualisierung prüfen".

`semver_cmp()` treated any two pre-release suffixes of the same `x.y.z` as **equal**, so `version_cmp("1.4.0-rc2", "1.4.0-rc1")` returned `0` and `resolve_manifest()` reported `FW_UPDATE_NO_NEW`. The manual `force` path only relaxes the downgrade case (`vcmp < 0`), not equality, so the button didn't help either. The stable channel was unaffected because its `x.y.z` increases between releases.

## Fix
- Extract the comparison into a pure `main/version_cmp.c` / `.h` module (same pattern as `sched_time.c`), so it is host-testable.
- Order two pre-releases of the same `x.y.z` by their identifier with a **natural compare**: `rc1 < rc2 < rc10`. A final release still sorts above any pre-release of the same `x.y.z`, and a release still beats a pre-release of a lower version.
- Add host test `test/test_version_cmp.c` covering the beta-channel cases.

## Verification
- `make test_version_cmp` green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)