### PR TITLE
Dongle: surface REGISTER rejection cause + reopen connection on definitive failure

### DIFF
--- a/phoneblock-dongle/firmware/main/sip_parse.c
+++ b/phoneblock-dongle/firmware/main/sip_parse.c
@@ -59,6 +59,24 @@ int parse_status_code(const char *resp, int len)
     return status;
 }
 
+int parse_reason_phrase(const char *resp, int len, char *out, int cap)
+{
+    if (cap > 0) out[0] = '\0';
+    if (cap <= 0 || parse_status_code(resp, len) < 0) return 0;
+    // Status line: "SIP/2.0" SP code SP reason-phrase. Skip the version
+    // and the 3-digit code, then the single SP before the phrase.
+    const char *p   = resp + 8;          // past "SIP/2.0 "
+    const char *end = resp + len;
+    while (p < end && *p != ' ' && *p != '\r' && *p != '\n') p++;  // code
+    while (p < end && *p == ' ') p++;                              // SP(s)
+    int n = 0;
+    while (p < end && *p != '\r' && *p != '\n' && n < cap - 1) {
+        out[n++] = *p++;
+    }
+    out[n] = '\0';
+    return n;
+}
+
 // Parse a non-negative integer at *pp up to end. Advances *pp past the
 // digits. Returns -1 if no digits, otherwise the parsed value clamped
 // to 30 days.

--- a/phoneblock-dongle/firmware/main/sip_parse.h
+++ b/phoneblock-dongle/firmware/main/sip_parse.h
@@ -38,6 +38,14 @@ int parse_method(const char *pkt, int len, char *method, int cap);
 // Returns -1 if the first line doesn't look like a status line.
 int parse_status_code(const char *resp, int len);
 
+// Copy the reason phrase from a status line "SIP/2.0 NNN Reason…" — the
+// text after the numeric code, trimmed of trailing CR/LF — into out.
+// Writes at most cap-1 bytes + NUL. Returns the number of bytes written
+// (0 and empty out if the line isn't a status line or carries no phrase).
+// Registrars often put the actionable cause here ("Forbidden - Registration
+// limit exceeded"), so surfacing it turns a bare "403" into a diagnosis.
+int parse_reason_phrase(const char *resp, int len, char *out, int cap);
+
 // Parse the granted REGISTER expiry (in seconds) from a 200 OK
 // response. Per RFC 3261 §10.2.4 a contact-level ";expires=<n>"
 // parameter takes precedence over the top-level Expires header; this

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1489,6 +1489,41 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
 // busy-waits — CPU usage is essentially zero between events.
 // ---------------------------------------------------------------------------
 
