### PR TITLE
Dongle: drop benign httpd recv WARNs from the web log ring

### DIFF
--- a/phoneblock-dongle/firmware/CLAUDE.md
+++ b/phoneblock-dongle/firmware/CLAUDE.md
@@ -20,6 +20,16 @@ it shows up on the UI automatically** — no per-call-site plumbing. Keep
 few seconds (they'd flush the 32-entry ring). The parsing of the formatted
 log line is host-tested in `test/test_log_capture.c`.
 
+Some ESP-IDF libraries WARN on routine, self-recovering conditions they
+have no INFO path for (e.g. `httpd_txrx` logs `error in recv` every time a
+browser drops a keep-alive socket). Those aren't faults but would alarm
+users on the panel. The `k_suppress` denylist in `log_capture.c` drops
+such lines from the *ring only* — they still reach the serial console.
+Keep entries narrow (exact tag + message substring + level) so a genuine
+error from the same component still surfaces; add a host test alongside.
+Prefer this over `esp_log_level_set(tag, …)`, which also kills the serial
+line and hides the whole tag.
+
 ### Long-running timer intervals
 
 `pdMS_TO_TICKS(ms)` multiplies its argument by `configTICK_RATE_HZ` in

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -104,6 +104,47 @@ char log_capture_parse(const char *line,
 }
 
 // ---------------------------------------------------------------------------
+// Library-noise suppression (host-testable).
+//
+// A few ESP-IDF libraries log routine, self-recovering conditions at WARN
+// because they have no INFO-level path for them. Mirrored into the web
+// "Protokoll" panel those read as faults and alarm users even though
+// nothing is wrong. Drop the specific lines from the ring — they still go
+// to the serial console (log_hook forwards every line there), so they stay
+// available for real debugging.
+//
+// Keep this list SHORT and SPECIFIC: an exact tag plus a message substring,
+// at one level. It is the opposite of a blanket per-tag mute — a genuine
+// error from the same component must still surface.
+struct log_suppress {
+    char        level;   // level letter this rule applies to ('W', 'E', …)
+    const char *tag;     // exact ESP-IDF tag
+    const char *needle;  // substring that must appear in the message
+};
+
+static const struct log_suppress k_suppress[] = {
+    // esp_http_server logs this WARN every time a client socket drops
+    // mid-recv: a browser closing a keep-alive connection, an RST, or an
+    // idle EAGAIN timeout. Routine for a web server handing out the
+    // dongle's own UI; not a fault. The library hard-codes it at WARN with
+    // no INFO path, so the ring is the only place to filter it.
+    // (esp-idf httpd_txrx.c: httpd_sock_err("recv", …) →
+    //  "httpd_sock_err: error in recv : <errno>".)
+    { 'W', "httpd_txrx", "error in recv" },
+};
+
+int log_capture_suppressed(char level, const char *tag, const char *msg)
+{
+    if (!tag || !msg) return 0;
+    for (size_t i = 0; i < sizeof(k_suppress) / sizeof(k_suppress[0]); i++) {
+        const struct log_suppress *s = &k_suppress[i];
+        if (level == s->level && strcmp(tag, s->tag) == 0 && strstr(msg, s->needle))
+            return 1;
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
 // ESP-IDF log hook. Compiled out on the host.
 // ---------------------------------------------------------------------------
 #ifdef ESP_PLATFORM
@@ -138,11 +179,12 @@ static char s_line[192];
 static char s_tag[STATS_ERROR_TAG_LEN];
 static char s_msg[STATS_ERROR_MSG_LEN];
 
-static void capture_line(int level, const char *fmt, va_list ap)
+static void capture_line(char lvl, int level, const char *fmt, va_list ap)
 {
     if (!s_lock || xSemaphoreTake(s_lock, 0) != pdTRUE) return;
     vsnprintf(s_line, sizeof(s_line), fmt, ap);
-    if (log_capture_parse(s_line, s_tag, sizeof(s_tag), s_msg, sizeof(s_msg))) {
+    if (log_capture_parse(s_line, s_tag, sizeof(s_tag), s_msg, sizeof(s_msg))
+            && !log_capture_suppressed(lvl, s_tag, s_msg)) {
         stats_record_error(level, s_tag, s_msg);
     }
     xSemaphoreGive(s_lock);
@@ -181,7 +223,7 @@ static int log_hook(const char *fmt, va_list ap)
     if (level) {
         va_list copy;
         va_copy(copy, ap);
-        capture_line(level, fmt, copy);
+        capture_line(lvl, level, fmt, copy);
         va_end(copy);
     }
 

--- a/phoneblock-dongle/firmware/main/log_capture.h
+++ b/phoneblock-dongle/firmware/main/log_capture.h
@@ -35,3 +35,11 @@ char log_capture_level(const char *line);
 char log_capture_parse(const char *line,
                        char *tag, size_t tag_cap,
                        char *msg, size_t msg_cap);
+
+// True if a parsed (level, tag, message) is known-benign ESP-IDF library
+// noise that should NOT reach the web "Protokoll" ring. The line is still
+// printed to the serial console — this only suppresses the user-facing
+// mirror. Matching is deliberately narrow (exact tag + message substring,
+// at a specific level) so a genuine error from the same component still
+// surfaces. `level` is the letter from log_capture_parse ('W','E',…).
+int log_capture_suppressed(char level, const char *tag, const char *msg);

--- a/phoneblock-dongle/firmware/test/test_log_capture.c
+++ b/phoneblock-dongle/firmware/test/test_log_capture.c
@@ -127,6 +127,28 @@ int main(void)
         CHECK_STR("utf8-keep/msg", "ab→", msg);
     }
 
+    // --- library-noise suppression -----------------------------------
+    // The benign httpd recv WARN is dropped from the ring; everything else
+    // (other tags, other messages, the same line at ERROR) is kept.
+    CHECK_CHAR("suppress/httpd-recv-warn", 1,
+               log_capture_suppressed('W', "httpd_txrx",
+                                      "httpd_sock_err: error in recv : 104"));
+    // A send error from the same helper is NOT the routine client-drop case.
+    CHECK_CHAR("suppress/httpd-send-warn", 0,
+               log_capture_suppressed('W', "httpd_txrx",
+                                      "httpd_sock_err: error in send : 104"));
+    // Only WARN is suppressed — a genuine ERROR still surfaces.
+    CHECK_CHAR("suppress/httpd-recv-error", 0,
+               log_capture_suppressed('E', "httpd_txrx",
+                                      "httpd_sock_err: error in recv : 104"));
+    // A different tag with the same substring is left alone.
+    CHECK_CHAR("suppress/other-tag", 0,
+               log_capture_suppressed('W', "sip", "error in recv : 104"));
+    // Unrelated lines pass through untouched.
+    CHECK_CHAR("suppress/unrelated", 0,
+               log_capture_suppressed('W', "wifi", "weak signal"));
+    CHECK_CHAR("suppress/null", 0, log_capture_suppressed('W', NULL, NULL));
+
     printf("log_capture: %d tests, %d failures\n", g_tests, g_failures);
     return g_failures ? 1 : 0;
 }


### PR DESCRIPTION
Users were alarmed by a recurring warning on the dongle's web "Protokoll" panel:

```
[httpd_txrx] httpd_sock_err: error in recv : <errno>
```

This is **not a fault**. `esp_http_server` logs it from `httpd_default_recv` every time a client socket drops mid-`recv()` — a browser closing a keep-alive connection, an RST, or an idle `EAGAIN` timeout. Routine for any web server. The library hard-codes the line at `WARN` with no `INFO` path, so the only place to filter it is our own `log_capture` hook (which mirrors every `WARN`/`ERROR` into the panel).

## Change
- Add a narrow `(level, tag, needle)` denylist (`k_suppress`) to `log_capture.c`, checked after parsing. Matched lines are dropped from the web ring **but still printed to the serial console**, so they stay available for real debugging.
- The single entry: `{ 'W', "httpd_txrx", "error in recv" }`. Matching is exact tag + message substring at `WARN` only — so a `send` error, a genuine `ERROR` from the same tag, or any other tag all still surface.
- The mechanism is reusable: future library WARN-noise is one table entry + one host test.

## Why not `esp_log_level_set("httpd_txrx", ESP_LOG_ERROR)`
That is blunt: it also silences the serial line and hides *every* warning from the tag, losing genuinely useful ones. The ring-level denylist keeps full serial visibility and is surgical.

## Verification
- Host tests (`firmware/test && make test`): `log_capture: 40 tests, 0 failures`; all suites green.
- `idf.py build`: clean.
- Firmware `CLAUDE.md` updated to document the denylist and when to prefer it.

> The `dongle-1.4.x` release branch isn't a clean ancestor of `master`, so this ships as two PRs; the release-branch counterpart is the sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)