### PR TITLE
Dongle: connect to hidden WiFi SSIDs (#458)

### DIFF
--- a/phoneblock-dongle/firmware/main/wifi.c
+++ b/phoneblock-dongle/firmware/main/wifi.c
@@ -259,27 +259,29 @@ static void on_wifi_event(void *arg, esp_event_base_t base, int32_t id, void *da
             // fields (threshold.authmode, pmf_cfg, sae_pwe_h2e, …)
             // needed to associate with the AP we just paired with.
             //
-            // For the single-AP case (ap_cred_cnt <= 1) we therefore
-            // do NOT touch sta_config — leaving the driver-populated
-            // version in place, which esp_wifi_set_storage(FLASH)
-            // also persists to NVS for the next boot. Earlier code
-            // here built a fresh wifi_config_t = {0} and copied only
-            // SSID/passphrase into it; that wiped the security
-            // fields, so on the next boot the STA loaded a config
-            // with no PMF capability, no auth-mode threshold, and
-            // got Reason 210 on every reconnect against any modern
-            // PMF-enabled AP. See recovery path above for the
-            // user-visible symptom.
+            // We read-modify-write that driver config rather than
+            // rebuilding it from scratch: get it first, change only the
+            // fields we must, set it back. Rebuilding a fresh
+            // wifi_config_t = {0} and copying only SSID/passphrase (as
+            // earlier code did) wiped the security fields, so on the
+            // next boot the STA loaded a config with no PMF capability,
+            // no auth-mode threshold, and got Reason 210 on every
+            // reconnect against any modern PMF-enabled AP. See the
+            // recovery path above for the user-visible symptom.
             //
-            // For the rare multi-AP case (ap_cred_cnt > 1) we still
-            // need to pick one credential set. We then read-modify-
-            // write: get the driver's cfg first, override only the
-            // SSID/passphrase fields, set it back. Security fields
-            // stay intact.
+            // Two things we override:
+            //  - scan_method → WIFI_ALL_CHANNEL_SCAN, so that if the AP
+            //    is hidden, the stored-credentials reconnect on the next
+            //    boot can still find it (a hidden SSID is invisible to
+            //    the default fast scan — see wifi_set_credentials() and
+            //    issue #458). The immediate post-WPS connect below is
+            //    unaffected; this matters for later reboots.
+            //  - for the rare multi-AP case (ap_cred_cnt > 1), the
+            //    SSID/passphrase, to pick one of the offered sets.
             wifi_event_sta_wps_er_success_t *evt = data;
-            if (evt && evt->ap_cred_cnt > 1) {
-                wifi_config_t cfg;
-                if (esp_wifi_get_config(WIFI_IF_STA, &cfg) == ESP_OK) {
+            wifi_config_t cfg;
+            if (esp_wifi_get_config(WIFI_IF_STA, &cfg) == ESP_OK) {
+                if (evt && evt->ap_cred_cnt > 1) {
                     memset(cfg.sta.ssid,     0, sizeof(cfg.sta.ssid));
                     memset(cfg.sta.password, 0, sizeof(cfg.sta.password));
                     memcpy(cfg.sta.ssid,
@@ -288,15 +290,16 @@ static void on_wifi_event(void *arg, esp_event_base_t base, int32_t id, void *da
                     memcpy(cfg.sta.password,
                            evt->ap_cred[0].passphrase,
                            sizeof(cfg.sta.password));
-                    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &cfg));
                     ESP_LOGI(TAG, "WPS success — picked SSID=%s of %d offered",
                              cfg.sta.ssid, evt->ap_cred_cnt);
                 } else {
-                    ESP_LOGW(TAG, "esp_wifi_get_config failed — "
-                                  "trusting driver-internal cfg");
+                    ESP_LOGI(TAG, "WPS success — credentials auto-persisted");
                 }
+                cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+                ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &cfg));
             } else {
-                ESP_LOGI(TAG, "WPS success — credentials auto-persisted");
+                ESP_LOGW(TAG, "esp_wifi_get_config failed — "
+                              "trusting driver-internal cfg");
             }
             ESP_ERROR_CHECK(esp_wifi_wps_disable());
             s_wps_active = false;
@@ -420,6 +423,15 @@ esp_err_t wifi_set_credentials(const char *ssid, const char *password)
                                           : WIFI_AUTH_OPEN;
     cfg.sta.pmf_cfg.capable    = true;
     cfg.sta.pmf_cfg.required   = false;
+    // A hidden AP omits its SSID from beacons, so the default
+    // WIFI_FAST_SCAN — which stops at the first beaconed SSID that
+    // matches — never locates it. WIFI_ALL_CHANNEL_SCAN runs a full
+    // active scan (directed probe requests across all channels), which
+    // is the only way to associate with a hidden SSID. There is no
+    // dedicated "hidden" flag in wifi_sta_config_t; scan_method is the
+    // lever. sort_method stays at its zero-init default
+    // (WIFI_CONNECT_AP_BY_SIGNAL). See issue #458.
+    cfg.sta.scan_method        = WIFI_ALL_CHANNEL_SCAN;
 
     // WIFI_STORAGE_FLASH persists this to NVS for the next boot.
     esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &cfg);
@@ -504,6 +516,9 @@ static void seed_baked_creds(void)
     cfg.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
     cfg.sta.pmf_cfg.capable    = true;
     cfg.sta.pmf_cfg.required   = false;
+    // Full active scan so a hidden SSID can be associated with — see the
+    // rationale in wifi_set_credentials() and issue #458.
+    cfg.sta.scan_method        = WIFI_ALL_CHANNEL_SCAN;
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &cfg));
 }
