### PR TITLE
Register third-party app "Kallm" (iOS call blocker)

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -97,6 +97,8 @@ Before integrating, you need to register your app with PhoneBlock to receive an 
 **Current Registered Apps:**
 - `PhoneBlockMobile` → Redirects to `PhoneBlockMobile://auth`
 - `PhoneSpamBlocker` → Redirects to `PhoneSpamBlocker://auth`
+- `SpamBlocker` → Redirects to `spamblocker://auth`
+- `kallm` → Redirects to `kallm://phoneblock-auth` (iOS CallKit call blocker for Italy; `state` round-tripped for CSRF protection)
 
 ### Step 5: Token Reception
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/CreateAuthTokenServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/CreateAuthTokenServlet.java
@@ -119,6 +119,12 @@ public class CreateAuthTokenServlet extends HttpServlet {
 				redirectUrl = ServletUtil.withParam(redirectUrl,
 					STATE, req.getParameter(STATE));
 				break;
+			case "kallm":
+				redirectUrl = ServletUtil.withParam("kallm://phoneblock-auth",
+					TOKEN_PARAM, loginToken.getToken());
+				redirectUrl = ServletUtil.withParam(redirectUrl,
+					STATE, req.getParameter(STATE));
+				break;
 			case APP_ID_DONGLE:
 				redirectUrl = ServletUtil.withParam(callback,
 					TOKEN_PARAM, loginToken.getToken());

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/controller/StatsController.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/controller/StatsController.java
@@ -135,7 +135,8 @@ public class StatsController extends DefaultController {
 			"SpamBlocker", "SpamBlocker",
 			"FRITZOS_CardDAV_Client", "Fritz!Box",
 			"PhoneBlockMobile", "PhoneBlock Mobile",
-			"PhoneSpamBlocker", "PhoneSpamBlocker");
+			"PhoneSpamBlocker", "PhoneSpamBlocker",
+			"kallm", "Kallm");
 		colorIndex = 0;
 		boolean firstDataset = true;
 		for (Map.Entry<String, List<Integer>> entry : perAgentData.entrySet()) {


### PR DESCRIPTION
Registers the **Kallm** iOS app as a third-party OAuth integration, so it can obtain per-user API tokens through the standard `/create-token` login flow.

## App details
- **App name:** Kallm
- **Platform:** iOS (CallKit Call Directory + Unwanted Communication extension)
- **Bundle identifier:** `app.kallm`
- **appId:** `kallm`
- **Redirect URI scheme:** `kallm://phoneblock-auth`
- **Description:** Minimal, privacy-first call blocker for Italy. Blocks or labels spam numbers on-device using a community blocklist. Users can report unwanted calls back to PhoneBlock via `POST /api/rate` (each user with their own token via the OAuth flow).

## Changes
- **`CreateAuthTokenServlet`** — new `case "kallm"` in the redirect switch, issuing the token back to `kallm://phoneblock-auth?loginToken=…`. Modeled on the `SpamBlocker` flow, it round-trips the CSRF `state` parameter (safe no-op if the app omits it), which suits an iOS OAuth deep-link flow.
- **`StatsController`** — maps the `kallm` User-Agent prefix to the display label `Kallm` so Kallm installations appear as a named series in the per-agent stats chart.
- **`INTEGRATIONS.md`** — adds Kallm to the *Current Registered Apps* list (and documents the previously-missing `SpamBlocker` entry).

## Notes
- The `POST /api/rate` reporting already works with any issued bearer token, so no code was needed for it — captured in docs/commit metadata instead.
- The callback host is `phoneblock-auth`, unlike the `://auth` convention used by the other registered apps; used exactly as supplied.

## Verification
Java compiles cleanly (both changed classes build). The WAR packaging step fails only because the Flutter UI output (`phoneblock_answerbot_ui/build/web`) isn't built in this workspace — a pre-existing environmental issue unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #477 