### PR TITLE
Dongle: discover public RTP port via STUN and fix per-binding REGISTER lease

### DIFF
--- a/phoneblock-dongle/PROVIDERS.md
+++ b/phoneblock-dongle/PROVIDERS.md
@@ -37,6 +37,7 @@ gegenchecken — Registrar-Namen und Port-/Transport-Zwang können sich
 | Auth-User | E-Mail des T-Online-Accounts |
 | Passwort | T-Online-Webpasswort |
 | SRTP | bei TLS Pflicht; G.711a (PCMA) Pflicht für Notruf |
+| STUN | `stun.t-online.de:3478` — im Preset gesetzt; der Dongle ermittelt damit seinen öffentlichen (post-NAT) RTP-Port und annonciert ihn im SDP statt des lokalen Ports |
 | Stolperfalle | Reg nur aus Telekom-Netz, fremde ISPs werden abgelehnt |
 
 ### Vodafone (DSL / Kabel, ehem. Arcor/KDG)

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -25,6 +25,7 @@ static const char *NS   = "phoneblock";
 #define K_SIP_OUTBOUND  "sip_outbound"
 #define K_SIP_REALM     "sip_realm"
 #define K_SIP_SRTP      "sip_srtp"
+#define K_SIP_STUN      "sip_stun"
 #define K_FB_APP_USER   "fb_app_user"
 #define K_FB_APP_PASS   "fb_app_pass"
 #define K_SYNC_ENABLED  "sync_enabled"
@@ -93,6 +94,8 @@ typedef struct {
     char sip_outbound[80];
     char sip_realm[64];
     char sip_srtp[16];       // "off" | "optional" | "mandatory"
+    char sip_stun[64];       // STUN server "host[:port]" for RTP NAT
+                             // discovery; "" = disabled (set by provider preset)
     char fb_app_user[32];
     char fb_app_pass[40];    // spec cap is 32; 40 for NUL + padding
     char sync_enabled[4];    // "1" | "0" (or empty = default off)
@@ -244,6 +247,7 @@ void config_load(void)
         s_config.sip_outbound[0]  = '\0';
         s_config.sip_realm[0]     = '\0';
         copy_default(s_config.sip_srtp,   sizeof(s_config.sip_srtp),   "optional");
+        s_config.sip_stun[0]      = '\0';
         s_config.fb_app_user[0]   = '\0';
         s_config.fb_app_pass[0]   = '\0';
         s_config.sync_enabled[0]  = '\0';
@@ -302,6 +306,8 @@ void config_load(void)
              s_config.sip_realm,    sizeof(s_config.sip_realm));
     load_str(h, K_SIP_SRTP,     "optional",
              s_config.sip_srtp,     sizeof(s_config.sip_srtp));
+    load_str(h, K_SIP_STUN,     "",
+             s_config.sip_stun,     sizeof(s_config.sip_stun));
     load_str(h, K_FB_APP_USER,  "",
              s_config.fb_app_user,  sizeof(s_config.fb_app_user));
     load_str(h, K_FB_APP_PASS,  "",
@@ -467,6 +473,7 @@ int         config_rtp_port(void)
 {
     return s_config.rtp_port > 0 ? s_config.rtp_port : DEFAULT_RTP_PORT;
 }
+const char *config_stun_server(void)         { return s_config.sip_stun; }
 const char *config_phoneblock_base_url(void) { return s_config.pb_base_url; }
 const char *config_phoneblock_token(void)    { return s_config.pb_token; }
 int         config_min_direct_votes(void)     { return s_config.min_direct_votes; }
@@ -614,6 +621,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.sip_realm, sizeof(s_config.sip_realm));
     if (err == ESP_OK) err = set_str_if(h, K_SIP_SRTP, u->sip_srtp,
                                         s_config.sip_srtp, sizeof(s_config.sip_srtp));
