### PR TITLE
Dongle: live full-log stream over HTTP (GET /api/log/stream)

### DIFF
--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -36,6 +36,21 @@ char log_capture_level(const char *line)
     return is_level(c) ? c : '\0';
 }
 
+int log_strip_ansi(char *s, int len)
+{
+    int w = 0;
+    for (int r = 0; r < len; ) {
+        if (s[r] == '\033') {            // ESC: drop up to and including 'm'
+            r++;
+            while (r < len && s[r] != 'm') r++;
+            if (r < len) r++;            // skip the terminating 'm'
+        } else {
+            s[w++] = s[r++];
+        }
+    }
+    return w;
+}
+
 // Largest length <= len whose prefix ends on a UTF-8 character boundary.
 // A hard byte-truncation at msg_cap can cut a multibyte sequence — an
 // arrow in our own messages, or an umlaut in an external string like a
@@ -151,9 +166,11 @@ int log_capture_suppressed(char level, const char *tag, const char *msg)
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
+#include "freertos/message_buffer.h"
 
 #include "esp_log.h"
 
@@ -162,6 +179,19 @@ int log_capture_suppressed(char level, const char *tag, const char *msg)
 
 // Previous (console) sink, so the serial log stays fully intact.
 static vprintf_like_t s_console;
+
+// --- Live full-log stream state --------------------------------------
+// One subscriber drains every formatted line through a message buffer.
+// s_stream_on is the hot-path gate (read once per logged line); the
+// buffer + scratch exist only while a client is attached. State changes
+// (open/close) and the per-line tee both run under s_lock, so a tee
+// never touches a buffer that close() is freeing.
+#define LOG_STREAM_BUF_BYTES 6144   // message-buffer capacity for bursts
+
+static volatile bool         s_stream_on;
+static MessageBufferHandle_t s_stream_buf;
+static char                 *s_stream_scratch;   // LOG_STREAM_LINE_MAX bytes
+static uint32_t              s_stream_dropped;    // lines lost to a full buffer
 
 // The hook runs on the stack of whatever task logs the line, and the
 // formatting scratch dominates that cost. Keeping line/tag/msg here as
@@ -179,15 +209,106 @@ static char s_line[192];
 static char s_tag[STATS_ERROR_TAG_LEN];
 static char s_msg[STATS_ERROR_MSG_LEN];
 
