### PR TITLE
Fix /api/rate & search 500s: block-aggregation race + contention

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/analysis/NumberAnalyzer.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/analysis/NumberAnalyzer.java
@@ -82,7 +82,7 @@ public class NumberAnalyzer {
 	 * Removes grouping characters from the given phone number.
 	 */
 	public static String normalizeNumber(String phoneNumber) {
-		return NORMALIZE_PATTERN.matcher(phoneNumber).replaceAll("");
+		return NORMALIZE_PATTERN.matcher(phoneNumber.strip()).replaceAll("");
 	}
 
 	/**

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/RateServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/RateServlet.java
@@ -5,6 +5,9 @@ package de.haumacher.phoneblock.app.api;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.haumacher.msgbuf.json.JsonReader;
 import de.haumacher.msgbuf.server.io.ReaderAdapter;
 import de.haumacher.phoneblock.analysis.NumberAnalyzer;
@@ -25,8 +28,23 @@ import jakarta.servlet.http.HttpServletResponse;
  */
 @WebServlet(urlPatterns = RateServlet.PATH)
 public class RateServlet extends HttpServlet {
-	
+
+	private static final Logger LOG = LoggerFactory.getLogger(RateServlet.class);
+
 	public static final String PATH = "/api/rate";
+
+	@Override
+	protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		try {
+			super.service(req, resp);
+		} catch (Exception ex) {
+			LOG.error("Request failed.", ex);
+
+			String message = ex.getMessage();
+			ServletUtil.sendMessage(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+				ex.getClass().getName() + (message == null ? "" : ": " + message));
+		}
+	}
 
 	@Override
 	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/DefaultController.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/DefaultController.java
@@ -175,8 +175,15 @@ public class DefaultController implements WebController {
     		if (acceptLanguageHeader == null) {
 				locale = null;
     		} else {
-    			List<LanguageRange> acceptLanguage = LanguageRange.parse(acceptLanguageHeader);
-    			locale = Locale.lookup(acceptLanguage, Language.supportedLocales());
+    			try {
+    				List<LanguageRange> acceptLanguage = LanguageRange.parse(acceptLanguageHeader);
+    				locale = Locale.lookup(acceptLanguage, Language.supportedLocales());
+    			} catch (IllegalArgumentException ex) {
+    				// A malformed Accept-Language header (e.g. "en=0.9;q=0.9") makes LanguageRange.parse
+    				// throw; fall back to the default language rather than failing the whole request.
+    				LOG.warn("Ignoring malformed Accept-Language header '{}': {}", acceptLanguageHeader, ex.getMessage());
+    				locale = null;
+    			}
     		}
     		lang = Language.fromLocale(locale);
     		

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -165,6 +167,22 @@ public class DB {
 
 	private List<ScheduledFuture<?>> _tasks = new ArrayList<>();
 
+	/**
+	 * /100 prefixes touched by a vote/report/call since the last {@link #drainDirtyBlocks()} run
+	 * (#300 follow-up). Multiple signals in the same /100 coalesce to a single background recompute.
+	 */
+	private final Set<String> _dirtyHundreds = ConcurrentHashMap.newKeySet();
+
+	/**
+	 * Serialises the writers of the {@code NUMBERS_AGGREGATION_*} tables — the periodic full sweep
+	 * ({@link #recomputeBlockAggregation}) and the dirty-set drain ({@link #drainDirtyBlocks()}) — so
+	 * they never clash on the shared aggregation rows. Both run off the request path.
+	 */
+	private final Object _aggregationLock = new Object();
+
+	/** Interval of the background {@link #drainDirtyBlocks()} worker (#300 follow-up). */
+	private static final long BLOCK_DIRTY_DRAIN_INTERVAL_MS = 5_000L;
+
 	private MailService _mailService;
 
 	private DBConfig _config;
@@ -212,7 +230,11 @@ public class DB {
 
 		 Date timeHistory = schedule(0, this::runActivityRetention);
 		 LOG.info("Scheduled activity-ledger retention: " + timeHistory);
-		 
+
+		 _tasks.add(_scheduler.scheduler().scheduleWithFixedDelay(this::drainDirtyBlocks,
+			 BLOCK_DIRTY_DRAIN_INTERVAL_MS, BLOCK_DIRTY_DRAIN_INTERVAL_MS, TimeUnit.MILLISECONDS));
+		 LOG.info("Scheduled block-aggregation dirty-set drain every {} ms.", BLOCK_DIRTY_DRAIN_INTERVAL_MS);
+
 		 if (_config.isSendHelpMails() && _mailService != null) {
 			 Date supportMails = schedule(18, this::sendSupportMails);
 			 LOG.info("Scheduled support mails: " + supportMails);
@@ -966,10 +988,11 @@ public class DB {
 			reports.mergeActivity(phone, epochDay(time), 0, 0, absVotes);
 		}
 
-		// #300 follow-up: rebuild this number's /100 block aggregation now (real-time, scoped to the
-		// touched /100), counting how many of its numbers are *currently* spam. The daily sweep
-		// (recomputeBlockAggregation) handles only the silent decay of blocks that get no votes.
-		recomputeBlockForNumber(reports, phone, time);
+		// #300 follow-up: mark this number's /100 block dirty so the background drainDirtyBlocks()
+		// worker recomputes its aggregation off the request path (was a synchronous recompute here,
+		// which held the NUMBERS row lock across a range scan+rewrite and raced with concurrent
+		// writers). The periodic recomputeBlockAggregation sweep reconciles any drift.
+		markBlockDirty(phone);
 
 		if (votes > 0) {
 			updateLocalization(reports, phone, dialPrefix, 0, 0, votes, heatInc, spamEvidenceInc, time);
@@ -1085,7 +1108,7 @@ public class DB {
 			updateLocalization(reports, phone, dialPrefix, 0, 0, 0, 0.0, spamNeg, now);
 		}
 		updatePhoneHashVisibility(reports, phone, hash);
-		recomputeBlockForNumber(reports, phone, now);
+		markBlockDirty(phone);
 	}
 
 	// Removed: pingRelatedNumbers (#91). Bumping LASTPING on all spam
@@ -1118,36 +1141,92 @@ public class DB {
 	public void recomputeBlockAggregation(long now) {
 		double minNetRaw = Ema.projectedThreshold(MIN_MEMBER_VOTES - 0.5, now, Ema.CLASSIFICATION_TAU_MILLIS);
 
-		try (SqlSession session = openSession()) {
-			SpamReports reports = session.getMapper(SpamReports.class);
+		synchronized (_aggregationLock) {
+			try (SqlSession session = openSession()) {
+				SpamReports reports = session.getMapper(SpamReports.class);
 
-			List<AggregationInfo> tens = reports.aggregateMembersByTen(minNetRaw);
+				List<AggregationInfo> tens = reports.aggregateMembersByTen(minNetRaw);
 
-			reports.clearAggregation10();
-			reports.clearAggregation100();
+				reports.clearAggregation10();
+				reports.clearAggregation100();
 
-			int[] blocks = writeBlocksFromTens(reports, tens);
+				int[] blocks = writeBlocksFromTens(reports, tens);
 
-			session.commit();
-			LOG.info("Recomputed block aggregation: {} /10 blocks, {} /100 blocks (from {} populated /10).",
-				blocks[0], blocks[1], tens.size());
+				session.commit();
+				LOG.info("Recomputed block aggregation: {} /10 blocks, {} /100 blocks (from {} populated /10).",
+					blocks[0], blocks[1], tens.size());
+			}
 		}
 	}
 
 	/**
-	 * Incremental, real-time rebuild of the single /100 block touching the given number (#300
-	 * follow-up). Same computation as {@link #recomputeBlockAggregation} but scoped to one /100, so
-	 * a newly forming spam block is detected at vote time without waiting for the daily sweep. The
-	 * sweep stays responsible only for the silent decay of blocks that get no further votes.
+	 * Rebuilds the aggregation of a single /100 block from the current {@code NUMBERS} evidence (#300
+	 * follow-up). Same computation as {@link #recomputeBlockAggregation} but scoped to one /100.
+	 * Invoked only by the background {@link #drainDirtyBlocks()} worker (serialised via
+	 * {@link #_aggregationLock}), never from a request thread.
 	 */
-	void recomputeBlockForNumber(SpamReports reports, String phone, long now) {
-		String p100 = prefix100(phone);
+	void recomputeBlockForHundred(SpamReports reports, String p100, long now) {
 		double minNetRaw = Ema.projectedThreshold(MIN_MEMBER_VOTES - 0.5, now, Ema.CLASSIFICATION_TAU_MILLIS);
 
 		List<AggregationInfo> tens = reports.aggregateMembersByTenForHundred(p100, minNetRaw);
 		reports.clearAggregation10ForHundred(p100);
 		reports.clearAggregation100ForHundred(p100);
 		writeBlocksFromTens(reports, tens);
+	}
+
+	/**
+	 * Marks the /100 block containing {@code phone} as dirty so the background
+	 * {@link #drainDirtyBlocks()} worker recomputes its aggregation off the request path (#300
+	 * follow-up). Replaces the former synchronous per-vote recompute, which held the touched
+	 * {@code NUMBERS} row lock across a wide range scan+rewrite and raced with concurrent writers on
+	 * the shared aggregation tables. This is a cheap in-memory {@code Set.add} — no DB access, no
+	 * lock — so it adds no contention to the request path.
+	 */
+	private void markBlockDirty(String phone) {
+		_dirtyHundreds.add(prefix100(phone));
+	}
+
+	/**
+	 * Recomputes the aggregation of every /100 marked dirty since the last run, off the request path
+	 * and serialised against the full sweep (#300 follow-up). Coalescing keeps the work proportional
+	 * to the number of distinct touched blocks. On failure the batch is re-queued; the periodic
+	 * {@link #recomputeBlockAggregation} sweep is the ultimate backstop for any missed update.
+	 *
+	 * <p>Public so tests can drain deterministically instead of waiting for the timer.</p>
+	 */
+	public void drainDirtyBlocks() {
+		if (_dirtyHundreds.isEmpty()) {
+			return;
+		}
+
+		Set<String> batch = new HashSet<>();
+		for (Iterator<String> it = _dirtyHundreds.iterator(); it.hasNext();) {
+			batch.add(it.next());
+			it.remove();
+		}
+		if (batch.isEmpty()) {
+			return;
+		}
+
+		long now = System.currentTimeMillis();
+		synchronized (_aggregationLock) {
+			try (SqlSession session = openSession()) {
+				SpamReports reports = session.getMapper(SpamReports.class);
+				for (String p100 : batch) {
+					// Commit per /100: each block becomes visible as soon as it is recomputed, the
+					// aggregation-table lock is held only briefly, and a single failing block does not
+					// discard the others (only it is re-queued). The periodic full sweep reconciles.
+					try {
+						recomputeBlockForHundred(reports, p100, now);
+						session.commit();
+					} catch (RuntimeException ex) {
+						session.rollback();
+						_dirtyHundreds.add(p100);
+						LOG.error("Block aggregation drain failed for /100 {}; will retry.", p100, ex);
+					}
+				}
+			}
+		}
 	}
 
 	/**
@@ -2646,9 +2725,10 @@ public class DB {
 		// pure search carries no hash, and recordCall's UPDATE branch would not set it.
 		updatePhoneHashVisibility(reports, phoneId, hash);
 
-		// Per-region signal (#340) and real-time block rebuild for the touched /100 (#300
-		// follow-up) — a call report can push a block over the spam gate just like a vote.
-		recomputeBlockForNumber(reports, phoneId, now);
+		// Per-region signal (#340) and block rebuild for the touched /100 (#300 follow-up) — a call
+		// report can push a block over the spam gate just like a vote. The recompute is deferred to
+		// the background drainDirtyBlocks() worker (off the request path); see markBlockDirty.
+		markBlockDirty(phoneId);
 		updateLocalization(reports, phoneId, dialPrefix, 0, 1, 0, heatInc, evidenceInc, now);
 	}
 

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/SpamReports.java
@@ -140,8 +140,14 @@ public interface SpamReports {
 	@Delete("delete from NUMBERS_AGGREGATION_100")
 	void clearAggregation100();
 
-	/** Clears the /10 rows of a single /100 block (its /10 prefixes are {@code p100 + digit…}). */
-	@Delete("delete from NUMBERS_AGGREGATION_10 where PREFIX > #{p100} and PREFIX < concat(#{p100}, 'Z')")
+	/**
+	 * Clears the /10 rows of a single /100 block. Its /10 prefixes are {@code p100 + digit…}, but a
+	 * member number one digit shorter than the rated number yields a /10 prefix equal to {@code p100}
+	 * itself, so the lower bound must be inclusive ({@code >=}) — matching {@link #clearAggregation100ForHundred}.
+	 * A strict {@code >} would leave that boundary row behind and {@link DB#writeBlocksFromTens} would
+	 * then collide with it on re-insert (unique-key violation on PREFIX).
+	 */
+	@Delete("delete from NUMBERS_AGGREGATION_10 where PREFIX >= #{p100} and PREFIX < concat(#{p100}, 'Z')")
 	void clearAggregation10ForHundred(String p100);
 
 	/** Clears the /100 row(s) within a /100 block's prefix range (covers over-long-number buckets). */

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberAnalyzer.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/analysis/TestNumberAnalyzer.java
@@ -70,6 +70,13 @@ class TestNumberAnalyzer {
 		"+*4917650642+*602*, +4917650642602*",
 		"*004917650642+*602*, 004917650642602*",
 		"00+491722144286, 00491722144286",
+		// Surrounding whitespace must be stripped so the leading '+' is preserved (#leading-space).
+		"' +4989896798174', +4989896798174",
+		"'+4989896798174 ', +4989896798174",
+		"'  +4989896798174  ', +4989896798174",
+		// Interior whitespace is already removed as an interior grouping char by the regex.
+		"'+49 89 6798174', +49896798174",
+		"'  +49 89 6798174  ', +49896798174",
 	})
 	void testNormalize(String input, String normalized) {
 		String normalizedNumber = NumberAnalyzer.normalizeNumber(input);

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -529,6 +529,8 @@ public class TestDB {
 			_db.recordCall(reports, blocklist, userId, number, id, "+49", now);
 			tx.commit();
 		}
+		// Drain the deferred block-aggregation recompute so tests see the effect immediately.
+		_db.drainDirtyBlocks();
 	}
 
 	/** Looks up the test user by login, creating it on first use. */
@@ -941,6 +943,9 @@ public class TestDB {
 
 	private void processVotes(String phone, int votes, long time) {
 		_db.processVotes(NumberAnalyzer.analyze(phone, "+49"), "+49", votes, time);
+		// Block aggregation is now recomputed off the request path; drain synchronously so tests
+		// observe the block state deterministically instead of waiting for the timer.
+		_db.drainDirtyBlocks();
 	}
 
 	/** Raw EMA columns straight from NUMBERS — for confidence-model assertions (#332). */
@@ -1480,6 +1485,8 @@ public class TestDB {
 
 	private void addRating(String userName, String phoneId, Rating rating, String comment, long now) {
 		_db.addRating(userName, NumberAnalyzer.analyze(phoneId, "+49"), "+49", rating, comment, "de", now);
+		// Drain the deferred block-aggregation recompute so tests see the effect immediately.
+		_db.drainDirtyBlocks();
 	}
 
 	public List<? extends UserComment> getComments(String phone) {

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -3,6 +3,7 @@
  */
 package de.haumacher.phoneblock.db;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -771,6 +772,39 @@ public class TestDB {
 				.stream().map(AggregationInfo::getPrefix).collect(Collectors.toSet());
 			assertTrue(hundreds.contains("0402999629"), "spread×mass /100 must qualify");
 		}
+	}
+
+	/**
+	 * Regression for the /10 aggregation clear boundary (incremental rebuild). A member one digit
+	 * shorter than the number being rated produces a /10 block whose {@code PREFIX} equals the
+	 * incremental rebuild's own /100 scope. {@link SpamReports#clearAggregation10ForHundred} must
+	 * clear that boundary row with an inclusive lower bound; a strict {@code >} leaves it behind and
+	 * {@link DB#writeBlocksFromTens} then collides with it on re-insert (unique-key violation on
+	 * {@code NUMBERS_AGGREGATION_10(PREFIX)}), which surfaced as an HTTP 500 on {@code /api/rate}.
+	 *
+	 * <p>Numbers are synthetic (030-1234567…).</p>
+	 */
+	@Test
+	void testIncrementalRebuildClearsBoundaryTenBlock() {
+		long now = System.currentTimeMillis();
+
+		// Four 11-digit members sharing the 10-digit prefix "0301234567" form a /10 concentration
+		// block with PREFIX "0301234567" (written under the 9-digit /100 scope "030123456").
+		processVotes("03012345670", 2, now);
+		processVotes("03012345671", 2, now);
+		processVotes("03012345672", 2, now);
+		processVotes("03012345673", 2, now);
+		assertTrue(wildcardVotes("03012345679") > 0, "four members -> /10 '0301234567' is a block");
+
+		// Rating a 12-digit number in the same range runs the incremental rebuild for /100 scope
+		// prefix100("030123456700") == "0301234567" — exactly the existing /10 block's prefix. The
+		// clear must remove that row so the re-insert does not collide. Before the fix this threw a
+		// unique-key violation (JdbcSQLIntegrityConstraintViolationException).
+		assertDoesNotThrow(() -> processVotes("030123456700", 2, now),
+			"incremental rebuild must clear the boundary /10 row before re-inserting it");
+
+		// The /10 block survives the rebuild intact.
+		assertTrue(wildcardVotes("03012345679") > 0, "/10 block intact after incremental rebuild");
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Users reported that adding a number via the mobile app failed with **HTTP 500**, with nothing in the application log. Investigation surfaced three distinct, related failures — all rooted in how the block aggregation (`NUMBERS_AGGREGATION_10/100`) is maintained:

1. **Deterministic:** rating certain numbers threw `JdbcSQLIntegrityConstraintViolationException` on `NUMBERS_AGGREGATION_10` — an off-by-one in the incremental clear range.
2. **Invisible:** `RateServlet` had no exception handling, so failures went only to the container log (`catalina.out`/`localhost.*`), never to the app log.
3. **Concurrency:** under load (spam waves), the per-vote recompute — run *inside* the vote transaction — held the `NUMBERS` row lock across a wide range scan+rewrite and had every request thread write the shared aggregation tables. This produced unique-key/concurrent-update collisions and `Timeout trying to lock table NUMBERS` (50200) on unrelated writers such as the search-hit counter.

A separate malformed-`Accept-Language` crash (HTTP 500 on page rendering) was found alongside and fixed too.

## Changes (4 commits)

1. **Fix unique-key violation in incremental block aggregation rebuild** — `clearAggregation10ForHundred` used a strict lower bound (`PREFIX > p100`); the aggregation legitimately produces a `/10` block whose `PREFIX` equals the `/100` scope (from a member one digit shorter than the rated number), so that boundary row was never cleared and collided on re-insert. Use `PREFIX >= p100`, matching `clearAggregation100ForHundred`. Includes a regression test (synthetic numbers) reproducing the exact collision.

2. **Log failures in RateServlet** — wrap `service()` with the same `try/catch` + `LOG.error` + `ServletUtil.sendMessage` pattern as `PersonalizationServlet`, so `/api/rate` failures land in the app log with a clean error body.

3. **Tolerate malformed Accept-Language headers** — catch `IllegalArgumentException` from `LanguageRange.parse` in `DefaultController.selectLanguage` and fall back to the default language.

4. **Move block-aggregation recompute off the request path (dirty-set worker)** — a vote/report/call now only marks the touched `/100` dirty (cheap in-memory `Set.add`, no DB, no lock). A background worker (`drainDirtyBlocks`, every 5s, commit per `/100`, coalescing) recomputes off the request path. All aggregation writers (periodic full sweep + drain) are serialised on a single monitor, so the tables have exactly one writer at a time. Block-formation latency goes from instant to ≤5s, which the design already tolerates (the full sweep was the source of truth). Tests drain synchronously to keep block state deterministically observable.

## Testing

- `TestDB` 46/46, plus `TestDbService`/`TestIncrementalBlocklist`/`TestConfidence` 17/17.
- The boundary regression test reproduces the production collision without the fix and is green with it.

## Follow-ups (not in this PR)

- The search-hit counter (`incSearchCount`) still writes synchronously to the hot `NUMBERS` row on every lookup — the remaining contributor to 50200 timeouts (the long lock-hold, the main culprit, is removed here). Batching/deferring it is a possible next step.
- `SpamCheckServlet`/`NumServlet` could get the same logging wrapper as `RateServlet`.
- The 5s drain interval is hardcoded; could be made JNDI-configurable like the sweep interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)