### PR TITLE
Dongle: skip wildcard & non-E.164 sync entries instead of rating them (#469)

### DIFF
--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
+    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/phone_norm.c
+++ b/phoneblock-dongle/firmware/main/phone_norm.c
@@ -1,0 +1,49 @@
+#include "phone_norm.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+// True if `s` is non-empty and every character is an ASCII digit.
+static bool all_digits(const char *s)
+{
+    if (!*s) return false;
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9') return false;
+    }
+    return true;
+}
+
+phone_class_t phone_normalise(const char *in, char *out, size_t cap)
+{
+    if (cap == 0) return PHONE_SKIP;
+    out[0] = '\0';
+    if (!in || !*in) return PHONE_SKIP;
+
+    // Wildcard barring patterns (e.g. "+43*", "08*") are a local blocklist
+    // concept, not a concrete number to report — never rate them.
+    if (strchr(in, '*')) return PHONE_SKIP;
+
+    if (in[0] == '+') {
+        // Already E.164; keep as-is once we've confirmed digits follow.
+        if (!all_digits(in + 1)) return PHONE_SKIP;
+        strncpy(out, in, cap - 1);
+        out[cap - 1] = '\0';
+        return PHONE_RATEABLE;
+    }
+    if (in[0] == '0' && in[1] == '0') {
+        if (!all_digits(in + 2)) return PHONE_SKIP;
+        snprintf(out, cap, "+%s", in + 2);
+        return PHONE_RATEABLE;
+    }
+    if (in[0] == '0') {
+        if (!all_digits(in + 1)) return PHONE_SKIP;
+        snprintf(out, cap, "+49%s", in + 1);
+        return PHONE_RATEABLE;
+    }
+
+    // Bare number with no country context (e.g. "1727905225"): we cannot
+    // reliably turn it into E.164, and the raw value is rejected by the
+    // server — skip rather than forward garbage.
+    return PHONE_SKIP;
+}

--- a/phoneblock-dongle/firmware/main/phone_norm.h
+++ b/phoneblock-dongle/firmware/main/phone_norm.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stddef.h>
+
+// Normalisation of Fritz!Box call-barring entries into a form the
+// PhoneBlock /api/rate endpoint accepts. Extracted from sync.c as a pure,
+// host-testable unit (see test/test_phone_norm.c) — issue #469.
+//
+// The server accepts neither a wildcard barring pattern (e.g. "+43*") nor
+// a non-E.164 number (e.g. "1727905225"); both used to be forwarded
+// verbatim, rejected with HTTP 400, kept in the box and retried on every
+// sync run, flooding the log ring. The classification below lets the sync
+// path drop such entries *before* they reach the network.
+
+typedef enum {
+    // `out` holds a normalised E.164 number ("+49…") safe to submit.
+    PHONE_RATEABLE = 0,
+    // Wildcard pattern or a value that cannot be normalised to E.164 —
+    // must not be sent to /api/rate. `out` is left empty.
+    PHONE_SKIP,
+} phone_class_t;
+
+// Classify and, when rateable, normalise `in` into `out` (capacity `cap`,
+// always NUL-terminated). Rules:
+//   - empty / NULL                → PHONE_SKIP
+//   - contains '*' (wildcard)     → PHONE_SKIP
+//   - "+<digits>"                 → passed through (already E.164)
+//   - "00<digits>"               → "+<digits>"
+//   - "0<digits>"                → "+49<digits>" (German national)
+//   - bare "<digits>" (no + / 0)  → PHONE_SKIP (no country context)
+//   - any non-digit in the number part → PHONE_SKIP
+phone_class_t phone_normalise(const char *in, char *out, size_t cap);

--- a/phoneblock-dongle/firmware/main/sync.c
+++ b/phoneblock-dongle/firmware/main/sync.c
@@ -15,6 +15,7 @@
 #include "api.h"
 #include "config.h"
 #include "http_util.h"
+#include "phone_norm.h"
 #include "scheduler.h"
 #include "stats.h"
 #include "tr064.h"
@@ -36,15 +37,17 @@ static void set_status_running(bool running)
     xSemaphoreGive(s_lock);
 }
 
