### PR TITLE
Dongle 1.4.0 release notes: finalize for the release

### DIFF
--- a/phoneblock-dongle/firmware/release-notes/1.4.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.4.0.md
@@ -1,6 +1,6 @@
 # PhoneBlock Dongle 1.4.0
 
-*2026-06-19*
+*2026-06-28*
 
 ## Added
 
@@ -21,11 +21,22 @@
   wrong. Set your mail server, sender and recipient under the new "Status
   e-mail" settings; a test button confirms it works. Off by default.
 
-- **System view.** A new "System" panel shows free memory and the CPU
-  usage per task, so an unstable or warm device can be diagnosed at a
-  glance instead of guessing.
+- **System view.** A new "System" panel shows free memory (including the
+  largest contiguous block, the figure that matters for the encrypted
+  connection), the internal clock and time zone, and the CPU usage per
+  task, so an unstable or warm device can be diagnosed at a glance instead
+  of guessing.
+
+- **Live diagnostics log.** The web UI can now show the device's log
+  scrolling live, so an intermittent problem can be watched as it happens
+  rather than pieced together afterwards.
 
 ## Changed
+
+- **The status e-mail now lists the calls.** When the dongle caught spam
+  calls, the daily mail used to report only a count. It now includes the
+  actual list of callers, with each number linked to its page on
+  phoneblock.net, sent as a proper HTML message.
 
 - **Real timestamps instead of "3 min ago".** Now that the dongle knows
   the actual time, the recent-calls list and the diagnostics log show
@@ -35,9 +46,28 @@
 
 - **Tidier settings page.** The configuration areas are now collapsible
   cards, keeping the "is it working" status and recent calls up top and
-  the configure-once settings tucked away.
+  the configure-once settings tucked away. The diagnostics log starts
+  collapsed too, with a note that it is there to analyse problems — not
+  every entry it shows is an actual fault.
 
 ## Fixed
+
+- **The dongle no longer loses its Telekom registration after about half
+  an hour.** On a direct Telekom connection the dongle would silently stop
+  accepting calls roughly 30 minutes after registering and only recover
+  when unplugged. The cause was a keep-alive exchange on the encrypted
+  connection whose reply confused the dongle's message parser into
+  rejecting an otherwise valid renewal. The dongle now handles that reply
+  correctly and stays registered.
+
+- **Registration on Telekom no longer hangs when memory is tight.**
+  Setting up the encrypted connection occasionally failed because the
+  device had run low on contiguous memory. The dongle now reserves less
+  for it, so the secure connection comes up reliably.
+
+- **Fewer Wi-Fi disconnects.** Some routers periodically dropped the
+  dongle's Wi-Fi (and with it the registration). Disabling the Wi-Fi
+  power-saving mode keeps the link up.
 
 - **Spam calls now hang up immediately after the announcement.** On a
   direct Telekom connection the dongle's own "hang up" was not accepted
@@ -50,6 +80,10 @@
   more memory than the device had, which could reboot it mid-call. The
   call report is now sent after the announcement has finished, so the two
   no longer compete for memory.
+
+- **The status e-mail no longer contains stray characters.** A flaw in
+  assembling the message could append leftover memory after the intended
+  text. The mail is now always terminated cleanly.
 
 - **Diagnostics log no longer garbles special characters.** A long log
   line cut at the buffer limit could split a multi-byte character (an


### PR DESCRIPTION
Finalizes the 1.4.0 release notes for the upcoming release: keeps the rc1 entries and adds the rc2/rc3 user-facing changes (status mail now lists the caught calls, System view extras + live log, log panel collapsed by default; fixes for the ~30 min Telekom registration drop, the memory-pressure registration hang, Wi-Fi power-save disconnects, and a stray-memory leak into the status mail).

Docs only — the code for all of these is already merged via #443/#444. This commit was accidentally pushed onto those branches *after* they were merged, so it never landed; this PR puts it on the right base.