@@ -548,6 +563,21 @@ esp_err_t wifi_connect(void)
 
     if (have_stored) {
         ESP_LOGI(TAG, "using stored credentials (SSID=%s)", stored.sta.ssid);
+        // Credentials persisted by firmware that predates hidden-SSID
+        // support carry scan_method = WIFI_FAST_SCAN, which can't locate
+        // a hidden AP. Upgrade the persisted config in place so a device
+        // paired on old firmware still connects if its SSID is hidden
+        // after the update. Idempotent: only rewritten when it differs,
+        // so a config already on all-channel scan isn't touched. See
+        // issue #458.
+        if (stored.sta.scan_method != WIFI_ALL_CHANNEL_SCAN) {
+            stored.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+            esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &stored);
+            if (err != ESP_OK) {
+                ESP_LOGW(TAG, "failed to upgrade stored scan_method: %s",
+                         esp_err_to_name(err));
+            }
+        }
     } else if (have_baked) {
         ESP_LOGI(TAG, "seeding from baked credentials (SSID=%s)", BAKED_SSID);
         seed_baked_creds();

--- a/phoneblock-dongle/firmware/release-notes/1.5.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.5.0.md
@@ -52,12 +52,6 @@
   fresh connection before retrying when a previously established
   registration is refused, the way a normal phone recovers.
 
-- **The blocklist cache now refreshes reliably.** After the first
-  successful download, every later refresh failed with "rename: I/O error"
-  (regardless of free space), leaving the cache stale. The dongle now
-  swaps the updated list into place correctly, so the daily refresh works
-  every time.
-
 - **Fewer false alarms in the diagnostics log.** Routine, self-healing
   events no longer show up as warnings in the "Protokoll" panel: a
   re-REGISTER refresh that briefly times out while the existing

--- a/phoneblock-dongle/firmware/release-notes/1.5.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.5.0.md
@@ -4,6 +4,18 @@
 
 ## Added
 
+- **Local blocklist cache — the dongle now blocks most spam without asking
+  the server on every call.** Instead of a live query for each incoming
+  call, the dongle downloads the community blocklist (and your personal
+  one) to its own flash once a day and checks callers against that local
+  copy first; it only falls back to a live query when the local list has
+  no verdict yet. Calls are handled faster and keep being screened even
+  during a brief server or internet hiccup. A new "Blocklist cache" panel
+  shows the cache state and its last update, with a master on/off switch,
+  a "download now" button, and a wildcard-block toggle. Activating a token
+  triggers an immediate first download, so a freshly set-up dongle has a
+  usable cache within seconds rather than waiting for the next daily run.
+
 - **Connects to WiFi networks with a hidden SSID.** A network whose name
   is not broadcast could not be joined before — the dongle only connected
   once the SSID was made visible. It now performs a full scan across all
@@ -11,3 +23,44 @@
   network, so a dongle can be paired with a router that keeps its SSID
   hidden. This also covers a device that was already paired and later has
   its SSID hidden: the setting is applied automatically after the update.
+
+## Changed
+
+- **Block-threshold settings are now dropdowns.** The two "how many votes
+  block a call" controls offer the same fixed choices as the mobile app
+  (direct votes 2 / 4 / 10 / 20 / 50 / 100; range votes Off / 10 / 20 / 50
+  / 100 / 500) instead of free-form numbers. Besides matching the app, this
+  keeps the shared community cache from fragmenting into a separate encode
+  per unusual threshold pair. A non-standard value stored by older firmware
+  is shown as an extra option so the control never misrepresents the live
+  setting.
+
+- **A refused registration now says why.** When the provider rejects the
+  dongle's registration, the diagnostics panel used to show only a bare
+  code. It now includes the registrar's own reason and any retry hint —
+  e.g. "authentication rejected: 403 Forbidden – Registration limit
+  exceeded; Retry-After: 1800" — so a persistent rejection can be told
+  apart (lockout vs. bad contact vs. binding conflict) without attaching a
+  serial console.
+
+## Fixed
+
+- **Recovers from a stuck registration on a hybrid line.** On some Telekom
+  hybrid lines a renewal that had been working could start being refused
+  indefinitely over the same still-open connection, and the dongle would
+  keep re-registering over that wedged connection forever. It now opens a
+  fresh connection before retrying when a previously established
+  registration is refused, the way a normal phone recovers.
+
+- **The blocklist cache now refreshes reliably.** After the first
+  successful download, every later refresh failed with "rename: I/O error"
+  (regardless of free space), leaving the cache stale. The dongle now
+  swaps the updated list into place correctly, so the daily refresh works
+  every time.
+
+- **Fewer false alarms in the diagnostics log.** Routine, self-healing
+  events no longer show up as warnings in the "Protokoll" panel: a
+  re-REGISTER refresh that briefly times out while the existing
+  registration is still valid, and a web browser closing an idle
+  connection to the dongle's status page. Both are still visible on the
+  serial console for real debugging.

--- a/phoneblock-dongle/firmware/release-notes/1.5.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.5.0.md
@@ -1,0 +1,13 @@
+# PhoneBlock Dongle 1.5.0
+
+*2026-07-06*
+
+## Added
+
+- **Connects to WiFi networks with a hidden SSID.** A network whose name
+  is not broadcast could not be joined before — the dongle only connected
+  once the SSID was made visible. It now performs a full scan across all
+  channels when associating, which is what it takes to find a hidden
+  network, so a dongle can be paired with a router that keeps its SSID
+  hidden. This also covers a device that was already paired and later has
+  its SSID hidden: the setting is applied automatically after the update.


### PR DESCRIPTION
Fixes #458.

## Problem

The dongle would not connect to a WiFi network whose SSID is hidden. As soon as the SSID was made visible it connected immediately.

## Root cause

The STA config was zero-initialised, leaving `scan_method` at `WIFI_FAST_SCAN`. Fast scan stops at the first AP whose SSID appears in a beacon, but a hidden AP broadcasts an empty SSID, so the station never locates it. `WIFI_ALL_CHANNEL_SCAN` runs a full active scan (directed probe requests across all channels), which is the only way an ESP32 station associates with a hidden SSID — there is no dedicated "hidden" flag in `wifi_sta_config_t`.

## Fix

Set `scan_method = WIFI_ALL_CHANNEL_SCAN` in every path that establishes the STA config, so the setting is persisted to NVS and survives reboots:

- **`wifi_set_credentials()`** — Improv / browser-installer provisioning (the path the reporter used).
- **`seed_baked_creds()`** — baked-in credentials.
- **WPS success** — converted to a read-modify-write that overrides only `scan_method` (and, for the multi-AP case, the SSID/passphrase), preserving the driver-populated security fields that guard against the Reason-210 reconnect loop.
- **`wifi_connect()`** — upgrade an already-persisted config in place, so a device paired on firmware that predates this change still connects if its SSID is hidden after an OTA update. Idempotent: NVS is rewritten only when the stored value differs, so there is no per-boot flash write.

## Trade-off

All-channel scan slightly slows initial connect/reconnect for every dongle, hidden or not — the standard, accepted cost of hidden-AP support.

## Verification

- `idf.py build` → *Project build complete*, no warnings in `wifi.c`.
- No host-testable surface exists (pure ESP-IDF driver behavior); runtime confirmation needs an actual hidden-SSID AP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)