-static void set_status_result(bool ok, int pushed, int failed, const char *err)
+static void set_status_result(bool ok, int pushed, int failed, int skipped,
+                              const char *err)
 {
     xSemaphoreTake(s_lock, portMAX_DELAY);
-    s_status.ever_ran    = true;
-    s_status.last_ok     = ok;
-    s_status.running     = false;
-    s_status.last_at_us  = esp_timer_get_time();
-    s_status.last_pushed = pushed;
-    s_status.last_failed = failed;
+    s_status.ever_ran     = true;
+    s_status.last_ok      = ok;
+    s_status.running      = false;
+    s_status.last_at_us   = esp_timer_get_time();
+    s_status.last_pushed  = pushed;
+    s_status.last_failed  = failed;
+    s_status.last_skipped = skipped;
     if (err) {
         strncpy(s_status.last_error, err, sizeof(s_status.last_error) - 1);
         s_status.last_error[sizeof(s_status.last_error) - 1] = '\0';
@@ -109,29 +112,11 @@ static int http_get_to_buf(const char *url, char *buf, int cap)
 // can exercise the real AVM XML shapes. sync.c only glues the
 // callback plus per-entry PhoneBlock submission around it.
 
-// Convert what we read from the Fritz!Box into a form the PhoneBlock
-// /api/rate endpoint accepts. The server is lenient but prefers +49…
-// E.164. "00…" → "+…", leading-zero national → "+49…". Anything
-// already starting with "+" or "*" is passed through.
-static void normalise_phone(const char *in, char *out, size_t cap)
-{
-    if (!in || !*in) { out[0] = '\0'; return; }
-    if (in[0] == '+' || in[0] == '*') {
-        strncpy(out, in, cap - 1);
-        out[cap - 1] = '\0';
-        return;
-    }
-    if (in[0] == '0' && in[1] == '0') {
-        snprintf(out, cap, "+%s", in + 2);
-        return;
-    }
-    if (in[0] == '0') {
-        snprintf(out, cap, "+49%s", in + 1);
-        return;
-    }
-    strncpy(out, in, cap - 1);
-    out[cap - 1] = '\0';
-}
+// Normalisation of a Fritz!Box call-barring entry into the E.164 form the
+// PhoneBlock /api/rate endpoint accepts now lives in phone_norm.c, so it
+// can be exercised by the host test suite. Wildcards ("+43*") and bare
+// non-E.164 numbers are classified PHONE_SKIP and never reach the network
+// (issue #469) — sending them produced HTTP 400s retried on every run.
 
 typedef struct {
     const char *host;
@@ -139,14 +124,21 @@ typedef struct {
     const char *app_pass;
     int pushed;
     int failed;
+    int skipped;
 } run_ctx_t;
 
 static void process_contact(const char *uid, const char *number, void *user)
 {
     run_ctx_t *c = user;
     char normalised[48];
-    normalise_phone(number, normalised, sizeof(normalised));
-    if (!normalised[0]) { c->failed++; return; }
+    if (phone_normalise(number, normalised, sizeof(normalised)) != PHONE_RATEABLE) {
+        // Wildcard or non-normalisable entry — leave it in the Fritz!Box
+        // silently. Deliberately not WARN: it recurs every sync run and
+        // would flush the 32-entry log ring (issue #469). The run summary
+        // reports the aggregate skip count at INFO.
+        c->skipped++;
+        return;
+    }
 
     if (!phoneblock_rate(normalised, "B_MISSED", NULL)) {
         ESP_LOGW(TAG, "rate failed for %s, keeping in Fritz!Box", normalised);
@@ -179,12 +171,12 @@ static void run_once(void)
     const char *app_pass = config_fritzbox_app_pass();
     if (!host[0] || !app_user[0] || !app_pass[0]) {
         ESP_LOGI(TAG, "sync skipped — no Fritz!Box app credentials");
-        set_status_result(false, 0, 0, "not set up for Fritz!Box");
+        set_status_result(false, 0, 0, 0, "not set up for Fritz!Box");
         return;
     }
     if (strlen(config_phoneblock_token()) == 0) {
         ESP_LOGI(TAG, "sync skipped — no PhoneBlock token");
-        set_status_result(false, 0, 0, "no PhoneBlock token");
+        set_status_result(false, 0, 0, 0, "no PhoneBlock token");
         return;
     }
     // The config_sync_enabled() gate is applied in the task loop
@@ -206,21 +198,21 @@ static void run_once(void)
         char msg[80];
         snprintf(msg, sizeof(msg), "list: %.60s",
                  detail[0] ? detail : "network");
-        set_status_result(false, 0, 0, msg);
+        set_status_result(false, 0, 0, 0, msg);
         return;
     }
 
     ESP_LOGI(TAG, "GET %s", url);
     char *xml = malloc(8192);
     if (!xml) {
-        set_status_result(false, 0, 0, "out of memory");
+        set_status_result(false, 0, 0, 0, "out of memory");
         return;
     }
     int len = http_get_to_buf(url, xml, 8192);
     if (len <= 0) {
         ESP_LOGE(TAG, "list download failed (len=%d)", len);
         free(xml);
-        set_status_result(false, 0, 0, "list download failed");
+        set_status_result(false, 0, 0, 0, "list download failed");
         return;
     }
     ESP_LOGI(TAG, "phonebook XML: %d bytes", len);
@@ -232,15 +224,18 @@ static void run_once(void)
 
     run_ctx_t ctx = {
         .host = host, .app_user = app_user, .app_pass = app_pass,
-        .pushed = 0, .failed = 0,
+        .pushed = 0, .failed = 0, .skipped = 0,
     };
     int total = tr064_parse_phonebook_contacts(xml, len,
                                                 process_contact, &ctx);
     free(xml);
-    ESP_LOGI(TAG, "sync done: %d contacts, %d pushed, %d failed",
-             total, ctx.pushed, ctx.failed);
+    ESP_LOGI(TAG, "sync done: %d contacts, %d pushed, %d failed, %d skipped",
+             total, ctx.pushed, ctx.failed, ctx.skipped);
 
-    set_status_result(ctx.failed == 0, ctx.pushed, ctx.failed, NULL);
+    // Skipped (unrateable) entries are not failures — a run with only
+    // skips still reports ok, so the dashboard doesn't flag it red.
+    set_status_result(ctx.failed == 0, ctx.pushed, ctx.failed, ctx.skipped,
+                      NULL);
 }
 
 void sync_run(bool manual)

--- a/phoneblock-dongle/firmware/main/sync.h
+++ b/phoneblock-dongle/firmware/main/sync.h
@@ -34,6 +34,7 @@ typedef struct {
     int64_t last_at_us;      // esp_timer when the last attempt finished
     int     last_pushed;     // count of entries successfully submitted
     int     last_failed;     // count of entries that errored on push or delete
+    int     last_skipped;    // count of unrateable entries (wildcard / non-E.164) left in place
     char    last_error[64];  // short diagnostic, empty on success
 } sync_status_t;
 

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -399,6 +399,7 @@ static esp_err_t handle_status(httpd_req_t *req)
     cJSON_AddNumberToObject(syn, "last_ago_s", (double)ago_s);
     cJSON_AddNumberToObject(syn, "last_pushed", ss.last_pushed);
     cJSON_AddNumberToObject(syn, "last_failed", ss.last_failed);
+    cJSON_AddNumberToObject(syn, "last_skipped", ss.last_skipped);
     cJSON_AddStringToObject(syn, "last_error", ss.last_error);
 
     cJSON *bl = cJSON_AddObjectToObject(root, "blocklist");

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -25,6 +25,9 @@ test_sip_auth: test_sip_auth.c ../main/sip_auth.c ../main/sip_auth.h
 
 test_tr064_parse: test_tr064_parse.c ../main/tr064_parse.c ../main/tr064_parse.h
 	$(CC) $(CFLAGS) test_tr064_parse.c ../main/tr064_parse.c -o $@
+
+test_phone_norm: test_phone_norm.c ../main/phone_norm.c ../main/phone_norm.h
+	$(CC) $(CFLAGS) test_phone_norm.c ../main/phone_norm.c -o $@
 
 test_log_capture: test_log_capture.c ../main/log_capture.c ../main/log_capture.h
 	$(CC) $(CFLAGS) test_log_capture.c ../main/log_capture.c -o $@

--- a/phoneblock-dongle/firmware/test/test_phone_norm.c
+++ b/phoneblock-dongle/firmware/test/test_phone_norm.c
@@ -1,0 +1,93 @@
+// Host-side tests for the call-barring phone normaliser (phone_norm.c).
+// No ESP-IDF dependencies — plain gcc build, see Makefile.
+//
+// Guards issue #469: wildcards and non-E.164 barring entries must be
+// classified PHONE_SKIP so they are never forwarded to /api/rate.
+
+#include <stdio.h>
+#include <string.h>
+
+#include "phone_norm.h"
+
+static int failures = 0;
+
+#define CHECK(cond) do {                                                  \
+    if (!(cond)) {                                                        \
+        fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);   \
+        failures++;                                                       \
+    }                                                                     \
+} while (0)
+
+// Expect PHONE_RATEABLE with `in` normalising to `expected`.
+static void ok(const char *in, const char *expected)
+{
+    char out[48];
+    strcpy(out, "sentinel");
+    phone_class_t cls = phone_normalise(in, out, sizeof(out));
+    if (cls != PHONE_RATEABLE) {
+        fprintf(stderr, "FAIL %s: expected RATEABLE, got SKIP\n", in);
+        failures++;
+        return;
+    }
+    if (strcmp(out, expected) != 0) {
+        fprintf(stderr, "FAIL %s: got \"%s\", expected \"%s\"\n",
+                in, out, expected);
+        failures++;
+    }
+}
+
+// Expect PHONE_SKIP and an emptied output buffer.
+static void skip(const char *in)
+{
+    char out[48];
+    strcpy(out, "sentinel");
+    phone_class_t cls = phone_normalise(in, out, sizeof(out));
+    if (cls != PHONE_SKIP) {
+        fprintf(stderr, "FAIL %s: expected SKIP, got RATEABLE (\"%s\")\n",
+                in, out);
+        failures++;
+        return;
+    }
+    if (out[0] != '\0') {
+        fprintf(stderr, "FAIL %s: SKIP must empty out, got \"%s\"\n", in, out);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    // --- normalisation of valid entries ---------------------------------
+    ok("+4930123456", "+4930123456");   // already E.164, passed through
+    ok("004930123456", "+4930123456");  // 00 international prefix → +
+    ok("030123456", "+4930123456");     // leading-zero German national → +49
+    // Real-world numbers from the tr064_parse fixtures.
+    ok("069200940084", "+4969200940084");
+    ok("030330759014", "+4930330759014");
+
+    // --- wildcards (issue #469) -----------------------------------------
+    skip("+43*");    // trailing wildcard on a country code
+    skip("+8*");
+    skip("08*");     // national wildcard
+    skip("*");       // bare wildcard
+
+    // --- bare non-E.164 numbers (issue #469) ----------------------------
+    skip("1727905225");   // no +/0 prefix — no country context
+    skip("2166123456");
+    skip("800123456");
+
+    // --- malformed / empty ----------------------------------------------
+    skip("");
+    skip(NULL);
+    skip("+");            // '+' with no digits
+    skip("00");           // "00" with no digits
+    skip("0");            // "0" with no digits
+    skip("+49 30 123");   // spaces are not digits
+    skip("0049abc");      // non-digit tail
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("OK — all phone_norm tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #469.

## Problem

The dongle's Fritz!Box call-barring sync forwarded **wildcard** patterns (`+43*`) and **bare non-E.164** numbers (`1727905225`) verbatim to `POST /api/rate`. The server rejects both with **HTTP 400**, the entry is kept in the Fritz!Box, and — with nothing marking it as permanently unrateable — it is **retried on every sync run forever**. Production logs showed 66× `api: rate: HTTP 400` in a ~24 h window, each flushing the 32-entry error log ring (against the "don't WARN things that recur" convention in `firmware/CLAUDE.md`).

## Fix

Filter unrateable entries on the **client**, before they reach the network:

- **New host-tested module `main/phone_norm.{c,h}`** — `phone_normalise()` classifies an entry as `PHONE_RATEABLE` (normalised to E.164 in `out`) or `PHONE_SKIP`. Skips anything containing `*` (wildcard) and bare numbers with no `+`/`00`/`0` prefix (no country context); keeps and validates the `00…→+…`, `0…→+49…`, `+…` cases as digit-only.
- **`sync.c`** — `process_contact` skips `PHONE_SKIP` entries into a new `skipped` tally, reported only in the run summary at **INFO** — never a per-entry WARN — so unrateable entries left in the box no longer flush the log ring. A skip-only run still reports `ok` (skips are not failures).
- **`sync.h` / `web.c`** — expose `last_skipped` in the status snapshot and the `/api/status` sync JSON (diagnostics).
- **`test/test_phone_norm.c`** — covers normalisation, all wildcard shapes, bare non-E.164 skips, the real-world `069…`/`030…` fixtures, and malformed inputs.

### Scope note (issue point 3)

The issue also suggested treating HTTP 400 as a permanent rejection (parking entries in NVS). That isn't needed for any of the documented cases: every value that produced a 400 in the evidence (wildcards, non-E.164) is now skipped **before** it is sent, so the recurring flood is eliminated at the source without persistent state.

## Verification

- Host suite `cd phoneblock-dongle/firmware/test && make test` — **8 passed, 0 failed** (incl. new `test_phone_norm`).
- Full `idf.py build` — success, no warnings on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)