-static void capture_line(char lvl, int level, const char *fmt, va_list ap)
+// Tee one log line into the live stream (caller holds s_lock). Re-formats
+// at full width into the heap scratch — the 192 B ring buffer above would
+// clip long lines (e.g. a SIP dump) far shorter than a stream viewer wants
+// — strips the console's ANSI colour, and enqueues it. A full buffer drops
+// the line and bumps a counter the reader surfaces.
+static void stream_tee_locked(const char *fmt, va_list ap)
+{
+    if (!s_stream_on || !s_stream_buf || !s_stream_scratch) return;
+    int n = vsnprintf(s_stream_scratch, LOG_STREAM_LINE_MAX, fmt, ap);
+    if (n <= 0) return;
+    if (n >= LOG_STREAM_LINE_MAX) n = LOG_STREAM_LINE_MAX - 1;
+    n = log_strip_ansi(s_stream_scratch, n);
+    if (n <= 0) return;
+    if (xMessageBufferSend(s_stream_buf, s_stream_scratch, (size_t)n, 0) == 0)
+        s_stream_dropped++;
+}
+
+static void capture_line(char lvl, int level, bool stream,
+                         const char *fmt, va_list ap)
 {
     if (!s_lock || xSemaphoreTake(s_lock, 0) != pdTRUE) return;
-    vsnprintf(s_line, sizeof(s_line), fmt, ap);
-    if (log_capture_parse(s_line, s_tag, sizeof(s_tag), s_msg, sizeof(s_msg))
-            && !log_capture_suppressed(lvl, s_tag, s_msg)) {
-        stats_record_error(level, s_tag, s_msg);
+    if (level) {
+        va_list a1;
+        va_copy(a1, ap);
+        vsnprintf(s_line, sizeof(s_line), fmt, a1);
+        va_end(a1);
+        if (log_capture_parse(s_line, s_tag, sizeof(s_tag), s_msg, sizeof(s_msg))
+                && !log_capture_suppressed(lvl, s_tag, s_msg)) {
+            stats_record_error(level, s_tag, s_msg);
+        }
+    }
+    if (stream) {
+        va_list a2;
+        va_copy(a2, ap);
+        stream_tee_locked(fmt, a2);
+        va_end(a2);
     }
     xSemaphoreGive(s_lock);
+}
+
+// --- Live-stream subscriber API (see log_capture.h) ------------------
+
+bool log_stream_open(void)
+{
+    if (!s_lock) return false;
+    MessageBufferHandle_t mb = xMessageBufferCreate(LOG_STREAM_BUF_BYTES);
+    char *scratch = malloc(LOG_STREAM_LINE_MAX);
+    if (!mb || !scratch) {
+        if (mb) vMessageBufferDelete(mb);
+        free(scratch);
+        return false;
+    }
+    bool ok = false;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (!s_stream_on) {
+        s_stream_buf     = mb;
+        s_stream_scratch = scratch;
+        s_stream_dropped = 0;
+        s_stream_on      = true;   // publish last: gates the tee
+        ok = true;
+    }
+    xSemaphoreGive(s_lock);
+    if (!ok) { vMessageBufferDelete(mb); free(scratch); }  // lost the race
+    return ok;
+}
+
+void log_stream_close(void)
+{
+    if (!s_lock) return;
+    MessageBufferHandle_t mb = NULL;
+    char *scratch = NULL;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (s_stream_on) {
+        s_stream_on      = false;  // retract first: no tee past this point
+        mb               = s_stream_buf;     s_stream_buf = NULL;
+        scratch          = s_stream_scratch; s_stream_scratch = NULL;
+    }
+    xSemaphoreGive(s_lock);
+    if (mb) vMessageBufferDelete(mb);   // safe: tee is gated off, reader is us
+    free(scratch);
+}
+
+size_t log_stream_read(char *out, size_t cap, uint32_t timeout_ms)
+{
+    if (!s_stream_buf || cap == 0) return 0;
+    // Surface any overflow since the last read before the next real line.
+    uint32_t dropped = 0;
+    if (xSemaphoreTake(s_lock, 0) == pdTRUE) {
+        dropped = s_stream_dropped;
+        s_stream_dropped = 0;
+        xSemaphoreGive(s_lock);
+    }
+    if (dropped) {
+        int n = snprintf(out, cap,
+                         "... %lu log line(s) dropped (stream overflow)\n",
+                         (unsigned long)dropped);
+        return (n > 0 && (size_t)n < cap) ? (size_t)n : 0;
+    }
+    return xMessageBufferReceive(s_stream_buf, out, cap,
+                                 pdMS_TO_TICKS(timeout_ms));
 }
 
 // STACK SIZING — important. This hook runs on the stack of whatever task
@@ -220,10 +341,15 @@ static int log_hook(const char *fmt, va_list ap)
     if      (lvl == 'E') level = ESP_LOG_ERROR;
     else if (lvl == 'W') level = ESP_LOG_WARN;
     else if (lvl == 'I' && config_log_info()) level = ESP_LOG_INFO;
-    if (level) {
+
+    // A live subscriber gets *every* line regardless of level — that is the
+    // point of "what the serial console shows". s_stream_on is a single
+    // volatile read when nobody is streaming (the common case).
+    bool stream = s_stream_on;
+    if (level || stream) {
         va_list copy;
         va_copy(copy, ap);
-        capture_line(lvl, level, fmt, copy);
+        capture_line(lvl, level, stream, fmt, copy);
         va_end(copy);
     }
 

--- a/phoneblock-dongle/firmware/main/log_capture.h
+++ b/phoneblock-dongle/firmware/main/log_capture.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 // Global log capture: mirrors every WARN/ERROR line the firmware emits
 // — our own modules and the ESP-IDF libraries alike — into the stats
@@ -16,6 +18,36 @@
 
 // Install the log hook. Call once, after stats_setup(). ESP-only.
 void log_capture_start(void);
+
+// --- Live full-log stream (ESP-only) --------------------------------
+// Beyond the 32-entry WARN/ERROR ring, one client at a time can follow
+// the *complete* log live: every formatted line that reaches the serial
+// console, all levels, ANSI colour stripped. The HTTP handler in web.c
+// drives this:
+//
+//   log_stream_open()  reserves the single slot and allocates the buffer;
+//                      returns false if a stream is already active or out
+//                      of memory.
+//   log_stream_read()  blocks up to timeout_ms for the next line, copies
+//                      it into out (cap must be >= LOG_STREAM_LINE_MAX),
+//                      returns its byte count — 0 on timeout, when the
+//                      caller should emit a heartbeat to detect a gone
+//                      client.
+//   log_stream_close() releases the slot and frees the buffer.
+//
+// While a stream is open, the log hook tees each line into it. With none
+// open the hot-path cost is a single bool read per logged line.
+#define LOG_STREAM_LINE_MAX 1024   // bytes mirrored per line (longer clipped)
+
+bool   log_stream_open(void);
+size_t log_stream_read(char *out, size_t cap, uint32_t timeout_ms);
+void   log_stream_close(void);
+
+// Strip in-place every ANSI escape ("ESC[...m") from the first `len`
+// bytes of `s`, returning the new length. Host-testable; used to turn a
+// colourised console line into plain text for the stream and to pin the
+// behaviour in test/test_log_capture.c.
+int log_strip_ansi(char *s, int len);
 
 // --- Host-testable log-line parsing (no ESP-IDF dependencies) -------
 // Split out so test/test_log_capture.c can pin the fragile parsing on

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -1,5 +1,6 @@
 #include "web.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
@@ -24,6 +25,7 @@
 #include "api.h"
 #include "config.h"
 #include "firmware_update.h"
+#include "log_capture.h"
 #include "mail.h"
 #include "scheduler.h"
 #include "sip_register.h"
@@ -1237,6 +1239,91 @@ static esp_err_t handle_errors(httpd_req_t *req)
     return ESP_OK;
 }
 
+// GET /api/log/stream — follow the full log live (every line that hits
+// the serial console, all levels), one subscriber at a time.
+//
+// esp_http_server dispatches handlers on its single worker task, so a
+// handler that blocked in the stream loop would freeze the whole web UI.
+// Instead we detach the request (httpd_req_async_handler_begin) and serve
+// it from a dedicated task, leaving the worker free; the worker returns
+// immediately. The task sends one chunk per log line — each chunk is its
+// own TCP write, so lines reach the client the instant they are logged.
+
+// True while the streaming client's socket is still open. During idle
+// gaps we must notice a vanished client *without writing*: a heartbeat
+// byte would litter the log with blank lines. A non-blocking MSG_PEEK
+// returns 0 on an orderly close (FIN) and a hard error on a reset;
+// EWOULDBLOCK means "connected, nothing to read" — the normal case for a
+// stream the client only reads from.
+static bool log_client_connected(int fd)
+{
+    if (fd < 0) return false;
+    char probe;
+    int r = recv(fd, &probe, 1, MSG_DONTWAIT | MSG_PEEK);
+    if (r == 0) return false;                                   // client closed
+    if (r < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+        return false;                                           // reset / error
+    return true;
+}
+
+static void log_stream_task(void *arg)
+{
+    httpd_req_t *req = (httpd_req_t *)arg;
+    int fd = httpd_req_to_sockfd(req);
+    char *buf = malloc(LOG_STREAM_LINE_MAX);
+    if (buf) {
+        httpd_resp_set_type(req, "text/plain; charset=utf-8");
+        httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+        httpd_resp_set_hdr(req, "X-Accel-Buffering", "no");  // no proxy buffering
+        esp_err_t err = httpd_resp_send_chunk(req, "--- live log ---\n",
+                                              HTTPD_RESP_USE_STRLEN);
+        while (err == ESP_OK) {
+            size_t n = log_stream_read(buf, LOG_STREAM_LINE_MAX, 5000);
+            if (n > 0) {
+                err = httpd_resp_send_chunk(req, buf, n);  // one chunk per line
+            } else if (!log_client_connected(fd)) {
+                break;            // idle gap and the peer is gone — free the slot
+            }
+            // else: idle but still connected — emit nothing (no heartbeat noise)
+        }
+        free(buf);
+    }
+    httpd_resp_send_chunk(req, NULL, 0);         // best-effort terminate
+    httpd_req_async_handler_complete(req);
+    log_stream_close();
+    vTaskDelete(NULL);
+}
+
+static esp_err_t handle_log_stream(httpd_req_t *req)
+{
+    REQUIRE_AUTH_API(req);
+
+    // Single subscriber: reserve the slot before detaching the request.
+    if (!log_stream_open()) {
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "text/plain");
+        httpd_resp_sendstr(req, "log stream already in use\n");
+        return ESP_OK;
+    }
+
+    httpd_req_t *areq = NULL;
+    if (httpd_req_async_handler_begin(req, &areq) != ESP_OK) {
+        log_stream_close();
+        httpd_resp_set_status(req, "500 Internal Server Error");
+        httpd_resp_set_type(req, "text/plain");
+        httpd_resp_sendstr(req, "cannot start log stream\n");
+        return ESP_OK;
+    }
+    // 4 KB stack: the read buffer is on the heap, the send path is plain
+    // HTTP (no TLS), so the chunk framing is all this task needs.
+    if (xTaskCreate(log_stream_task, "logstream", 4096, areq,
+                    tskIDLE_PRIORITY + 5, NULL) != pdPASS) {
+        httpd_req_async_handler_complete(areq);  // can no longer respond on req
+        log_stream_close();
+    }
+    return ESP_OK;
+}
+
 // GET /api/announcement — streams the currently active A-law audio.
 // Content-Type: audio/basic (the IANA-registered type for G.711
 // µ-law, close enough to A-law for a "audio payload" hint; browsers
@@ -1841,6 +1928,7 @@ static const httpd_uri_t URIS[] = {
     { .uri = "/api/status",  .method = HTTP_GET,  .handler = handle_status,      .user_ctx = NULL },
     { .uri = "/api/calls",   .method = HTTP_GET,  .handler = handle_calls,       .user_ctx = NULL },
     { .uri = "/api/errors",  .method = HTTP_GET,  .handler = handle_errors,      .user_ctx = NULL },
+    { .uri = "/api/log/stream", .method = HTTP_GET, .handler = handle_log_stream, .user_ctx = NULL },
     { .uri = "/api/errors/clear",    .method = HTTP_POST, .handler = handle_errors_clear,   .user_ctx = NULL },
     { .uri = "/api/calls/clear",     .method = HTTP_POST, .handler = handle_calls_clear,    .user_ctx = NULL },
     { .uri = "/api/factory-reset",   .method = HTTP_POST, .handler = handle_factory_reset,  .user_ctx = NULL },

--- a/phoneblock-dongle/firmware/test/test_log_capture.c
+++ b/phoneblock-dongle/firmware/test/test_log_capture.c
@@ -149,6 +149,35 @@ int main(void)
                log_capture_suppressed('W', "wifi", "weak signal"));
     CHECK_CHAR("suppress/null", 0, log_capture_suppressed('W', NULL, NULL));
 
+    // --- log_strip_ansi: colour removal for the live log stream -------
+    {
+        // A coloured line collapses to its plain text (length returned,
+        // not NUL-terminated by the function — terminate before compare).
+        char a[] = GREEN "I (12345) sip: REGISTER ok" RESET "\n";
+        int n = log_strip_ansi(a, (int)strlen(a));
+        a[n] = '\0';
+        CHECK_STR("strip/coloured", "I (12345) sip: REGISTER ok\n", a);
+
+        // No escapes → unchanged, same length.
+        char b[] = "W (7) wifi: weak signal\n";
+        int m = log_strip_ansi(b, (int)strlen(b));
+        b[m] = '\0';
+        CHECK_STR("strip/plain", "W (7) wifi: weak signal\n", b);
+
+        // Escape with no terminating 'm' before end is dropped wholesale
+        // (no stray bytes left behind).
+        char c[] = "x\033[0;3";
+        int k = log_strip_ansi(c, (int)strlen(c));
+        c[k] = '\0';
+        CHECK_STR("strip/truncated-escape", "x", c);
+
+        // Embedded reset between two runs of text.
+        char d[] = "ab" RESET "cd";
+        int j = log_strip_ansi(d, (int)strlen(d));
+        d[j] = '\0';
+        CHECK_STR("strip/embedded-reset", "abcd", d);
+    }
+
     printf("log_capture: %d tests, %d failures\n", g_tests, g_failures);
     return g_failures ? 1 : 0;
 }