+    if (err == ESP_OK) err = set_str_if(h, K_SIP_STUN, u->sip_stun,
+                                        s_config.sip_stun, sizeof(s_config.sip_stun));
     if (err == ESP_OK) err = set_str_if(h, K_FB_APP_USER, u->fritzbox_app_user,
                                         s_config.fb_app_user, sizeof(s_config.fb_app_user));
     if (err == ESP_OK) err = set_str_if(h, K_FB_APP_PASS, u->fritzbox_app_pass,

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -55,6 +55,15 @@ int         config_contact_port_override(void);
 int         config_sip_local_port(void);
 int         config_rtp_port(void);
 
+// STUN server ("host" or "host:port"; default port 3478) the dongle
+// queries on its own RTP socket to discover the public (post-NAT) IP:port
+// its media will appear to come from. That endpoint is advertised in the
+// SDP answer instead of the unmapped local port, which is only correct
+// when the router happens to preserve that port across NAT. Empty (the
+// default) disables STUN; a provider preset fills it in (e.g. Telekom →
+// stun.t-online.de).
+const char *config_stun_server(void);
+
 // Fritz!Box "app" credentials created by
 // X_AVM-DE_AppSetup:RegisterApp during the setup wizard. Only
 // Phone rights, no internet access — used by the later sync task
@@ -238,6 +247,8 @@ typedef struct {
     const char *sip_outbound;
     const char *sip_realm;
     const char *sip_srtp;
+    const char *sip_stun;       // STUN server "host[:port]" ("" disables),
+                                // NULL = leave unchanged
     const char *fritzbox_app_user;
     const char *fritzbox_app_pass;
     // "1" = enable sync, "0" = disable, NULL = leave unchanged.

--- a/phoneblock-dongle/firmware/main/rtp.c
+++ b/phoneblock-dongle/firmware/main/rtp.c
@@ -10,12 +10,234 @@
 #include "esp_log.h"
 #include "esp_random.h"
 #include "lwip/sockets.h"
+#include "lwip/netdb.h"
 
 #include "config.h"
 
 #include "srtp.h"
 
 static const char *TAG = "rtp";
+
+// Singleton RTP socket, created once and reused for every call: the STUN
+// probe (run from the SIP task before we answer) and the streaming task
+// (run after ACK) must share one local port so the public mapping STUN
+// learns is the one the announcement is then sent from. -1 = not yet open.
+static int s_rtp_sock = -1;
+
+int rtp_socket_ensure(void)
+{
+    if (s_rtp_sock >= 0) return s_rtp_sock;
+
+    int sock = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "RTP socket: %s", strerror(errno));
+        return -1;
+    }
+    int reuse = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    int rtp_port = config_rtp_port();
+    struct sockaddr_in local = {
+        .sin_family      = AF_INET,
+        .sin_addr.s_addr = htonl(INADDR_ANY),
+        .sin_port        = htons(rtp_port),
+    };
+    if (bind(sock, (struct sockaddr *)&local, sizeof(local)) < 0) {
+        ESP_LOGE(TAG, "bind RTP :%d: %s", rtp_port, strerror(errno));
+        close(sock);
+        return -1;
+    }
+    s_rtp_sock = sock;
+    return sock;
+}
+
+#define STUN_MAGIC_COOKIE 0x2112A442u
+
+// Resolve a STUN server spec "host[:port]" (default port 3478) to an IPv4
+// socket address.
+static bool stun_resolve(const char *server, struct sockaddr_in *out)
+{
+    if (!server || !server[0]) return false;
+
+    char host[128];
+    snprintf(host, sizeof(host), "%s", server);
+    int port = 3478;
+    char *colon = strrchr(host, ':');
+    if (colon) {
+        *colon = '\0';
+        int p = atoi(colon + 1);
+        if (p > 0) port = p;
+    }
+
+    char port_str[12];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    struct addrinfo hints = { .ai_family = AF_INET, .ai_socktype = SOCK_DGRAM };
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res) {
+        ESP_LOGW(TAG, "STUN: DNS lookup of %s failed", host);
+        return false;
+    }
+    memcpy(out, res->ai_addr, sizeof(*out));
+    freeaddrinfo(res);
+    return true;
+}
+
+// Send a STUN Binding Request to `srv` on `sock` and parse the public
+// (XOR-)MAPPED-ADDRESS from the reply. Returns false on timeout / bad
+// response. Two short attempts — we must not stall the 200 OK for long
+// when called on the answer path (the INVITE transaction is waiting).
+static bool stun_exchange(int sock, const struct sockaddr_in *srv,
+                          char *ip_out, int ip_cap, int *port_out)
+{
+    // 20-byte header, no attributes; bytes 4..7 magic cookie, 8..19 a random
+    // transaction id, both matched in the reply so a stray packet on the RTP
+    // port can't be mistaken for the response.
+    uint8_t req[20] = { 0x00, 0x01, 0x00, 0x00,
+                        0x21, 0x12, 0xA4, 0x42 };
+    for (int i = 8; i < 20; i++) req[i] = (uint8_t)esp_random();
+
+    for (int attempt = 0; attempt < 2; attempt++) {
+        if (sendto(sock, req, sizeof(req), 0,
+                   (struct sockaddr *)srv, sizeof(*srv)) < 0) {
+            ESP_LOGW(TAG, "STUN: sendto failed: %s", strerror(errno));
+            continue;
+        }
+
+        fd_set rf;
+        FD_ZERO(&rf);
+        FD_SET(sock, &rf);
+        struct timeval tv = { .tv_sec = 0, .tv_usec = 250000 };
+        if (select(sock + 1, &rf, NULL, NULL, &tv) <= 0) continue;
+
+        uint8_t resp[256];
+        struct sockaddr_in from;
+        socklen_t fl = sizeof(from);
+        int n = recvfrom(sock, resp, sizeof(resp), 0,
+                         (struct sockaddr *)&from, &fl);
+        // Binding Success Response (0x0101) echoing our cookie + txid.
+        if (n < 20 || resp[0] != 0x01 || resp[1] != 0x01) continue;
+        if (memcmp(resp + 4, req + 4, 16) != 0) continue;
+
+        int msg_len = (resp[2] << 8) | resp[3];
+        int end = 20 + msg_len;
+        if (end > n) end = n;
+        for (int pos = 20; pos + 4 <= end; ) {
+            int atype = (resp[pos] << 8) | resp[pos + 1];
+            int alen  = (resp[pos + 2] << 8) | resp[pos + 3];
+            int aval  = pos + 4;
+            if (aval + alen > end) break;
+            // (XOR-)MAPPED-ADDRESS, IPv4 (family byte at aval+1 == 0x01).
+            if ((atype == 0x0020 || atype == 0x0001)
+                && alen >= 8 && resp[aval + 1] == 0x01) {
+                uint16_t xport = (resp[aval + 2] << 8) | resp[aval + 3];
+                uint32_t xaddr = ((uint32_t)resp[aval + 4] << 24)
+                               | ((uint32_t)resp[aval + 5] << 16)
+                               | ((uint32_t)resp[aval + 6] << 8)
+                               |  (uint32_t)resp[aval + 7];
+                if (atype == 0x0020) {          // XOR-MAPPED: undo the cookie
+                    xport ^= (STUN_MAGIC_COOKIE >> 16);
+                    xaddr ^= STUN_MAGIC_COOKIE;
+                }
+                struct in_addr a = { .s_addr = htonl(xaddr) };
+                inet_ntoa_r(a, ip_out, ip_cap);
+                *port_out = xport;
+                return true;
+            }
+            // Attributes are padded to a 4-byte boundary.
+            pos = aval + alen + ((alen & 3) ? (4 - (alen & 3)) : 0);
+        }
+    }
+    return false;
+}
+
+bool rtp_stun_map(const char *stun_server, char *ip_out, int ip_cap,
+                  int *port_out)
+{
+    int sock = rtp_socket_ensure();
+    if (sock < 0) return false;
+    struct sockaddr_in srv;
+    if (!stun_resolve(stun_server, &srv)) return false;
+    if (!stun_exchange(sock, &srv, ip_out, ip_cap, port_out)) {
+        ESP_LOGW(TAG, "STUN: no usable response from %s", stun_server);
+        return false;
+    }
+    ESP_LOGI(TAG, "STUN: %s → public %s:%d", stun_server, ip_out, *port_out);
+    return true;
+}
+
+// Built-in STUN servers used (besides the configured one) to probe the NAT
+// mapping behaviour. Only their reachability and distinct IPs matter, not
+// which provider runs them.
+static const char *STUN_FALLBACKS[] = {
+    "stun.t-online.de:3478",
+    "stun.1und1.de:3478",
+    "stun.sipgate.net:10000",
+};
+
+static nat_mapping_t s_nat_mapping = NAT_MAP_UNKNOWN;
+
+nat_mapping_t rtp_nat_mapping(void) { return s_nat_mapping; }
+
+const char *rtp_nat_mapping_str(void)
+{
+    switch (s_nat_mapping) {
+        case NAT_MAP_ENDPOINT_INDEPENDENT: return "endpoint-independent";
+        case NAT_MAP_ENDPOINT_DEPENDENT:   return "endpoint-dependent";
+        default:                           return "unknown";
+    }
+}
+
+nat_mapping_t rtp_probe_nat_mapping(const char *primary_stun)
+{
+    int sock = rtp_socket_ensure();
+    if (sock < 0) { s_nat_mapping = NAT_MAP_UNKNOWN; return s_nat_mapping; }
+
+    // Candidate list: the configured server first, then the built-in ones.
+    #define N_STUN_FALLBACKS (sizeof(STUN_FALLBACKS) / sizeof(STUN_FALLBACKS[0]))
+    const char *cands[1 + N_STUN_FALLBACKS];
+    int nc = 0;
+    if (primary_stun && primary_stun[0]) cands[nc++] = primary_stun;
+    for (size_t i = 0; i < N_STUN_FALLBACKS; i++) cands[nc++] = STUN_FALLBACKS[i];
+    #undef N_STUN_FALLBACKS
+
+    // Query servers until two at *different* IPs answered, then compare the
+    // mapped ports: same external port for both → endpoint-independent.
+    uint32_t first_ip   = 0;
+    int      first_port = -1;
+    for (int i = 0; i < nc; i++) {
+        struct sockaddr_in srv;
+        if (!stun_resolve(cands[i], &srv)) continue;
+        if (first_port >= 0 && srv.sin_addr.s_addr == first_ip) continue;
+
+        char mip[INET_ADDRSTRLEN];
+        int  mport = 0;
+        if (!stun_exchange(sock, &srv, mip, sizeof(mip), &mport)) continue;
+
+        if (first_port < 0) {
+            first_ip   = srv.sin_addr.s_addr;
+            first_port = mport;
+            continue;
+        }
+        if (mport == first_port) {
+            s_nat_mapping = NAT_MAP_ENDPOINT_INDEPENDENT;
+            ESP_LOGI(TAG, "NAT mapping: endpoint-independent (port %d from two "
+                          "servers) — STUN usable for media", mport);
+        } else {
+            s_nat_mapping = NAT_MAP_ENDPOINT_DEPENDENT;
+            ESP_LOGW(TAG, "NAT mapping: endpoint-dependent / symmetric (ports "
+                          "%d vs %d) — STUN cannot fix media; for direct "
+                          "provider registration use a port-identical UDP "
+                          "forward of the RTP port, or a VoIP router",
+                     first_port, mport);
+        }
+        return s_nat_mapping;
+    }
+
+    s_nat_mapping = NAT_MAP_UNKNOWN;
+    ESP_LOGW(TAG, "NAT mapping: probe inconclusive (need two reachable STUN "
+                  "servers at different IPs)");
+    return s_nat_mapping;
+}
 
 #define FRAME_SAMPLES    160          // 20 ms at 8 kHz
 #define FRAME_BYTES      FRAME_SAMPLES // 1 byte per sample for PCMA