+// Force a fresh transport connection (new source port, new TLS session)
+// before the next REGISTER. Used when a *previously established*
+// registration is suddenly refused with a definitive error: a negative
+// SIP response never tears the connection down on its own (it is a
+// successfully-received response), so the dongle would otherwise re-REGISTER
+// forever over the very same connection. If the registrar is wedged on
+// soft-state bound to that connection — observed on Telekom hybrid lines
+// (#423), where a byte-identical REGISTER that earned a 200 starts earning
+// 403 on a stable connection — only a clean connection can reset it, the
+// way a real phone recovers by re-registering on a fresh socket.
+//
+// Reuses the configured transport kind. A NULL reopen result keeps the old
+// handle so the caller never dereferences NULL; the next retry then runs
+// over the old connection (or its transparent reconnect) as before.
+static void reopen_transport(sip_ctx_t *c)
+{
+    char host[64];
+    int  port;
+    dial_destination(host, sizeof(host), &port);
+    const char *outbound = config_sip_outbound();
+    const char *sni = (outbound && outbound[0]) ? host : config_sip_host();
+
+    sip_transport_t *nt = sip_transport_open(config_sip_transport(),
+                                             host, port, sni,
+                                             config_sip_local_port());
+    if (nt) {
+        sip_transport_close(c->transport);
+        c->transport = nt;
+        ESP_LOGW(TAG, "reopened SIP connection after definitive rejection");
+    } else {
+        ESP_LOGW(TAG, "reopen after definitive rejection failed — "
+                      "keeping existing connection");
+    }
+}
+
 static void sip_task(void *arg)
 {
     sip_ctx_t ctx = {0};
@@ -1838,6 +1873,7 @@ static void sip_task(void *arg)
             } else {
                 // Either definitive (won't recover with retries) or
                 // transient that has finally outlived the binding.
+                bool was_registered = s_registered;
                 if (s_registered) stats_record_sip_state(false);
                 s_registered = false;
                 char msg[STATS_ERROR_MSG_LEN];
@@ -1856,6 +1892,21 @@ static void sip_task(void *arg)
                 s_binding_expires_at_us = 0;
                 s_pending_error[0] = '\0';
                 refresh_at_us = now + (int64_t)retry_delay_s * 1000000LL;
+
+                // A definitive rejection of an *established* binding is the
+                // #423 signature: the connection is healthy at the TCP/TLS
+                // layer (no transport error fired, so nothing else reopens
+                // it), yet the registrar refuses a REGISTER that succeeded
+                // minutes earlier. Force a clean connection before the next
+                // attempt so it gets a fresh start instead of re-presenting
+                // the same wedged context every 30 s. Gated on was_registered
+                // so a genuine wrong-credentials setup (never registered)
+                // doesn't churn the connection, and on a connection-oriented
+                // transport (UDP has no connection state to reset).
+                if (r == REGISTER_DEFINITIVE && was_registered
+                        && strcasecmp(canonical_transport(), "udp") != 0) {
+                    reopen_transport(&ctx);
+                }
             }
             continue;
         }

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -725,11 +725,30 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
             }
         }
 
-        ESP_LOGI(TAG, "← %d (authenticated)", status);
-        if (err) snprintf(err, err_cap,
-            "authentication rejected: %d — check SIP user/password/realm",
-            status);
-        ESP_LOGE(TAG, "authentication rejected: %d", status);
+        // Surface the registrar's actual cause, not just the bare code.
+        // The full response is only ESP_LOGI (serial-only); the operator
+        // sees the web UI "Protokoll" panel, which mirrors WARN/ERROR. So
+        // lift the status-line reason phrase plus any Warning/Retry-After
+        // header into the ERROR line — that is what turns "403" into a
+        // diagnosis ("Forbidden - Registration limit exceeded; Retry-After:
+        // 1800") without anyone attaching a serial console.
+        char reason[64] = "", warn[80] = "", retry[24] = "";
+        parse_reason_phrase(rx, rx_len, reason, sizeof(reason));
+        const char *wh = find_header(rx, rx_len, "Warning");
+        if (wh) header_value(wh, rx + rx_len, warn, sizeof(warn));
+        const char *rh = find_header(rx, rx_len, "Retry-After");
+        if (rh) header_value(rh, rx + rx_len, retry, sizeof(retry));
+
+        char diag[STATS_ERROR_MSG_LEN];
+        int m = snprintf(diag, sizeof(diag), "authentication rejected: %d%s%s",
+                         status, reason[0] ? " " : "", reason);
+        if (retry[0] && m > 0 && m < (int)sizeof(diag))
+            m += snprintf(diag + m, sizeof(diag) - m, "; Retry-After: %s", retry);
+        if (warn[0] && m > 0 && m < (int)sizeof(diag))
+            snprintf(diag + m, sizeof(diag) - m, "; Warning: %s", warn);
+
+        if (err) snprintf(err, err_cap, "%s", diag);
+        ESP_LOGE(TAG, "%s", diag);
         result = REGISTER_DEFINITIVE;
         goto cleanup;
     }

--- a/phoneblock-dongle/firmware/test/test_sip_parse.c
+++ b/phoneblock-dongle/firmware/test/test_sip_parse.c
@@ -79,6 +79,13 @@ static void expect_status(int expected, const char *resp)
     report_int("parse_status_code", resp, expected, got);
 }
 
