### PR TITLE
Dongle: runtime "quiet mode" for the status LED (#462)

### DIFF
--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -31,6 +31,7 @@ static const char *NS   = "phoneblock";
 #define K_SYNC_ENABLED  "sync_enabled"
 #define K_LOG_KNOWN     "log_known_calls"
 #define K_LOG_INFO      "log_info"
+#define K_LED_QUIET     "led_quiet"
 #define K_AUTH_ENABLED  "auth_enabled"
 #define K_AUTH_USER     "auth_user"
 #define K_AUTH_PERSIST  "auth_persist"
@@ -104,6 +105,7 @@ typedef struct {
     char sync_enabled[4];    // "1" | "0" (or empty = default off)
     char log_known[4];       // "1" | "0" (or empty = default on)
     char log_info[4];        // "1" = also mirror INFO lines to the log panel (default off)
+    char led_quiet[4];       // "1" = LED dark when READY (default off = solid on)
     char auth_enabled[4];    // "1" | "0" (or empty = default off)
     char auth_user[64];      // pinned PhoneBlock user-name; empty = no pin
     char auth_persist[33];   // 32 hex chars + NUL; empty = nobody is "remembered"
@@ -259,6 +261,7 @@ void config_load(void)
         s_config.sync_enabled[0]  = '\0';
         s_config.log_known[0]     = '\0';
         s_config.log_info[0]      = '\0';
+        s_config.led_quiet[0]     = '\0';
         s_config.auth_enabled[0]  = '\0';
         s_config.auth_user[0]     = '\0';
         s_config.auth_persist[0]  = '\0';
@@ -327,6 +330,8 @@ void config_load(void)
              s_config.log_known, sizeof(s_config.log_known));
     load_str(h, K_LOG_INFO, "",
              s_config.log_info, sizeof(s_config.log_info));
+    load_str(h, K_LED_QUIET, "",
+             s_config.led_quiet, sizeof(s_config.led_quiet));
     load_str(h, K_AUTH_ENABLED, "",
              s_config.auth_enabled, sizeof(s_config.auth_enabled));
     load_str(h, K_AUTH_USER, "",
@@ -420,6 +425,13 @@ bool        config_log_info(void)
     // the UI for troubleshooting, when the context that only INFO lines
     // carry (e.g. "registrar host:port") is needed. Only "1" enables it.
     return s_config.log_info[0] == '1';
+}
+bool        config_led_quiet(void)
+{
+    // Default off (empty / unrecognised → solid-on when READY, the
+    // original behaviour). Only an explicit "1" flips the LED to
+    // dark-when-fine; see the header for the full semantics.
+    return s_config.led_quiet[0] == '1';
 }
 bool        config_auth_enabled(void)
 {
@@ -672,6 +684,8 @@ esp_err_t config_update(const config_update_t *u)
                                         s_config.log_known, sizeof(s_config.log_known));
     if (err == ESP_OK) err = set_str_if(h, K_LOG_INFO, u->log_info,
                                         s_config.log_info, sizeof(s_config.log_info));
+    if (err == ESP_OK) err = set_str_if(h, K_LED_QUIET, u->led_quiet,
+                                        s_config.led_quiet, sizeof(s_config.led_quiet));
     if (err == ESP_OK) err = set_str_if(h, K_AUTH_ENABLED, u->auth_enabled,
                                         s_config.auth_enabled, sizeof(s_config.auth_enabled));
     if (err == ESP_OK) err = set_str_if(h, K_AUTH_USER, u->auth_user,

--- a/phoneblock-dongle/firmware/main/config.h
+++ b/phoneblock-dongle/firmware/main/config.h
@@ -92,6 +92,16 @@ bool        config_log_known_calls(void);
 // on, reproduced, read, and turned off again.
 bool        config_log_info(void);
 
+// Whether the status LED runs in "quiet mode". Default off — the LED is
+// solid-on in the READY state, as it always has been. When on, READY
+// instead leaves the LED *dark*: off now means "everything is fine", so
+// a lit/blinking LED unambiguously signals a problem (setup needed,
+// registration lost, token rejected, no connection). Only the READY
+// pattern changes; the fault states keep their existing blink/on
+// patterns, so the dongle still signals trouble visibly. Meant for
+// living-room installs where a permanently-lit LED is a nuisance.
+bool        config_led_quiet(void);
+
 // Whether the web UI requires "Login with PhoneBlock" before
 // showing call data or accepting setting changes. Default off —
 // during initial provisioning the LAN-local UI must be reachable
@@ -277,6 +287,9 @@ typedef struct {
     // "1" = also capture INFO log lines, "0" = only WARN/ERROR. NULL =
     // leave unchanged. Default when unset is "off".
     const char *log_info;
+    // "1" = status LED quiet mode (dark when READY), "0" = solid-on when
+    // READY. NULL = leave unchanged. Default when unset is "off".
+    const char *led_quiet;
     // "1" = require "Login with PhoneBlock" before serving the UI,
     // "0" = open access. NULL = leave unchanged. Default when the
     // key is unset is "open access" (setup phase).

--- a/phoneblock-dongle/firmware/main/status_led.c
+++ b/phoneblock-dongle/firmware/main/status_led.c
@@ -103,8 +103,14 @@ typedef struct {
     uint8_t  ticks;    // total ticks before the pattern wraps
 } pattern_t;
 
-static pattern_t pattern_for(led_state_t s)
+static pattern_t pattern_for(led_state_t s, bool quiet)
 {
+    // Quiet mode inverts only the READY signal: a healthy dongle keeps
+    // its LED dark, so any light at all means "look at me". The fault
+    // states below are left untouched — they must stay visible.
+    if (s == ST_READY && quiet) {
+        return (pattern_t){ .on_mask = 0x0, .ticks = 1 };
+    }
     switch (s) {
         case ST_PAIRING:
             // 100 ms on / 100 ms off  →  (on off) repeating every 4 ticks
@@ -158,15 +164,21 @@ static void led_task(void *arg)
              (unsigned)uxTaskGetStackHighWaterMark(NULL));
 
     led_state_t last_state = (led_state_t)-1;
-    pattern_t   pat        = pattern_for(ST_CONNECTING);
+    bool        last_quiet = false;
+    pattern_t   pat        = pattern_for(ST_CONNECTING, false);
     uint8_t     tick       = 0;
 
     while (1) {
-        led_state_t s = derive_state();
-        if (s != last_state) {
-            pat = pattern_for(s);
+        led_state_t s     = derive_state();
+        bool        quiet = config_led_quiet();
+        // Recompute on a quiet-mode toggle too, not just a state change:
+        // the user may flip the setting while the dongle sits in READY,
+        // when the state itself never changes.
+        if (s != last_state || quiet != last_quiet) {
+            pat = pattern_for(s, quiet);
             tick = 0;
             last_state = s;
+            last_quiet = quiet;
         }
         bool on = (pat.on_mask >> tick) & 0x1u;
         int level = active_low ? !on : on;

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -427,6 +427,9 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON *lg = cJSON_AddObjectToObject(root, "log");
     cJSON_AddBoolToObject  (lg,   "capture_info", config_log_info());
 
+    cJSON *led = cJSON_AddObjectToObject(root, "led");
+    cJSON_AddBoolToObject  (led,  "quiet",        config_led_quiet());
+
     cJSON *au = cJSON_AddObjectToObject(root, "auth");
     cJSON_AddBoolToObject  (au,   "enabled",     config_auth_enabled());
     cJSON_AddBoolToObject  (au,   "logged_in",   web_auth_is_logged_in(req));
@@ -596,6 +599,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     char sync_en_s[4]     = "";
     char log_known_s[4]   = "";
     char log_info_s[4]    = "";
+    char led_quiet_s[4]   = "";
     char auto_update_s[4] = "";
     char channel_s[8]     = "";
     char crash_rep_s[4]   = "";
@@ -633,6 +637,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
     bool have_sync_en   = form_get(body, "sync_enabled",  sync_en_s,    sizeof(sync_en_s));
     bool have_log_known = form_get(body, "log_known_calls", log_known_s, sizeof(log_known_s));
     bool have_log_info  = form_get(body, "log_info", log_info_s, sizeof(log_info_s));
+    bool have_led_quiet = form_get(body, "led_quiet", led_quiet_s, sizeof(led_quiet_s));
     bool have_auto_upd  = form_get(body, "auto_update",   auto_update_s, sizeof(auto_update_s));
     bool have_channel   = form_get(body, "channel",       channel_s,     sizeof(channel_s));
     bool have_crash_rep = form_get(body, "crash_report",  crash_rep_s,   sizeof(crash_rep_s));
@@ -741,6 +746,7 @@ static esp_err_t handle_config_post(httpd_req_t *req)
         .sync_enabled    = have_sync_en   ? sync_en_s    : NULL,
         .log_known_calls = have_log_known ? log_known_s  : NULL,
         .log_info        = have_log_info  ? log_info_s   : NULL,
+        .led_quiet       = have_led_quiet ? led_quiet_s  : NULL,
         .auto_update     = have_auto_upd  ? auto_update_s : NULL,
         .ota_channel     = channel,
         .crash_report    = have_crash_rep ? crash_rep_s   : NULL,

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -176,6 +176,8 @@ const I18N = {
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack frei',
+    'status.system.led_quiet': 'LED nur bei Problemen leuchten lassen',
+    'status.system.led_quiet.hint': 'Normalerweise leuchtet die LED dauerhaft, wenn alles in Ordnung ist. Mit dieser Option bleibt sie im Normalbetrieb aus und leuchtet oder blinkt nur, wenn ein Problem vorliegt (Einrichtung nötig, keine Registrierung, Token ungültig, keine Verbindung). Praktisch im Wohnzimmer.',
     'status.clock.now': 'Uhrzeit: {time}',
     'status.clock.pending': 'Uhrzeit: wird synchronisiert …',
     'status.time.today': 'heute {time}',
@@ -457,6 +459,8 @@ const I18N = {
     'status.system.col.task': 'Task',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Stack free',
+    'status.system.led_quiet': 'Only light the LED when there is a problem',
+    'status.system.led_quiet.hint': 'Normally the LED stays lit while everything is fine. With this option it stays dark in normal operation and only lights or blinks when there is a problem (setup needed, not registered, token rejected, no connection). Handy in a living room.',
     'status.clock.now': 'Time: {time}',
     'status.clock.pending': 'Time: synchronising …',
     'status.time.today': 'today {time}',
@@ -725,6 +729,8 @@ const I18N = {
     'status.system.col.task': 'Tâche',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pile libre',
+    'status.system.led_quiet': 'N’allumer la LED qu’en cas de problème',
+    'status.system.led_quiet.hint': 'Normalement la LED reste allumée quand tout va bien. Avec cette option elle reste éteinte en fonctionnement normal et ne s’allume ou ne clignote qu’en cas de problème (configuration requise, non enregistré, jeton refusé, pas de connexion). Pratique dans un salon.',
     'status.time.today': "aujourd'hui {time}",
     'status.time.yesterday': 'hier {time}',
     'status.errors.title': 'Journal',
@@ -986,6 +992,8 @@ const I18N = {
     'status.system.col.task': 'Tarea',
     'status.system.col.cpu': 'CPU',
     'status.system.col.stack': 'Pila libre',
+    'status.system.led_quiet': 'Encender el LED solo cuando haya un problema',
+    'status.system.led_quiet.hint': 'Normalmente el LED permanece encendido cuando todo está bien. Con esta opción se queda apagado en funcionamiento normal y solo se enciende o parpadea cuando hay un problema (configuración necesaria, sin registrar, token rechazado, sin conexión). Útil en el salón.',
     'status.time.today': 'hoy {time}',
     'status.time.yesterday': 'ayer {time}',
     'status.errors.title': 'Registro',
@@ -1589,6 +1597,11 @@ function renderStatus(){
     + '<th style="text-align:right">'  + esc(t('status.system.col.cpu'))   + '</th>'
     + '<th style="text-align:right">'  + esc(t('status.system.col.stack')) + '</th>'
     + '</tr></thead><tbody id="systemTasks"></tbody></table>'
+    + '<label style="display:flex;align-items:center;gap:.4rem;font-weight:normal;margin-top:.9rem;font-size:.85rem">'
+    +   '<input type="checkbox" id="ledQuietChk" style="width:auto">'
+    +   '<span>' + esc(t('status.system.led_quiet')) + '</span></label>'
+    + '<p class="muted" style="font-size:.72rem;margin:.2rem 0 0">'
+    +   esc(t('status.system.led_quiet.hint')) + '</p>'
     + '</details>'
     + '<details id="thresholdsSection" class="adminsec" style="display:none">'
     + '<summary>' + esc(t('status.thresholds.title')) + '</summary>'
@@ -2592,6 +2605,25 @@ async function refreshAll(){
     logChk.onchange = async () => {
       const body = new URLSearchParams();
       body.append('log_info', logChk.checked ? '1' : '0');
+      try {
+        await fetch('/api/config', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+          body: body.toString(),
+        });
+      } catch (_){ /* next poll reconciles */ }
+      refreshAll();
+    };
+  }
+
+  // Status-LED quiet mode. Reflect the stored state on every poll;
+  // persist via /api/config on change.
+  const ledQuietChk = $('ledQuietChk');
+  if (ledQuietChk){
+    ledQuietChk.checked = !!(s.led && s.led.quiet);
+    ledQuietChk.onchange = async () => {
+      const body = new URLSearchParams();
+      body.append('led_quiet', ledQuietChk.checked ? '1' : '0');
       try {
         await fetch('/api/config', {
           method: 'POST',

--- a/phoneblock-dongle/firmware/release-notes/1.5.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.5.0.md
@@ -24,6 +24,14 @@
   hidden. This also covers a device that was already paired and later has
   its SSID hidden: the setting is applied automatically after the update.
 
+- **A quiet mode for the status LED.** For a dongle sitting in the living
+  room, a permanently-lit status LED can be a nuisance. The System panel
+  now has a "only light the LED when there is a problem" switch: with it
+  on, the LED stays dark while everything is fine and only lights or blinks
+  when something needs attention (setup missing, not registered, token
+  rejected, no connection). Off — the default — keeps the familiar
+  behaviour of a steady light meaning "up and running".
+
 ## Changed
 
 - **Block-threshold settings are now dropdowns.** The two "how many votes


### PR DESCRIPTION
Closes #462.

## What

Adds a runtime **"quiet mode"** for the dongle's status LED. Default behaviour is unchanged (LED solid-on in the `READY` state). When quiet mode is enabled, `READY` instead leaves the LED **dark** — so *off = everything is fine*, and any light or blink unambiguously signals a problem.

This addresses the living-room-nuisance request from discussion #459: the LED stops being permanently lit during normal operation, but still signals trouble visibly.

## How

Only the `READY` pattern changes. The fault states — setup needed (`ST_SETUP`), registration lost / token rejected (`ST_DEGRADED`), no connection (`ST_CONNECTING`), WPS pairing (`ST_PAIRING`) — keep their existing blink/on patterns, so faults remain visible.

Implemented as a new `led_quiet` NVS flag, following the existing `log_info` toggle end-to-end:

- `config.c` / `config.h` — NVS key, cache field, load/reset, `config_led_quiet()` getter, `config_update` write. Default off.
- `status_led.c` — `pattern_for()` takes a `quiet` flag and returns an all-off pattern for `ST_READY` when quiet. `led_task` recomputes on a quiet-mode toggle too, so flipping the setting while sitting in `READY` takes effect immediately (not just on the next state change).
- `web.c` — `led.quiet` in `/api/status`; `led_quiet` accepted in `/api/config`.
- `web/index.html` — checkbox + hint in the *System* card, wired like the INFO-log toggle, with de/en/fr/es strings.

## Verification

- `idf.py build` — clean.
- Host test suite (`make test`) — 8 passed, 0 failed.
- **On real hardware** (flashed to the test dongle): after reboot `/api/status` reports `led.quiet: false`; `POST led_quiet=1` → `true`; `POST led_quiet=0` → `false`. Full config round-trip confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