@@ -94,25 +316,11 @@ static void rtp_audio_task(void *arg)
 {
     rtp_args_t *a = (rtp_args_t *)arg;
 
-    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (sock < 0) {
-        ESP_LOGE(TAG, "socket(): %s", strerror(errno));
-        goto done;
-    }
-    int reuse = 1;
-    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
-
-    int rtp_port = config_rtp_port();
-    struct sockaddr_in local = {
-        .sin_family      = AF_INET,
-        .sin_addr.s_addr = htonl(INADDR_ANY),
-        .sin_port        = htons(rtp_port),
-    };
-    if (bind(sock, (struct sockaddr *)&local, sizeof(local)) < 0) {
-        ESP_LOGE(TAG, "bind RTP :%d: %s", rtp_port, strerror(errno));
-        close(sock);
-        goto done;
-    }
+    // Shared singleton socket (see rtp_socket_ensure): same local port the
+    // STUN probe used, so the announcement leaves from the mapping we
+    // advertised. Not closed here — it outlives the call.
+    int sock = rtp_socket_ensure();
+    if (sock < 0) goto done;
 
     // Set up SRTP if the SDP answer advertised RTP/SAVP. If session
     // creation fails we cannot send anything the remote will accept
@@ -122,10 +330,19 @@ static void rtp_audio_task(void *arg)
         srtp_session = srtp_open_tx(&a->srtp);
         if (!srtp_session) {
             ESP_LOGE(TAG, "SRTP requested but session setup failed — no audio");
-            close(sock);
             goto done;
         }
     }
+
+    // Diagnostic: count inbound packets (the gateway's return media) on the
+    // RTP socket. Receiving them proves the advertised endpoint is reachable
+    // and the NAT pinhole is two-way — strong evidence the announcement
+    // reaches the caller too. None arriving points at a one-way / NAT
+    // mapping problem (the very thing STUN is meant to fix). We don't decode
+    // them (they're SRTP when enabled) — source and count are enough.
+    unsigned inbound_pkts = 0;
+    char     inbound_src[INET_ADDRSTRLEN] = "";
+    int      inbound_port = 0;
 
     uint16_t seq       = (uint16_t)esp_random();
     uint32_t timestamp = esp_random();
@@ -199,14 +416,32 @@ static void rtp_audio_task(void *arg)
             ESP_LOGW(TAG, "rtp sendto: %s", strerror(errno));
         }
 
+        // Drain whatever the gateway sent back this frame (non-blocking),
+        // remembering the first source for the post-stream summary.
+        for (;;) {
+            uint8_t rbuf[256];
+            struct sockaddr_in raddr;
+            socklen_t rlen = sizeof(raddr);
+            int rn = recvfrom(sock, rbuf, sizeof(rbuf), MSG_DONTWAIT,
+                              (struct sockaddr *)&raddr, &rlen);
+            if (rn <= 0) break;
+            if (inbound_pkts == 0) {
+                inet_ntoa_r(raddr.sin_addr, inbound_src, sizeof(inbound_src));
+                inbound_port = ntohs(raddr.sin_port);
+            }
+            inbound_pkts++;
+        }
+
         seq++;
         timestamp += FRAME_SAMPLES;
         vTaskDelayUntil(&next, pdMS_TO_TICKS(20));
     }
 
+    ESP_LOGI(TAG, "inbound RTP during stream: %u packet(s) from %s:%d",
+             inbound_pkts, inbound_src, inbound_port);
+
     ESP_LOGI(TAG, "stream finished");
     if (srtp_session) srtp_dealloc(srtp_session);
-    close(sock);
 
 done:
     announcement_close(&a->src);

--- a/phoneblock-dongle/firmware/main/rtp.h
+++ b/phoneblock-dongle/firmware/main/rtp.h
@@ -39,6 +39,49 @@ void rtp_play_audio(const struct sockaddr_in *dest,
                     announcement_src_t *src,
                     const rtp_srtp_tx_t *srtp);
 
+// Ensure the singleton RTP UDP socket exists and is bound to
+// config_rtp_port(); returns its fd or -1 on failure. The socket is
+// reused across calls (and shared between the STUN probe and the
+// streaming task) so the public NAT mapping a STUN query learns stays
+// valid for the announcement that follows, and the binding stays warm.
+int rtp_socket_ensure(void);
+
+// Query `stun_server` ("host" or "host:port") over the RTP socket and
+// return the public (post-NAT) IPv4 endpoint our media will appear to
+// come from (from the response's XOR-MAPPED-ADDRESS). Returns false on
+// empty server / DNS / timeout / parse failure — the caller should then
+// fall back to the signalling-learned public IP and the local RTP port.
+// Best-effort: a symmetric NAT maps per destination, so the value learned
+// against the STUN server need not match the mapping toward the call's
+// media gateway; the streaming task's inbound-RTP log confirms which.
+bool rtp_stun_map(const char *stun_server, char *ip_out, int ip_cap,
+                  int *port_out);
+
+// NAT mapping behaviour as seen for the RTP socket (RFC 5780).
+typedef enum {
+    NAT_MAP_UNKNOWN = 0,            // probe not run / inconclusive
+    NAT_MAP_ENDPOINT_INDEPENDENT,  // cone — a STUN-learned port is valid toward
+                                   // any peer, including the media gateway
+    NAT_MAP_ENDPOINT_DEPENDENT,    // symmetric — the external port varies per
+                                   // destination, so STUN cannot predict the
+                                   // port the gateway will see; only a
+                                   // port-identical RTP forward (or a VoIP
+                                   // router) fixes media here
+} nat_mapping_t;
+
+// Probe the NAT mapping behaviour by querying two STUN servers at different
+// IPs from the same RTP socket and comparing the mapped ports (equal →
+// endpoint-independent, differ → endpoint-dependent). `primary_stun` (the
+// configured server, may be "") is tried first, then a built-in fallback
+// list. Result is cached and also returned. Run once after a direct
+// provider registration; takes up to ~1 s, so not on the call path.
+nat_mapping_t rtp_probe_nat_mapping(const char *primary_stun);
+
+// Last probe result (NAT_MAP_UNKNOWN until rtp_probe_nat_mapping ran), and
+// its lowercase string form for the status JSON.
+nat_mapping_t rtp_nat_mapping(void);
+const char   *rtp_nat_mapping_str(void);
+
 // Signal an in-flight rtp_play_audio task to stop at the next 20 ms
 // frame boundary. Used by the SIP task to preempt the announcement
 // when a second INVITE arrives while the first SPAM dialog is still