### PR DESCRIPTION
## Was

Fügt einen On-Demand-Endpoint hinzu, der **jede** formatierte Log-Zeile live streamt (eine Zeile pro HTTP-Chunk), sodass Browser/`curl` Meldungen in dem Moment sehen, in dem sie geloggt werden.

Hintergrund: Das Web-„Protokoll"-Panel zeigt nur den 32-Einträge-WARN/ERROR-Ring; das volle Serial-Log (INFO und darunter, z. B. die geparsten Crypto-/INVITE-Zeilen) war bisher nur über eine serielle Konsole erreichbar, die im Feld niemand hat.

## Mechanismus

- `log_capture.c` tee't jede Zeile in einen FreeRTOS-Message-Buffer, solange ein Subscriber hängt. Der Tee formatiert auf volle Breite neu, entfernt ANSI-Farbcodes (`log_strip_ansi`) und enqueued nicht-blockierend; ein voller Buffer verwirft die Zeile und der Reader zeigt einen Overflow-Marker. Ohne Subscriber kostet der Hot-Path einen `volatile bool`-Read pro Zeile, die Buffer werden gar nicht erst alloziert.
- Open/Close-Statuswechsel und der Per-Line-Tee laufen unter dem bestehenden `s_lock`, sodass ein Tee nie einen Buffer anfasst, den `close()` gerade freigibt.
- `web.c` löst den Request via `httpd_req_async_handler_begin` ab und bedient ihn aus einem eigenen Task (esp_http_server nutzt einen Worker — ein blockierender Stream-Loop würde sonst die ganze UI einfrieren). Ein Subscriber gleichzeitig (sonst 409). In Leerlaufphasen erkennt der Task einen verschwundenen Client per nicht-blockierendem `MSG_PEEK` statt per Heartbeat, sodass der Stream keine Leerzeilen einstreut.
- Hinter `REQUIRE_AUTH_API`: das volle Log trägt Anrufer­nummern und SIP-Interna, mehr als der Ring, also gleiche Auth wie der Rest der API (No-op bis ein Login konfiguriert ist).

## Tests

Host-Tests decken `log_strip_ansi` ab (farbig/plain/abgeschnittenes Escape/eingebettet); Firmware baut sauber. Auf Hardware verifiziert: Zeilen streamen live, mehrzeilige SIP-/Manifest-Dumps kommen durch, und ein 20-s-Idle-Capture liefert keine Leerzeilen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)