+static void expect_reason(const char *expected, const char *resp)
+{
+    char buf[64] = "sentinel";
+    parse_reason_phrase(resp, (int)strlen(resp), buf, sizeof(buf));
+    report_str("parse_reason_phrase", resp, expected, buf);
+}
+
 static void expect_register_expires(int expected, const char *resp)
 {
     int got = parse_register_expires(resp, (int)strlen(resp));
@@ -229,6 +236,22 @@ static void test_parse_status_code(void)
     expect_status(-1,  SAMPLE_INVITE);             // not a response
     expect_status(-1,  "");                         // too short
     expect_status(-1,  "HTTP/1.1 200 OK\r\n\r\n"); // wrong protocol
+}
+
+static void test_parse_reason_phrase(void)
+{
+    expect_reason("OK",        "SIP/2.0 200 OK\r\n\r\n");
+    expect_reason("Forbidden", "SIP/2.0 403 Forbidden\r\n\r\n");
+    // Multi-word phrase with a provider-specific cause is kept whole.
+    expect_reason("Forbidden - Registration limit exceeded",
+        "SIP/2.0 403 Forbidden - Registration limit exceeded\r\n"
+        "Retry-After: 1800\r\n\r\n");
+    expect_reason("Busy Here", "SIP/2.0 486 Busy Here\r\n\r\n");
+    // No phrase after the code → empty.
+    expect_reason("",          "SIP/2.0 100\r\n\r\n");
+    // Not a status line → empty (sentinel cleared).
+    expect_reason("",          SAMPLE_INVITE);
+    expect_reason("",          "");
 }
 
 static void test_parse_register_expires(void)
@@ -586,6 +609,7 @@ int main(void)
 {
     test_parse_method();
     test_parse_status_code();
+    test_parse_reason_phrase();
     test_parse_register_expires();
     test_parse_cseq();
     test_parse_call_id();


### PR DESCRIPTION
Best-effort improvements for the Telekom-hybrid registration problem (#423, related #382). **Deliberately does not close those issues** — the root cause is still server-side and unconfirmed; this makes the next field report conclusive and adds a plausible recovery, but it is not a proven fix.

## Commit 1 — surface the registrar's cause (diagnostics)

A definitive REGISTER rejection only logged `authentication rejected: <code>`. The full response carrying the cause is `ESP_LOGI` (serial-only), unreachable from the web UI "Protokoll" panel. So a field report of a persistent `403` gives a bare code with no way to tell a lockout from a binding conflict.

Now the status-line **reason phrase** plus any **`Warning`** / **`Retry-After`** header are lifted into the ERROR line, e.g. `authentication rejected: 403 Forbidden - Registration limit exceeded; Retry-After: 1800`. `parse_reason_phrase()` added to `sip_parse` (host-tested); Warning/Retry-After reuse existing `find_header`/`header_value`.

All three lines on the path are ERROR/WARN, so this works with **INFO logging off** — which also stops the 32-entry ring from being flushed by INFO dumps, so the trigger no longer scrolls away.

## Commit 2 — reopen connection on definitive failure of an established binding

A negative SIP response is a successfully-received response, so it never tears the connection down — the dongle re-REGISTERs forever over the same TLS connection. On the Telekom hybrid line a byte-identical REGISTER that earned a `200` starts earning a persistent `403` on a **stable** connection (confirmed: with INFO on, no reconnect lines appear). If the registrar is wedged on soft-state bound to that connection, re-presenting the same context can never recover.

So: when a **previously established** binding is refused definitively, force a fresh connection (new source port, new TLS session) before the next attempt — the way a real phone recovers. Gated on `was_registered` (a genuine wrong-credentials setup that never registered doesn't churn the connection) and on a connection-oriented transport (UDP has no connection state to reset); `s_registered` going false limits it to one reopen per loss-of-binding event.

## Verification
- Full `idf.py build` clean.
- Full host suite green (8/8); `parse_reason_phrase` covered in `test_sip_parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)