### PR TITLE
Dongle: fix ~30 min re-REGISTER failure on persistent TLS (leading-CRLF framing) + keepalive pong/log + collapse log panel

### DIFF
--- a/phoneblock-dongle/firmware/main/sip_frame.c
+++ b/phoneblock-dongle/firmware/main/sip_frame.c
@@ -62,6 +62,30 @@ static int parse_content_length(const char *p, int len)
 
 int sip_framer_pop(sip_framer_t *f, char *out, int out_cap)
 {
+    // RFC 3261 §7.5 / RFC 5626 §4.4.1: leading CRLFs before the start-line
+    // are keep-alives, not part of the next message. A CRLFCRLF is a PING
+    // (popped as a 4-byte frame below so the caller can pong it); a lone
+    // CRLF is a PONG answering our own ping. Surface the lone CRLF as its
+    // own 2-byte frame immediately — so the caller can log the inbound pong
+    // the moment it arrives (live ping↔pong correlation), AND so it can
+    // never glue onto the next message's start-line ("\r\nSIP/2.0 200 OK…"
+    // → bogus "rejected: -1", the ~30 min re-REGISTER failure on the
+    // persistent Telekom connection).
+    //
+    // Surfacing without waiting means a CRLFCRLF ping split across two
+    // recv()s (its two CRLFs in separate reads) is seen as two pongs and
+    // not answered — harmless and very rare (a 4-byte ping rides one TLS
+    // record), and worth it for the visibility.
+    if (f->have >= 2 && f->buf[0] == '\r' && f->buf[1] == '\n'
+            && !(f->have >= 4 && f->buf[2] == '\r' && f->buf[3] == '\n')) {
+        if (out_cap < 3) return -1;
+        out[0] = '\r'; out[1] = '\n'; out[2] = '\0';
+        int rest = f->have - 2;
+        if (rest > 0) memmove(f->buf, f->buf + 2, rest);
+        f->have = rest;
+        return 2;
+    }
+
     int hdr_end = find_headers_end(f->buf, f->have);
     if (hdr_end < 0) return 0;
 

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1433,12 +1433,34 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
     char from_ip[INET_ADDRSTRLEN];
     inet_ntoa_r(from->sin_addr, from_ip, sizeof(from_ip));
 
+    bool is_response = (len >= 7 && strncmp(pkt, "SIP/2.0", 7) == 0);
+    char method[16];
+    int  method_len  = is_response ? 0 : parse_method(pkt, len, method, sizeof(method));
+
+    // A SIP CRLF keep-alive carries no method and no SIP/2.0 status line.
+    // Handle it here — before the generic packet dump below — so the inbound
+    // ping is logged exactly once (one distinct, greppable marker) instead of
+    // also being dumped (with its blank CRLFs) by that line. RFC 5626 §4.4.1:
+    // answer a double-CRLF "ping" (>=4 bytes) with a single-CRLF "pong" (2
+    // bytes); Telekom probes us this way every ~60 s and resets the flow if we
+    // never answer. A 2-byte message is a pong to our own ping — don't answer
+    // it, that would loop.
+    if (!is_response && method_len == 0) {
+        ESP_LOGI(TAG, "← SIP keepalive ping (%d bytes) from %s:%d",
+                 len, from_ip, ntohs(from->sin_port));
+        if (len >= 4) {
+            sip_transport_send(c->transport, "\r\n", 2);
+            ESP_LOGI(TAG, "→ SIP keepalive pong (2 bytes)");
+        }
+        return;
+    }
+
     ESP_LOGI(TAG, "← from %s:%d  %d bytes:\n%.*s",
              from_ip, ntohs(from->sin_port),
              len, len, pkt);
 
     // Handle responses to our own out-of-dialog requests (BYE from us).
-    if (len >= 7 && strncmp(pkt, "SIP/2.0", 7) == 0) {
+    if (is_response) {
         int status = parse_status_code(pkt, len);
         if (c->dialog.state == DIALOG_BYE_SENT) {
             ESP_LOGI(TAG, "← %d on BYE → dialog closed", status);
@@ -1446,21 +1468,6 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
         } else {
             ESP_LOGW(TAG, "ignoring stray response %d", status);
         }
-        return;
-    }
-
-    char method[16];
-    int method_len = parse_method(pkt, len, method, sizeof(method));
-
-    // A SIP CRLF keep-alive ("\r\n\r\n") has no method — parse_method returns
-    // an empty string. Nothing to answer, but log a distinct one-line marker
-    // (not the "method not implemented" with a blank name) so the inbound
-    // keep-alive cadence is trivial to grep/time in the live log — useful to
-    // tell a NAT idle-timeout (no inbound pings) from a carrier-side reset
-    // (pings flowing yet the connection still dropped).
-    if (method_len == 0) {
-        ESP_LOGI(TAG, "← SIP keepalive ping (%d bytes) from %s:%d",
-                 len, from_ip, ntohs(from->sin_port));
         return;
     }
 
@@ -1858,6 +1865,7 @@ static void sip_task(void *arg)
             if (now >= keepalive_at_us) {
                 if (now < refresh_at_us) {
                     sip_transport_send(ctx.transport, "\r\n\r\n", 4);
+                    ESP_LOGI(TAG, "→ SIP keepalive ping (4 bytes)");
                 }
                 keepalive_at_us = now + (int64_t)SIP_KEEPALIVE_INTERVAL_S * 1000000LL;
             }

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -1438,19 +1438,23 @@ static void handle_incoming(sip_ctx_t *c, const char *pkt, int len,
     int  method_len  = is_response ? 0 : parse_method(pkt, len, method, sizeof(method));
 
     // A SIP CRLF keep-alive carries no method and no SIP/2.0 status line.
-    // Handle it here — before the generic packet dump below — so the inbound
-    // ping is logged exactly once (one distinct, greppable marker) instead of
-    // also being dumped (with its blank CRLFs) by that line. RFC 5626 §4.4.1:
-    // answer a double-CRLF "ping" (>=4 bytes) with a single-CRLF "pong" (2
-    // bytes); Telekom probes us this way every ~60 s and resets the flow if we
-    // never answer. A 2-byte message is a pong to our own ping — don't answer
-    // it, that would loop.
+    // Handle it here — before the generic packet dump below — so it is
+    // logged exactly once (one distinct, greppable marker) instead of also
+    // being dumped (with its blank CRLFs) by that line. RFC 5626 §4.4.1: a
+    // double-CRLF "ping" (>=4 bytes) is answered with a single-CRLF "pong"
+    // (2 bytes). Telekom probes us with pings every ~60 s and resets the
+    // flow if we never answer. A lone CRLF (2 bytes) is a pong answering our
+    // own ping — log it (this is how we see that Telekom really does answer)
+    // but don't reply, that would loop.
     if (!is_response && method_len == 0) {
-        ESP_LOGI(TAG, "← SIP keepalive ping (%d bytes) from %s:%d",
-                 len, from_ip, ntohs(from->sin_port));
         if (len >= 4) {
+            ESP_LOGI(TAG, "← SIP keepalive ping (%d bytes) from %s:%d",
+                     len, from_ip, ntohs(from->sin_port));
             sip_transport_send(c->transport, "\r\n", 2);
             ESP_LOGI(TAG, "→ SIP keepalive pong (2 bytes)");
+        } else {
+            ESP_LOGI(TAG, "← SIP keepalive pong (%d bytes) from %s:%d",
+                     len, from_ip, ntohs(from->sin_port));
         }
         return;
     }
@@ -1763,6 +1767,10 @@ static void sip_task(void *arg)
             // to see whether the new creds work.
             err[0] = '\0';
             r = do_register(&ctx, &granted_expires, err, sizeof(err));
+            // Defer the idle keepalive (see reconnect path): this REGISTER
+            // is fresh traffic, no need to ping right after it.
+            keepalive_at_us = esp_timer_get_time()
+                            + (int64_t)SIP_KEEPALIVE_INTERVAL_S * 1000000LL;
             ok = (r == REGISTER_OK);
             s_registered = ok;
             stats_record_sip_state(ok);
@@ -1794,6 +1802,12 @@ static void sip_task(void *arg)
             ESP_LOGW(TAG, "transport reconnected → re-REGISTER");
             err[0] = '\0';
             r = do_register(&ctx, &granted_expires, err, sizeof(err));
+            // A REGISTER is traffic; defer the idle keepalive a full
+            // interval so we never ping a connection we just used — least
+            // of all a freshly reconnected one, where an immediate ping
+            // only draws a lone-CRLF pong with nothing to keep alive.
+            keepalive_at_us = esp_timer_get_time()
+                            + (int64_t)SIP_KEEPALIVE_INTERVAL_S * 1000000LL;
             ok = (r == REGISTER_OK);
             s_registered = ok;
             stats_record_sip_state(ok);
@@ -1881,6 +1895,9 @@ static void sip_task(void *arg)
             err[0] = '\0';
             r = do_register(&ctx, &granted_expires, err, sizeof(err));
             now = esp_timer_get_time();
+            // Defer the idle keepalive (see reconnect path): the refresh
+            // REGISTER is traffic, so the next ping is a full interval out.
+            keepalive_at_us = now + (int64_t)SIP_KEEPALIVE_INTERVAL_S * 1000000LL;
             if (r == REGISTER_OK) {
                 ESP_LOGI(TAG, "re-REGISTERED (granted %d s)", granted_expires);
                 if (!s_registered) stats_record_sip_state(true);

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -180,6 +180,7 @@ const I18N = {
     'status.tz.apply': 'Auf {zone} umstellen',
     'status.tz.saved': 'Zeitzone gespeichert.',
     'status.errors.title': 'Protokoll',
+    'status.errors.note': 'Das Protokoll dient der Fehleranalyse — nicht jeder angezeigte Eintrag ist ein echtes Problem; viele Fehler sind vorübergehend und verschwinden von selbst.',
     'status.errors.empty': 'keine Einträge',
     'status.errors.clear': 'Protokoll leeren',
     'status.errors.capture_info': 'Auch Infos protokollieren',
@@ -438,6 +439,7 @@ const I18N = {
     'status.tz.apply': 'Switch to {zone}',
     'status.tz.saved': 'Timezone saved.',
     'status.errors.title': 'Log',
+    'status.errors.note': 'The log is for diagnosing problems — not every entry is a real fault; many errors are transient and clear up on their own.',
     'status.errors.empty': 'no entries',
     'status.errors.clear': 'Clear log',
     'status.errors.capture_info': 'Also log info messages',
@@ -679,6 +681,7 @@ const I18N = {
     'status.time.today': "aujourd'hui {time}",
     'status.time.yesterday': 'hier {time}',
     'status.errors.title': 'Journal',
+    'status.errors.note': "Le journal sert à diagnostiquer les problèmes — toute entrée affichée n'est pas forcément un vrai défaut ; beaucoup d'erreurs sont passagères et disparaissent d'elles-mêmes.",
     'status.errors.empty': 'aucune entrée',
     'status.errors.clear': 'Vider le journal',
     'status.errors.capture_info': 'Journaliser aussi les infos',
@@ -920,6 +923,7 @@ const I18N = {
     'status.time.today': 'hoy {time}',
     'status.time.yesterday': 'ayer {time}',
     'status.errors.title': 'Registro',
+    'status.errors.note': 'El registro sirve para diagnosticar problemas — no toda entrada es un fallo real; muchos errores son transitorios y desaparecen solos.',
     'status.errors.empty': 'sin entradas',
     'status.errors.clear': 'Vaciar registro',
     'status.errors.capture_info': 'Registrar también los mensajes info',
@@ -1465,10 +1469,13 @@ function renderStatus(){
     + '</section>'
     // Admin/config areas as collapsible cards. Status + recent calls
     // above stay always-open (the "is it working" view); everything here
-    // is configure-once, so it ships collapsed — except the log, which is
-    // the usual diagnostic landing and opens by default.
-    + '<details id="errorsSection" class="adminsec" open style="display:none">'
+    // is configure-once, so it ships collapsed — the log included: it
+    // surfaces transient, self-healing errors that alarm users who open
+    // it by reflex, so it stays closed until someone goes looking.
+    + '<details id="errorsSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.errors.title')) + '</summary>'
+    + '<p class="muted" style="font-size:.72rem;margin:.2rem 0 .6rem">'
+    +   esc(t('status.errors.note')) + '</p>'
     + '<div id="errorsList"></div>'
     + '<p style="margin-top:.6rem">'
     + '  <button id="errorsClear" class="btn-ghost" style="display:none;padding:.2rem .6rem;font-size:.75rem;text-transform:none;letter-spacing:0">'

--- a/phoneblock-dongle/firmware/test/test_sip_frame.c
+++ b/phoneblock-dongle/firmware/test/test_sip_frame.c
@@ -235,6 +235,104 @@ static void test_reset_clears_partial(void)
     check_str_eq("reset: pop content after", MSG_OK_NOBODY, out);
 }
 
+// A lone CRLF (a keep-alive PONG) glued in front of a real message
+// (RFC 3261 §7.5) must be surfaced as its own 2-byte frame, never parsed
+// as part of the following start-line. This is the exact failure seen on
+// the persistent Telekom connection: a pong landed just before the 200 OK
+// to a re-REGISTER, producing "\r\nSIP/2.0 200 OK…" and a bogus
+// "REGISTER rejected: -1". The 2-byte frame lets handle_incoming log the
+// inbound pong and leaves the next message clean.
+static void test_leading_crlf_pong_then_message(void)
+{
+    char combined[BUF_CAP];
+    int n = snprintf(combined, sizeof(combined), "\r\n%s", MSG_OK_NOBODY);
+
+    char buf[BUF_CAP];
+    char out[BUF_CAP];
+    sip_framer_t f;
+    sip_framer_init(&f, buf, sizeof(buf));
+
+    sip_framer_append(&f, combined, n);
+    check_int("pong+msg: pop pong length", 2, sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("pong+msg: pong content", "\r\n", out);
+    int len = (int)strlen(MSG_OK_NOBODY);
+    check_int("pong+msg: pop message", len, sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("pong+msg: message content", MSG_OK_NOBODY, out);
+    check_int("pong+msg: empty after", 0, sip_framer_pop(&f, out, sizeof(out)));
+}
+
+// A lone leading CRLF in its own read pops right away as a 2-byte pong
+// (immediate surfacing — no waiting), and the message in the next read
+// pops clean after it.
+static void test_leading_crlf_split_reads(void)
+{
+    char buf[BUF_CAP];
+    char out[BUF_CAP];
+    sip_framer_t f;
+    sip_framer_init(&f, buf, sizeof(buf));
+
+    sip_framer_append(&f, "\r\n", 2);
+    check_int("pong-split: pop pong immediately", 2,
+              sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("pong-split: pong content", "\r\n", out);
+    int len = (int)strlen(MSG_OK_NOBODY);
+    sip_framer_append(&f, MSG_OK_NOBODY, len);
+    check_int("pong-split: pop message", len, sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("pong-split: message content", MSG_OK_NOBODY, out);
+}
+
+// Documented edge of immediate surfacing: a CRLFCRLF ping split across two
+// reads is reported as two separate pongs (so it is not answered). Harmless
+// and very rare — a 4-byte ping normally rides a single TLS record.
+static void test_split_ping_seen_as_two_pongs(void)
+{
+    char buf[BUF_CAP];
+    char out[BUF_CAP];
+    sip_framer_t f;
+    sip_framer_init(&f, buf, sizeof(buf));
+
+    sip_framer_append(&f, "\r\n", 2);
+    check_int("split-ping: first half → pong", 2, sip_framer_pop(&f, out, sizeof(out)));
+    sip_framer_append(&f, "\r\n", 2);
+    check_int("split-ping: second half → pong", 2, sip_framer_pop(&f, out, sizeof(out)));
+    check_int("split-ping: empty after", 0, sip_framer_pop(&f, out, sizeof(out)));
+}
+
+// A CRLFCRLF keep-alive PING must still pop as a standalone 4-byte frame
+// so the caller can answer it with a pong — the leading-CRLF skip must
+// not swallow it.
+static void test_keepalive_ping_preserved(void)
+{
+    char buf[BUF_CAP];
+    char out[BUF_CAP];
+    sip_framer_t f;
+    sip_framer_init(&f, buf, sizeof(buf));
+
+    sip_framer_append(&f, "\r\n\r\n", 4);
+    check_int("ping: pop length", 4, sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("ping: content", "\r\n\r\n", out);
+    check_int("ping: empty after", 0, sip_framer_pop(&f, out, sizeof(out)));
+}
+
+// A PING immediately followed by a real message in one read: the ping
+// pops first, the message second.
+static void test_ping_then_message(void)
+{
+    char combined[BUF_CAP];
+    int n = snprintf(combined, sizeof(combined), "\r\n\r\n%s", MSG_OK_NOBODY);
+
+    char buf[BUF_CAP];
+    char out[BUF_CAP];
+    sip_framer_t f;
+    sip_framer_init(&f, buf, sizeof(buf));
+
+    sip_framer_append(&f, combined, n);
+    check_int("ping+msg: pop ping", 4, sip_framer_pop(&f, out, sizeof(out)));
+    int len = (int)strlen(MSG_OK_NOBODY);
+    check_int("ping+msg: pop message", len, sip_framer_pop(&f, out, sizeof(out)));
+    check_str_eq("ping+msg: content", MSG_OK_NOBODY, out);
+}
+
 int main(void)
 {
     test_single_message();
@@ -246,6 +344,11 @@ int main(void)
     test_malformed_content_length();
     test_overflow_append();
     test_reset_clears_partial();
+    test_leading_crlf_pong_then_message();
+    test_leading_crlf_split_reads();
+    test_split_ping_seen_as_two_pongs();
+    test_keepalive_ping_preserved();
+    test_ping_then_message();
 
     printf("test_sip_frame: %d tests, %d failures\n", g_tests, g_failures);
     return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Started as "answer Telekom's SIP keepalive ping with a pong", but on-hardware testing on the Telekom test line uncovered the **actual** cause of the recurring registration failure on the persistent TLS connection — so this PR now also carries that fix.

## Root cause (confirmed on hardware)

On the long-lived TLS connection the dongle sends RFC 5626 `CRLFCRLF` keep-alive pings. **Telekom answers every ping with a single-CRLF pong** (verified live — every `→ ping (4 bytes)` is followed ~10 ms later by `← pong (2 bytes) from 217.0.146.197`).

The stream framer could not pop a lone `CRLF` (`find_headers_end` needs a full `CRLFCRLF`), so the pong sat **orphaned** in the receive buffer. The next real message — the ~30 min re-REGISTER's `200 OK` — was appended right behind it (`\r\nSIP/2.0 200 OK…`); the status parser then found no `SIP/2.0` at offset 0 and rejected a perfectly good `200 OK`:

```
← 914 bytes:

SIP/2.0 200 OK
...
← -1 (914 bytes)
REGISTER rejected: -1 — retry in 30 s
```

Reopening the connection didn't help: the fresh connection's first ping drew another lone-CRLF pong → orphan → corrupted the next REGISTER again — a self-perpetuating 30 s retry loop until power-cycle (or a manual switch to plain TCP). The ping↔corruption correlation is exact: a REGISTER failed **iff** a keep-alive ping preceded it on that connection.

This is very likely also the cause of #423.

## Changes

1. **Answer Telekom's keep-alive ping with a pong** + log keepalives once each way (the original PR).
2. **Surface a leading `CRLF` before the SIP start-line as its own 2-byte frame** (RFC 3261 §7.5) — the framer never glues a stray CRLF onto the following message, and a `CRLFCRLF` ping still pops as a 4-byte frame so the pong path keeps working. This is the fix for the `-1` loop.
3. **Log the inbound pong** (a 2-byte CRLF frame, no longer mislabelled "ping") and **defer the idle keepalive after any REGISTER**, so a ping only fires after a genuine idle gap rather than right after a reconnect/refresh.
4. **Collapse the log ("Protokoll") panel by default** and add a short note that the log is for diagnosing problems — not every entry is a real fault. Stops users filing support questions over transient, self-healing errors.

## Tests

Host tests in `test/test_sip_frame.c` cover: lone-CRLF pong then message (one read and split reads), a split `CRLFCRLF` ping seen as two pongs, ping preserved, and ping-then-message. Full suite green (42 framer tests, 0 failures). Builds clean for both `dongle-1.4.x` and `master`.

## Verification

Flashed to the live Telekom test dongle (`1.4.0-rc3-19-g892b9fe4`). Registration stable on TLS, the pong is now visible live, and the orphan can no longer corrupt a response. Final gate before merge: a clean ~30 min re-REGISTER cycle (`← 200` + `re-REGISTERED`, no more `-1`).