--- a/phoneblock-dongle/firmware/main/sip_parse.c
+++ b/phoneblock-dongle/firmware/main/sip_parse.c
@@ -95,22 +95,75 @@ static int parse_uint_clamped(const char **pp, const char *end)
     return n;
 }
 
-int parse_register_expires(const char *resp, int resp_len)
+// Extract the contact-level ";expires=<n>" from a single Contact header
+// value [c, eol). Returns -1 when the parameter is absent.
+static int contact_expires(const char *c, const char *eol)
+{
+    for (const char *q = c; q + 9 <= eol; q++) {
+        if (q[0] == ';' && strncasecmp(q + 1, "expires=", 8) == 0) {
+            const char *p = q + 9;
+            return parse_uint_clamped(&p, eol);
+        }
+    }
+    return -1;
+}
+
+int parse_register_expires(const char *resp, int resp_len, const char *instance)
 {
     const char *end = resp + resp_len;
+    size_t inst_len = (instance && instance[0]) ? strlen(instance) : 0;
 
-    // Contact-level ";expires=<n>" wins over the top-level header.
-    const char *c = find_header(resp, resp_len, "Contact");
-    if (c) {
-        const char *eol = c;
+    // A 200 OK to REGISTER echoes ALL bindings currently held on the AOR,
+    // not just ours — on a Telekom line shared with the router's own VoIP
+    // (Fritz!Box / Speedport) that means several Contact headers with
+    // different ";expires=" values. We must read the lease of OUR binding,
+    // identified by the +sip.instance UUID we registered with; reading the
+    // first Contact instead picks up a foreign device's (longer) grant and
+    // makes us refresh too late (the binding lapses → missed inbound calls).
+    int  first_contact_expires = -1;
+    int  contact_count         = 0;
+    bool have_match            = false;
+    int  match_expires        = -1;
+
+    const char *p = resp;
+    while (p < end && *p != '\n') p++;   // skip the status line
+    if (p < end) p++;
+
+    while (p < end) {
+        const char *eol = p;
         while (eol < end && *eol != '\r' && *eol != '\n') eol++;
-        for (const char *q = c; q + 9 <= eol; q++) {
-            if (q[0] == ';' && strncasecmp(q + 1, "expires=", 8) == 0) {
-                const char *p = q + 9;
-                int n = parse_uint_clamped(&p, eol);
-                if (n >= 0) return n;
+
+        if ((size_t)(end - p) >= 8 && strncasecmp(p, "Contact:", 8) == 0) {
+            const char *c = p + 8;
+            while (c < eol && (*c == ' ' || *c == '\t')) c++;
+            int exp = contact_expires(c, eol);
+            contact_count++;
+            if (contact_count == 1) first_contact_expires = exp;
+            if (inst_len && !have_match) {
+                for (const char *r = c; r + inst_len <= eol; r++) {
+                    if (strncasecmp(r, instance, inst_len) == 0) {
+                        have_match   = true;
+                        match_expires = exp;
+                        break;
+                    }
+                }
             }
         }
+
+        p = eol;
+        while (p < end && (*p == '\r' || *p == '\n')) p++;
+    }
+
+    // Our own binding's lease wins. If we matched it but it carried no
+    // ";expires=", fall through to the top-level Expires header.
+    if (have_match && match_expires >= 0) return match_expires;
+    if (inst_len == 0) {
+        // Caller opted out of disambiguation: legacy "first Contact wins".
+        if (first_contact_expires >= 0) return first_contact_expires;
+    } else if (!have_match && contact_count == 1 && first_contact_expires >= 0) {
+        // Instance given but not echoed: a lone Contact can only be ours;
+        // never guess from one of several foreign bindings.
+        return first_contact_expires;
     }
 
     const char *e = find_header(resp, resp_len, "Expires");

--- a/phoneblock-dongle/firmware/main/sip_parse.h
+++ b/phoneblock-dongle/firmware/main/sip_parse.h
@@ -46,17 +46,22 @@ int parse_status_code(const char *resp, int len);
 // limit exceeded"), so surfacing it turns a bare "403" into a diagnosis.
 int parse_reason_phrase(const char *resp, int len, char *out, int cap);
 
-// Parse the granted REGISTER expiry (in seconds) from a 200 OK
-// response. Per RFC 3261 §10.2.4 a contact-level ";expires=<n>"
-// parameter takes precedence over the top-level Expires header; this
-// function checks the first Contact line for the parameter and falls
-// back to Expires. Returns -1 when neither is present, in which case
-// the caller should retain whatever value it requested.
+// Parse the granted REGISTER expiry (in seconds) for OUR binding from a
+// 200 OK response. Per RFC 3261 §10.2.4 a contact-level ";expires=<n>"
+// parameter takes precedence over the top-level Expires header.
 //
-// Multi-binding responses (rare for a single AOR REGISTER) are not
-// disambiguated — the first Contact wins. Values are clamped to
-// 30 days as a sanity bound on parser overflow.
-int parse_register_expires(const char *resp, int resp_len);
+// A 200 OK echoes every binding on the AOR, so on a line shared with the
+// router's own VoIP client there are several Contact headers with
+// differing leases. `instance` is the +sip.instance UUID we registered
+// with (config_device_id()): the Contact carrying it identifies our
+// binding and its ";expires=" is returned. A lone Contact is taken as
+// ours even without a match; among several foreign bindings with no
+// match we do NOT guess and fall back to the top-level Expires header.
+// Pass NULL/"" to opt out of disambiguation entirely — then the first
+// Contact wins (legacy behaviour). Returns -1 when nothing applies, in which
+// case the caller should retain whatever value it requested. Values are
+// clamped to 30 days as a sanity bound on parser overflow.
+int parse_register_expires(const char *resp, int resp_len, const char *instance);
 
 // Extract the numeric part of the CSeq header. 0 if absent or malformed.
 uint32_t parse_cseq(const char *req, int req_len);

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -101,6 +101,10 @@ typedef struct {
     bool     srtp_tx;             // true → answer/stream as SRTP (RTP/SAVP)
     int      srtp_tag;            // crypto tag to echo in the SDP answer
     uint8_t  srtp_tx_key[RTP_SRTP_KEY_LEN];  // our SDES master key+salt
+    char     media_ip[48];        // SDP c=/o= address to advertise (public,
+                                  // STUN-mapped if available, else signalling IP)
+    int      media_port;          // SDP m= port to advertise (public, post-NAT;
+                                  // 0 until prepare_media_endpoint ran)
     char     contact_uri[200];    // INVITE Contact = remote target (BYE R-URI)
     char     route[320];          // INVITE Record-Route, echoed as BYE Route
                                   // (Telekom's IMS token URI is ~211 chars;
@@ -649,7 +653,7 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
     ESP_LOGI(TAG, "← %d (%d bytes)", status, rx_len);
 
     if (status == 200) {
-        int granted = parse_register_expires(rx, rx_len);
+        int granted = parse_register_expires(rx, rx_len, config_device_id());
         if (granted >= 0) *granted_expires = granted;
         result = REGISTER_OK;
         goto cleanup;
@@ -763,7 +767,7 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
         goto cleanup;
     }
     {
-        int granted = parse_register_expires(rx, rx_len);
+        int granted = parse_register_expires(rx, rx_len, config_device_id());
         if (granted >= 0) *granted_expires = granted;
     }
     result = REGISTER_OK;
@@ -887,9 +891,15 @@ static void send_response(sip_ctx_t *c, const struct sockaddr_in *peer,
 // When the dialog negotiated SRTP (d->srtp_tx), the media line uses the
 // secure RTP/SAVP profile and carries our SDES key in an a=crypto line
 // echoing the offer's crypto tag; otherwise it stays plain RTP/AVP.
-static int build_sdp_body(const char *our_ip, const dialog_t *d,
+static int build_sdp_body(const char *fallback_ip, const dialog_t *d,
                           char *out, int cap)
 {
+    // Advertise the endpoint prepare_media_endpoint() resolved (public,
+    // STUN-mapped). Fall back to the signalling IP / local port if it was
+    // never set (defensive — the answer path always sets it first).
+    const char *ip = (d && d->media_ip[0]) ? d->media_ip : fallback_ip;
+    int port       = (d && d->media_port > 0) ? d->media_port : config_rtp_port();
+
     int n = snprintf(out, cap,
         "v=0\r\n"
         "o=phoneblock-dongle 0 0 IN IP4 %s\r\n"
@@ -898,7 +908,7 @@ static int build_sdp_body(const char *our_ip, const dialog_t *d,
         "t=0 0\r\n"
         "m=audio %d RTP/%s 8\r\n"
         "a=rtpmap:8 PCMA/8000\r\n",
-        our_ip, our_ip, config_rtp_port(),
+        ip, ip, port,
         (d && d->srtp_tx) ? "SAVP" : "AVP");
 
     if (d && d->srtp_tx) {
@@ -916,6 +926,46 @@ static int build_sdp_body(const char *our_ip, const dialog_t *d,
 
     n += snprintf(out + n, cap - n, "a=sendrecv\r\n");
     return n;
+}
+
+// Decide the IP:port to advertise as our media endpoint in the SDP answer,
+// storing it in the dialog for build_sdp_body (and any later retransmit).
+//
+// The signalling layer already knows our public IP (REGISTER "received="),
+// but not the public UDP *port* our RTP is mapped to: we bind a fixed local
+// port and used to advertise it verbatim, which is only correct when the
+// router preserves that port across NAT. So we ask STUN — on the very RTP
+// socket the announcement will stream from — for the post-NAT endpoint and
+// advertise that, falling back to the signalling IP + local port when STUN
+// yields nothing.
+static void prepare_media_endpoint(sip_ctx_t *c, dialog_t *d)
+{
+    snprintf(d->media_ip, sizeof(d->media_ip), "%s", advertised_host(c));
+    d->media_port = config_rtp_port();
+
+    // Under endpoint-dependent (symmetric) NAT the STUN-learned port wouldn't
+    // match the one the media gateway sees, so advertising it is pointless —
+    // stay on the local port. The boot-time probe already warned that only a
+    // port-identical RTP forward (or a VoIP router) fixes audio here.
+    if (rtp_nat_mapping() == NAT_MAP_ENDPOINT_DEPENDENT) {
+        ESP_LOGW(TAG, "symmetric NAT — advertising local RTP endpoint %s:%d "
+                      "(audio needs a port-identical RTP port-forward)",
+                 d->media_ip, d->media_port);
+        return;
+    }
+
+    char ip[INET_ADDRSTRLEN];
+    int  port = 0;
+    if (rtp_stun_map(config_stun_server(), ip, sizeof(ip), &port) && port > 0) {
+        ESP_LOGI(TAG, "media endpoint via STUN: %s:%d (local was %s:%d)",
+                 ip, port, d->media_ip, d->media_port);
+        snprintf(d->media_ip, sizeof(d->media_ip), "%s", ip);
+        d->media_port = port;
+    } else {
+        ESP_LOGW(TAG, "STUN gave no mapping — advertising local RTP endpoint "
+                      "%s:%d (only correct if the router preserves the port)",
+                 d->media_ip, d->media_port);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1312,6 +1362,9 @@ static void handle_invite(sip_ctx_t *c, const char *req, int req_len,
 
     if (d->verdict == VERDICT_SPAM) {
         char sdp[384];
+        // Resolve the public media endpoint (STUN) before answering, so the
+        // SDP carries the post-NAT IP:port the announcement is sent from.
+        prepare_media_endpoint(c, d);
         build_sdp_body(advertised_host(c), d, sdp, sizeof(sdp));
         send_response(c, from, req, req_len, 200, "OK", d->our_tag, sdp);
         d->state = DIALOG_ANSWERED;
@@ -1689,6 +1742,17 @@ static void sip_task(void *arg)
         s_sip_task = NULL;
         vTaskDelete(NULL);
         return;
+    }
+
+    // One-shot NAT mapping probe for direct-provider setups (a STUN server is
+    // configured only by a provider preset, never for a Fritz!Box on the LAN).
+    // Run here — after the initial registration attempt put the network up, but
+    // before the watchdog is armed below — so its ~1 s of STUN exchanges can't
+    // trip it. The result gates per-call STUN (see prepare_media_endpoint). A
+    // later provider switch via reload keeps this boot result until reboot; the
+    // NAT type is a property of the router, not the provider.
+    if (config_stun_server()[0]) {
+        rtp_probe_nat_mapping(config_stun_server());
     }
 
     // Subscribe to the task watchdog. Any iteration that doesn't loop

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -28,6 +28,7 @@
 #include "firmware_update.h"
 #include "log_capture.h"
 #include "mail.h"
+#include "rtp.h"
 #include "scheduler.h"
 #include "sip_register.h"
 #include "stats.h"
@@ -338,6 +339,8 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON_AddStringToObject(sip,  "outbound",          config_sip_outbound());
     cJSON_AddStringToObject(sip,  "realm",             config_sip_realm());
     cJSON_AddStringToObject(sip,  "srtp",              config_sip_srtp());
+    cJSON_AddStringToObject(sip,  "stun",              config_stun_server());
+    cJSON_AddStringToObject(sip,  "nat_mapping",       rtp_nat_mapping_str());
     // Local bind ports (to forward) + the public IP the registrar sees
     // us at — together these are what a UDP-behind-NAT setup needs.
     cJSON_AddNumberToObject(sip,  "local_port",        config_sip_local_port());
@@ -556,6 +559,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char sip_outbound[80] = "";
     char sip_realm[64]    = "";
     char sip_srtp[16]     = "";
+    char sip_stun[64]     = "";
     char sip_anon_s[4]    = "";
     char sync_en_s[4]     = "";
     char log_known_s[4]   = "";
@@ -587,6 +591,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_sip_out   = form_get(body, "sip_outbound",  sip_outbound, sizeof(sip_outbound));
     bool have_sip_realm = form_get(body, "sip_realm",     sip_realm,    sizeof(sip_realm));
     bool have_sip_srtp  = form_get(body, "sip_srtp",      sip_srtp,     sizeof(sip_srtp));
+    bool have_sip_stun  = form_get(body, "sip_stun",      sip_stun,     sizeof(sip_stun));
     // Present only when the manual form's "anonymous" box is ticked. Its
     // presence (not its value) is the signal to clear a stored password.
     bool have_sip_anon  = form_get(body, "sip_anon",      sip_anon_s,   sizeof(sip_anon_s));
@@ -694,6 +699,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .sip_outbound  = have_sip_out   ? sip_outbound : NULL,
         .sip_realm     = have_sip_realm ? sip_realm    : NULL,
         .sip_srtp      = have_sip_srtp  ? sip_srtp     : NULL,
+        .sip_stun      = have_sip_stun  ? sip_stun     : NULL,
         .sync_enabled    = have_sync_en   ? sync_en_s    : NULL,
         .log_known_calls = have_log_known ? log_known_s  : NULL,
         .log_info        = have_log_info  ? log_info_s   : NULL,
@@ -830,6 +836,7 @@ static esp_err_t finish_fritzbox_setup(httpd_req_t *req,
         .sip_outbound  = "",
         .sip_realm     = "",
         .sip_srtp      = "off",
+        .sip_stun      = "",
         .fritzbox_app_user = app_user,
         .fritzbox_app_pass = app_pass,
     };

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -128,6 +128,8 @@ const I18N = {
     'status.sip.at': 'bei {host} als {user}',
     'status.sip.ext': 'Interne Nummer {n}',
     'status.sip.public_ip': 'öffentliche IP {ip}',
+    'status.sip.nat_symmetric': '⚠️ symmetrisches NAT — Audio braucht eine portgleiche RTP-Port-Weiterleitung',
+    'status.sip.stun': 'STUN {server} · NAT: {nat}',
     'status.sip.setup_cta': 'Telefonie einrichten',
     'status.sip.redo_cta': 'Telefonie neu einrichten',
     'status.token.set': 'PhoneBlock-Token gesetzt',
@@ -359,6 +361,8 @@ const I18N = {
     'sip.manual.outbound.hint': 'Optional, Format host[:port]. Leer = direkt zum Registrar.',
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Leer = aus Challenge übernehmen.',
+    'sip.manual.stun': 'STUN-Server',
+    'sip.manual.stun.hint': 'Optional, Format host[:port]. Ermittelt bei direkter Provider-Anmeldung den öffentlichen RTP-Port. Leer = aus. Wird vom Provider-Preset gesetzt (Telekom: stun.t-online.de:3478).',
     'sip.manual.srtp': 'SRTP',
     'sip.manual.srtp.hint': 'SRTP wird automatisch ausgehandelt: Sprache wird verschlüsselt, sobald der Anbieter es anbietet (z. B. Telekom), sonst unverschlüsseltes RTP (z. B. Fritz!Box im LAN).',
     'sip.manual.local_port': 'Lokaler SIP-Port',
@@ -389,6 +393,8 @@ const I18N = {
     'status.sip.at': 'at {host} as {user}',
     'status.sip.ext': 'Internal number {n}',
     'status.sip.public_ip': 'Public IP {ip}',
+    'status.sip.nat_symmetric': '⚠️ symmetric NAT — audio needs a port-identical RTP port forward',
+    'status.sip.stun': 'STUN {server} · NAT: {nat}',
     'status.sip.setup_cta': 'Set up telephony',
     'status.sip.redo_cta': 'Reconfigure telephony',
     'status.token.set': 'PhoneBlock token set',
@@ -618,6 +624,8 @@ const I18N = {
     'sip.manual.outbound.hint': 'Optional, format host[:port]. Empty = register via the registrar directly.',
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Empty = take from the server challenge.',
+    'sip.manual.stun': 'STUN server',
+    'sip.manual.stun.hint': 'Optional, format host[:port]. Discovers the public RTP port for direct provider registration. Empty = off. Set by the provider preset (Telekom: stun.t-online.de:3478).',
     'sip.manual.srtp': 'SRTP',
     'sip.manual.srtp.hint': 'SRTP is negotiated automatically: media is encrypted whenever the provider offers it (e.g. Telekom), otherwise plain RTP (e.g. the Fritz!Box on the LAN).',
     'sip.manual.local_port': 'Local SIP port',
@@ -648,6 +656,8 @@ const I18N = {
     'status.sip.at': 'sur {host} en tant que {user}',
     'status.sip.ext': 'Numéro interne {n}',
     'status.sip.public_ip': 'IP publique {ip}',
+    'status.sip.nat_symmetric': '⚠️ NAT symétrique — l’audio nécessite une redirection de port RTP identique',
+    'status.sip.stun': 'STUN {server} · NAT : {nat}',
     'status.sip.setup_cta': 'Configurer la téléphonie',
     'status.sip.redo_cta': 'Reconfigurer la téléphonie',
     'status.token.set': 'Jeton PhoneBlock enregistré',
@@ -860,6 +870,8 @@ const I18N = {
     'sip.manual.outbound.hint': 'Optionnel, format hôte[:port]. Vide = passer directement par le registrar.',
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vide = reprendre la valeur du challenge du serveur.',
+    'sip.manual.stun': 'Serveur STUN',
+    'sip.manual.stun.hint': 'Optionnel, format hôte[:port]. Détecte le port RTP public lors d’un enregistrement direct chez l’opérateur. Vide = désactivé. Défini par le préréglage opérateur (Telekom : stun.t-online.de:3478).',
     'sip.manual.srtp': 'SRTP',
     'sip.manual.srtp.hint': 'Le SRTP est négocié automatiquement : le média est chiffré dès que le fournisseur le propose (p. ex. Telekom), sinon RTP en clair (p. ex. la Fritz!Box sur le LAN).',
     'sip.manual.local_port': 'Port SIP local',
@@ -890,6 +902,8 @@ const I18N = {
     'status.sip.at': 'en {host} como {user}',
     'status.sip.ext': 'Número interno {n}',
     'status.sip.public_ip': 'IP pública {ip}',
+    'status.sip.nat_symmetric': '⚠️ NAT simétrico — el audio necesita una redirección de puerto RTP idéntica',
+    'status.sip.stun': 'STUN {server} · NAT: {nat}',
     'status.sip.setup_cta': 'Configurar la telefonía',
     'status.sip.redo_cta': 'Reconfigurar la telefonía',
     'status.token.set': 'Token PhoneBlock configurado',
@@ -1102,6 +1116,8 @@ const I18N = {
     'sip.manual.outbound.hint': 'Opcional, formato host[:puerto]. Vacío = registrar directamente.',
     'sip.manual.realm': 'Realm',
     'sip.manual.realm.hint': 'Vacío = tomarlo del challenge del servidor.',
+    'sip.manual.stun': 'Servidor STUN',
+    'sip.manual.stun.hint': 'Opcional, formato host[:puerto]. Detecta el puerto RTP público al registrarse directamente con el proveedor. Vacío = desactivado. Lo define el preajuste del proveedor (Telekom: stun.t-online.de:3478).',
     'sip.manual.srtp': 'SRTP',
     'sip.manual.srtp.hint': 'El SRTP se negocia automáticamente: el audio se cifra cuando el proveedor lo ofrece (p. ej. Telekom); de lo contrario, RTP sin cifrar (p. ej. la Fritz!Box en la LAN).',
     'sip.manual.local_port': 'Puerto SIP local',
@@ -1343,6 +1359,9 @@ const PROVIDERS = {
     transport: 'tls',
     authUser: 'anonymous@t-online.de',
     anonymous: true,
+    // Telekom's own STUN — lets the dongle advertise its real post-NAT RTP
+    // port in the SDP instead of the unmapped local port.
+    stun: 'stun.t-online.de:3478',
     userHint: 'Rufnummer im Format +49… (E.164). Kein Passwort nötig — die Anmeldung erfolgt anonym (anonymous@t-online.de).',
   },
   einsundeins: {
@@ -1350,6 +1369,7 @@ const PROVIDERS = {
     host: 'sip.1und1.de',
     port: 5060,
     transport: 'tcp',
+    stun: 'stun.1und1.de:3478',
     userHint: 'Format: 49…, ohne „+" und ohne führende 0. Passwort = „Telefoniepasswort" aus dem 1&1-Control-Center.',
   },
   sipgate: {
@@ -1357,6 +1377,7 @@ const PROVIDERS = {
     host: 'sipgate.de',
     port: 5060,
     transport: 'tcp',
+    stun: 'stun.sipgate.net:10000',
     userHint: 'SIP-ID aus dem sipgate-Webportal. Passwort = separates SIP-Passwort.',
   },
   easybell: {
@@ -1364,6 +1385,7 @@ const PROVIDERS = {
     host: 'voip.easybell.de',
     port: 5060,
     transport: 'tcp',
+    // easybell documents that a STUN server is not required; left empty.
     userHint: 'SIP-Benutzer und -Passwort aus dem easybell-Kundenportal.',
   },
 };
@@ -1991,6 +2013,11 @@ async function refreshAll(){
     }
     if (s.sip.public_ip){
       parts.push(t('status.sip.public_ip', {ip: s.sip.public_ip}));
+    }
+    if (s.sip.nat_mapping === 'endpoint-dependent'){
+      parts.push(t('status.sip.nat_symmetric'));
+    } else if (s.sip.stun){
+      parts.push(t('status.sip.stun', {server: s.sip.stun, nat: s.sip.nat_mapping || 'unknown'}));
     }
     $('sipDetail').textContent = parts.join(' · ');
     sipCta.textContent = t('status.sip.redo_cta');
@@ -3026,6 +3053,9 @@ async function onProviderSubmit(e){
   body.append('sip_auth_user', p.authUser || '');
   body.append('sip_outbound', '');
   body.append('sip_realm', '');
+  // STUN server for RTP NAT discovery — set per preset (empty = off), so
+  // switching providers also clears a previous provider's STUN server.
+  body.append('sip_stun', p.stun || '');
   try {
     const r = await fetch('/api/config', {
       method: 'POST',
@@ -3062,6 +3092,7 @@ async function renderSipManual(){
   const au    = sip.auth_user || '';
   const outb  = sip.outbound  || '';
   const realm = sip.realm     || '';
+  const stun  = sip.stun      || '';
   // No stored password ⇒ pre-tick "anonymous", so the saved state stays
   // visible on reload (the password itself is never sent to the client).
   const passSet = !!sip.pass_set;
@@ -3128,6 +3159,10 @@ async function renderSipManual(){
     +     '<input type="number" name="rtp_port" min="1" max="65535" value="' + esc(rport) + '"></label>'
     +   '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
     +     esc(t('sip.manual.rtp_port.hint')) + '</p>'
+    +   '<label>' + esc(t('sip.manual.stun'))
+    +     '<input type="text" name="sip_stun" value="' + esc(stun) + '"></label>'
+    +   '<p class="muted" style="font-size:.75rem;margin:.2rem 0 .6rem">'
+    +     esc(t('sip.manual.stun.hint')) + '</p>'
     +   '<div class="muted" style="font-size:.75rem;margin:.6rem 0;border-left:3px solid #ccc;padding-left:.6rem">'
     +     '<strong>' + esc(t('sip.manual.fwd.title')) + '</strong><br>'
     +     esc(t('sip.manual.fwd.body', {sip: lportShown, rtp: rportShown}))

--- a/phoneblock-dongle/firmware/release-notes/1.4.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.4.0.md
@@ -31,6 +31,17 @@
   scrolling live, so an intermittent problem can be watched as it happens
   rather than pieced together afterwards.
 
+- **Better audio when registering directly at a provider behind a home
+  router.** Registered straight at a provider (e.g. Telekom) instead of via
+  a Fritz!Box, the dongle used to announce the local media port it listens
+  on — which only reaches the caller if the router happens to keep that port
+  unchanged. It now looks up the public port its media actually leaves from
+  (via a STUN server, set automatically by the provider preset) and
+  announces that instead. Where the router assigns the port unpredictably,
+  the dongle detects it on start-up and the status page recommends the
+  one-line router port-forward that resolves it. The manual SIP settings
+  gained a matching "STUN server" field.
+
 ## Changed
 
 - **The status e-mail now lists the calls.** When the dongle caught spam
@@ -89,3 +100,11 @@
   line cut at the buffer limit could split a multi-byte character (an
   arrow, or an umlaut in a caller name) and corrupt the log panel. Lines
   are now always cut on a character boundary.
+
+- **Registration no longer renewed too late on a shared line.** When the
+  same number is also registered by the router's own telephony (common on a
+  Telekom line behind a Fritz!Box or Speedport), the dongle misread how long
+  its registration had been granted and renewed it only at the very end of
+  that window — a single slow renewal could then briefly drop incoming
+  calls. The dongle now picks its own registration out of the provider's
+  reply and reads its lifetime correctly, so it renews in good time.

--- a/phoneblock-dongle/firmware/test/test_sip_parse.c
+++ b/phoneblock-dongle/firmware/test/test_sip_parse.c
@@ -88,8 +88,15 @@ static void expect_reason(const char *expected, const char *resp)
 
 static void expect_register_expires(int expected, const char *resp)
 {
-    int got = parse_register_expires(resp, (int)strlen(resp));
+    int got = parse_register_expires(resp, (int)strlen(resp), NULL);
     report_int("parse_register_expires", resp, expected, got);
+}
+
+static void expect_register_expires_inst(int expected, const char *resp,
+                                         const char *instance)
+{
+    int got = parse_register_expires(resp, (int)strlen(resp), instance);
+    report_int("parse_register_expires(inst)", resp, expected, got);
 }
 
 static void expect_cseq(uint32_t expected, const char *req)
@@ -300,6 +307,63 @@ static void test_parse_register_expires(void)
     expect_register_expires(-1,
         "SIP/2.0 200 OK\r\n"
         "Expires: \r\n\r\n");
+
+    // --- Multi-binding disambiguation by +sip.instance (real field logs) ---
+
+    // Fritz!Box line: the FB's own native binding is listed FIRST with the
+    // long 3600 s lease; OUR dongle binding follows with only 1800 s. The
+    // old "first Contact wins" logic mis-read 3600 and refreshed too late.
+    const char *fb_resp =
+        "SIP/2.0 200 OK\r\n"
+        "From: <sip:+4970412875@tel.t-online.de>;tag=bab44de7256553c7\r\n"
+        "CSeq: 4 REGISTER\r\n"
+        "Call-ID: 5dbd8740@phoneblock\r\n"
+        "Contact: <sip:+4970412875@93.195.216.76:61632;uniq=A591F883F8F54013C560272D96A2896;user=phone;transport=tls>;expires=3600;+sip.instance=\"<urn:uuid:9139c396-82ea-64d4-284a-14c307513cdc>\"\r\n"
+        "Contact: <sip:+4970412875@93.195.216.76:15060>;expires=1800;+sip.instance=\"<urn:uuid:7097f5e2-c1a0-4986-9f96-dd9ec2b9b9ac>\"\r\n"
+        "Content-Length: 0\r\n\r\n";
+    expect_register_expires_inst(1800, fb_resp,
+        "7097f5e2-c1a0-4986-9f96-dd9ec2b9b9ac");
+    // Without the instance, the legacy behaviour still picks the first.
+    expect_register_expires(3600, fb_resp);
+
+    // Speedport line: three bindings; the native MMTel device holds 3600 s,
+    // both :15060 bindings (ours + a stale one) get 660 s. Ours is last.
+    const char *sp_resp =
+        "SIP/2.0 200 OK\r\n"
+        "CSeq: 3 REGISTER\r\n"
+        "Contact: <sip:+4944896042@84.182.185.55:15060>;expires=660;+sip.instance=\"<urn:uuid:9cfefa74-96fd-48c6-87fa-6e4e46a2f87e>\"\r\n"
+        "Contact: <sip:+4944896042@84.182.185.55:5060;user=phone>;expires=3600;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b86685933e15>\";+g.3gpp.icsi-ref=\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\";audio\r\n"
+        "Contact: <sip:+4944896042@84.182.185.55:15060>;expires=660;+sip.instance=\"<urn:uuid:43eb6d15-baf1-49c9-8759-885894880b66>\"\r\n"
+        "Content-Length: 0\r\n\r\n";
+    expect_register_expires_inst(660, sp_resp,
+        "43eb6d15-baf1-49c9-8759-885894880b66");
+
+    // Single binding (the common case): matched by instance.
+    expect_register_expires_inst(3600,
+        "SIP/2.0 200 OK\r\n"
+        "Contact: <sip:alice@host:15060>;expires=3600;+sip.instance=\"<urn:uuid:abcd>\"\r\n\r\n",
+        "abcd");
+
+    // Instance given but our binding is absent among several foreign ones:
+    // do NOT borrow a foreign lease — fall back to top-level Expires.
+    expect_register_expires_inst(900,
+        "SIP/2.0 200 OK\r\n"
+        "Contact: <sip:a@h:5060>;expires=3600;+sip.instance=\"<urn:uuid:1111>\"\r\n"
+        "Contact: <sip:a@h:5061>;expires=7200;+sip.instance=\"<urn:uuid:2222>\"\r\n"
+        "Expires: 900\r\n\r\n",
+        "deadbeef");
+    // ...and with no top-level Expires either → -1 (keep requested).
+    expect_register_expires_inst(-1,
+        "SIP/2.0 200 OK\r\n"
+        "Contact: <sip:a@h:5060>;expires=3600;+sip.instance=\"<urn:uuid:1111>\"\r\n"
+        "Contact: <sip:a@h:5061>;expires=7200;+sip.instance=\"<urn:uuid:2222>\"\r\n\r\n",
+        "deadbeef");
+
+    // A lone Contact without our instance is still taken as ours.
+    expect_register_expires_inst(1200,
+        "SIP/2.0 200 OK\r\n"
+        "Contact: <sip:a@h:5060>;expires=1200\r\n\r\n",
+        "7097f5e2-c1a0-4986-9f96-dd9ec2b9b9ac");
 }
 
 static void test_parse_cseq(void)


### PR DESCRIPTION
## Summary

Two fixes for **direct registration at a provider** (Telekom IMS), where the dongle shares the line with the router's own VoIP client.

### Registration lease (fix)
`parse_register_expires()` read the first `Contact` of the REGISTER 200 OK, but on a shared line the response echoes several bindings. It now matches our own `+sip.instance` to read *our* lease (a lone Contact is still taken as ours; several foreign ones never). Fixes the misreported grant — `1800` logged as `3600` behind a Fritz!Box — and the resulting too-late refresh. Host tests cover both real field-log responses.

### Media / NAT traversal (feature)
- Advertise the real **post-NAT RTP endpoint** in the SDP answer: a STUN query on the RTP socket replaces the blindly-advertised local port (which only reached the gateway when the router preserved it).
- **One-shot NAT mapping probe** at registration (RFC 5780: two STUN servers at different IPs, same socket) gates per-call STUN. Endpoint-dependent (symmetric) NAT skips STUN and warns that only a port-identical RTP forward — or a VoIP router — fixes audio.
- **Inbound-RTP diagnostic** line during the announcement.
- New `sip_stun` config field (empty = off), set by the provider presets (Telekom / 1&1 / sipgate) and editable in the manual form; status JSON + UI surface the configured server and the probed NAT mapping.

## Testing
- `idf.py build` green on this branch; host tests `test_sip_parse` 158/158 (incl. the two field-log multi-binding fixtures).
- Deployed to the on-hardware test rig (direct-Telekom dongle): re-registers correctly, NAT probe reports `endpoint-independent` on the Fritz!Box line, new status/UI fields render.

## Honest caveat
The test rig is the *working* Fritz!Box line (positive control) — this confirms no regression and that the mechanism + probe work end-to-end. It does **not** prove it fixes the original one-way-audio case behind a Speedport; that needs the firmware on the affected device, where `nat_mapping` would show `endpoint-dependent` and surface the port-forward advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
