### PR TITLE
Dongle: keep self-healing re-REGISTER blips off the web log (#402)

### DIFF
--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -539,7 +539,12 @@ static int sip_send_recv(sip_ctx_t *c, const char *tx, int tx_len,
 
         int64_t remaining_us = deadline - esp_timer_get_time();
         if (remaining_us <= 0) {
-            ESP_LOGW(TAG, "no response from registrar within %d ms",
+            // INFO, not WARN: a single missed response is a routine
+            // transient (it usually recovers on the next refresh while the
+            // FB binding still covers us). The caller decides whether to
+            // surface it — keeping this off WARN/ERROR avoids flooding the
+            // web "Protokoll" ring (log_capture.c) on every blip (#402).
+            ESP_LOGI(TAG, "no response from registrar within %d ms",
                      SIP_REGISTER_RECV_TIMEOUT_MS);
             return -1;
         }
@@ -619,7 +624,11 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
     ESP_LOGI(TAG, "→ REGISTER (%d bytes):\n%.*s", tx_len, tx_len, tx);
     int rx_len = sip_send_recv(c, tx, tx_len, rx, SIP_RX_BUF_SIZE);
     if (rx_len < 0) {
-        ESP_LOGE(TAG, "sip_send_recv failed");
+        // Don't log here: do_register's contract is to NOT surface the
+        // failure itself (see header comment) — that decision belongs to
+        // the caller. The auth-retry path below (sip_send_recv at the
+        // 401/407 stage) already stays silent; match it so a transient
+        // refresh blip doesn't reach the web log (#402).
         if (err) snprintf(err, err_cap,
             "REGISTER: no response from registrar (timeout/transport)");
         result = REGISTER_TRANSIENT;
@@ -1819,7 +1828,13 @@ static void sip_task(void *arg)
                 // eventually lapse, and try again at the standard
                 // retry interval.
                 int64_t left_s = (s_binding_expires_at_us - now) / 1000000LL;
-                ESP_LOGW(TAG, "re-REGISTER transient (%s) — binding valid "
+                // INFO, not WARN: while the FB binding still covers us this
+                // is a self-healing retry, not a problem the user needs to
+                // see. If the binding does eventually lapse, the definitive
+                // branch below logs the stashed reason at ERROR as a single
+                // dashboard entry. Keeping the covered case off WARN/ERROR
+                // stops the web "Protokoll" ring filling with blips (#402).
+                ESP_LOGI(TAG, "re-REGISTER transient (%s) — binding valid "
                               "for %lld s more, retry in %d s",
                          err, (long long)left_s, retry_delay_s);
                 if (err[0]) {


### PR DESCRIPTION
Fixes #402 on `master`.

Sometimes the periodic SIP re-REGISTER refresh times out for a single attempt while the Fritz!Box binding is still valid. That case is *designed* to be silently retried, but three log sites pushed `WARN`/`ERROR` — which `log_capture.c` mirrors into the dongle's web "Protokoll" panel — so every transient blip produced a three-line warning cluster:

```
[sip] re-REGISTER transient (...) — binding valid for 99 s more, retry in 30 s
[sip] sip_send_recv failed
[sip] no response from registrar within 10000 ms
```

## Change
- `sip_send_recv` recv-timeout: `WARN` → `INFO` (the caller decides whether to surface it).
- `do_register` send/recv failure: drop the `ESP_LOGE` entirely — it contradicted `do_register`'s documented "does not log the failure itself" contract and was inconsistent with the already-silent auth-retry path.
- Refresh loop, binding-still-valid: `WARN` → `INFO`.

## What still surfaces (unchanged)
Initial-register and config-reload failures (`ERROR`), transport reconnects (`WARN`), and — crucially — a transient that *outlives* the binding still logs the stashed reason once as `binding expired: …` (`ERROR`). Serial console still shows the blips at `INFO`.

## Verification
- `idf.py build` — clean, no warnings.
- Host test suite (`firmware/test && make test`) — 8 passed, 0 failed.

> Note: the 1.4 release branch is not a clean ancestor of `master`, so this ships as two separate PRs. The release-branch counterpart is #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)