### PR TITLE
Fix inaccurate "no cookies" claim in footer (#431)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,13 +377,13 @@ Java `ResourceBundle` keys used by the web app live in `phoneblock/src/main/java
 
 - **Only edit `Messages_de.properties`** — it is the source of truth.
 - **All other `Messages_<lang>.properties` files are auto-generated via DeepL** — never edit them directly.
-- Translation is run via the `tl-maven-plugin` (`com.top-logic:tl-maven-plugin:translate`) with the `with-deepl` profile. Eclipse launch: `phoneblock/bin/Translate PhoneBlock Resources.launch`.
-- Manual command-line trigger (uses the `translate-messages` execution configured in `phoneblock/pom.xml`, so the plugin version is taken from there):
+- Translation runs automatically during the build (`process-resources`) via the `tl-maven-plugin`'s `translate-messages` execution — **but only when the `with-deepl` profile is active.** That profile is opt-in per developer (it needs a DeepL API key and the TopLogic Nexus, which are not in the repo); enable it locally in `~/.m2/settings.xml` with a `deepl` server holding the key plus `<activeProfiles>with-deepl</activeProfiles>`. With that in place, editing `Messages_de.properties` and rebuilding keeps all bundles in sync — no separate step. Eclipse launch: `phoneblock/bin/Translate PhoneBlock Resources.launch`.
+- To translate explicitly without a full build:
   ```bash
   cd phoneblock
   mvn -Pwith-deepl com.top-logic:tl-maven-plugin:translate@translate-messages -N
   ```
-- After adding/changing a key in `Messages_de.properties`, run the translation before committing so all language bundles stay in sync (otherwise the runtime throws `MissingResourceException`).
+- If you build **without** `with-deepl` enabled, the bundles are not regenerated — run the translation above before committing so all languages stay in sync (otherwise the runtime throws `MissingResourceException`).
 
 ### Mobile App Internationalization (phoneblock_mobile/)
 

--- a/phoneblock/pom.xml
+++ b/phoneblock/pom.xml
@@ -750,6 +750,10 @@ Copy '.phoneblock.template' to '.phoneblock' and fill in your local values
 						<executions>
 							<execution>
 								<id>translate-messages</id>
+								<!-- The translate goal has no default phase; bind it so message
+									 bundles regenerate on every build (only when with-deepl is
+									 active, i.e. for developers who opted in via settings.xml). -->
+								<phase>process-resources</phase>
 								<goals>
 									<goal>translate</goal>
 								</goals>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/ar/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/ar/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> و<strong>FITZ!OS</strong> علامتان تجاريتان مسجلتان لـ <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> لا علاقة لها بذلك.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">حماية البيانات - لا تتبع ولا إعلانات ولا بسكويت</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">حماية البيانات – لا تتبع، لا إعلانات، فقط كعكات محضرة منزليًّا</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">ترجمات من موقع deepl.com، شكراً لك!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">تحرير ترجمات هذه الصفحة</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/da/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/da/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> og <strong>FRITZ!OS</strong> er registrerede varemærker tilhørende <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> har ingen relation til dette.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Databeskyttelse - ingen sporing, ingen reklame, ingen kiks</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Databeskyttelse – Ingen sporing, ingen reklamer, kun hjemmebagte kager</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Oversættelser fra deepl.com, tak!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Rediger oversættelser af denne side</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/de/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/de/fragments/page.html
@@ -335,7 +335,7 @@
 		</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Datenschutz – Kein Tracking, keine Werbung, keine Kekse</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Datenschutz – Kein Tracking, keine Werbung, nur selbstgebackene Kekse</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Übersetungen von deepl.com, danke!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Übersetzungen dieser Seite bearbeiten</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/el/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/el/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> και <strong>FRITZ!OS</strong> είναι σήματα κατατεθέντα της <a target="_blank" th:href="@{/link/avm}">AVM</a>. Το <strong>PhoneBlock</strong> δεν έχει καμία σχέση με αυτό.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Προστασία δεδομένων - καμία παρακολούθηση, καμία διαφήμιση, κανένα μπισκότο</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Προστασία δεδομένων – Χωρίς παρακολούθηση, χωρίς διαφημίσεις, μόνο σπιτικά μπισκότα</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Μεταφράσεις από το deepl.com, ευχαριστώ!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Επεξεργασία μεταφράσεων αυτής της σελίδας</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/en-US/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/en-US/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> and <strong>FRITZ!OS</strong> are registered trademarks of <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> has no relation to this.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Data protection - no tracking, no advertising, no cookies</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Privacy Policy – No tracking, no ads, just homemade cookies</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Translations from deepl.com, thank you!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Edit translations of this page</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/es/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/es/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> y <strong>FRITZ!OS</strong> son marcas registradas de <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> no tiene ninguna relación con esto.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Protección de datos: sin seguimiento, sin publicidad, sin galletas</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Protección de datos: sin seguimiento, sin publicidad, solo galletas caseras</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Traducciones de deepl.com, ¡gracias!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Editar traducciones de esta página</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/fr/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/fr/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> et <strong>FRITZ!OS</strong> sont des marques déposées de <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> n'a aucun rapport avec cela.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Protection des données - Pas de traçage, pas de publicité, pas de biscuits</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Confidentialité – Pas de suivi, pas de publicité, juste des biscuits faits maison</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Traductions de deepl.com, merci !</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Modifier les traductions de cette page</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/it/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/it/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> e <strong>FRITZ!OS</strong> sono marchi registrati di <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> non ha alcuna relazione con questo.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Protezione dei dati - nessun tracciamento, nessuna pubblicità, nessun biscotto</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Privacy – Nessun tracciamento, nessuna pubblicità, solo biscotti fatti in casa</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Traduzioni da deepl.com, grazie!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Modifica delle traduzioni di questa pagina</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nb/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nb/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> og <strong>FRITZ!OS</strong> er registrerte varemerker som tilhører <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> har ingen relasjon til dette.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Personvern - ingen sporing, ingen reklame, ingen kjeks</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Personvern – Ingen sporing, ingen reklame, bare hjemmebakte kaker</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Oversettelser fra deepl.com, takk!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Rediger oversettelser av denne siden</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/nl/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/nl/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> en <strong>FRITZ!OS</strong> zijn geregistreerde handelsmerken van <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> heeft hier geen relatie mee.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Gegevensbescherming - geen tracking, geen reclame, geen koekjes</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Privacybeleid – Geen tracking, geen reclame, alleen zelfgebakken koekjes</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Vertalingen van deepl.com, bedankt!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Bewerk vertalingen van deze pagina</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/pl/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/pl/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> i <strong>FRITZ!OS</strong> są zastrzeżonymi znakami towarowymi <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> nie jest z tym związany.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Ochrona danych - bez śledzenia, bez reklam, bez ciastek</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Ochrona danych – bez śledzenia, bez reklam, tylko domowe ciasteczka</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Tłumaczenie z deepl.com, dziękuję!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Edytuj tłumaczenia tej strony</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/sv/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/sv/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> och <strong>FRITZ!OS</strong> är registrerade varumärken som tillhör <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> har ingen relation till detta.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Dataskydd - ingen spårning, ingen reklam, inga kakor</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Integritet – Ingen spårning, ingen reklam, bara hembakade kakor</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Översättningar från deepl.com, tack!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Redigera översättningar av denna sida</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/uk/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/uk/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ!Box</strong> та <strong>FRITZ!OS</strong> є зареєстрованими торговими марками компанії <a target="_blank" th:href="@{/link/avm}">AVM</a>. <strong>PhoneBlock</strong> не має до цього жодного відношення.</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">Захист даних - ніякого відстеження, ніякої реклами, ніякого печива</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">Захист даних — жодного відстеження, жодної реклами, лише домашнє печиво</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">Переклад з deepl.com, дякуємо!</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">Редагувати переклад цієї сторінки</a></strong><br/>

--- a/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/fragments/page.html
+++ b/phoneblock/src/main/webapp/WEB-INF/templates/zh-Hans/fragments/page.html
@@ -324,7 +324,7 @@
 		<p data-tx="t0022:a2362eaf"><strong>FRITZ！Box</strong>和<strong>FRITZ！OS</strong>是<a target="_blank" th:href="@{/link/avm}">AVM</a>的注册商标。<strong>PhoneBlock</strong>与此无关。</p>
 
 		<p>
-			<strong><a data-tx="t0023:b2b65883" th:href="@{/datenschutz}">数据保护--无跟踪、无广告、无饼干</a></strong><br/>
+			<strong><a data-tx="t0023:e2cb043f" th:href="@{/datenschutz}">隐私政策——不进行追踪，无广告，只有自制饼干</a></strong><br/>
 			<th:block th:unless="${#strings.equals(currentLang.tag, 'de')}">
 			<strong><a data-tx="t0058:9698970a" th:href="@{link/deepl}">翻译自 deepl.com，谢谢！</a></strong><br/>
 			<strong><a data-tx="t0059:99006217" th:href="|${contextPath}/link/translations${template}|">编辑本页的译文</a></strong><br/>


### PR DESCRIPTION
Closes #431.

## Content fix (commit 1)
The footer tagline advertised *"Kein Tracking, keine Werbung, keine Kekse"* ("…no cookies"), but PhoneBlock does set cookies — a technically-necessary session cookie (`JSESSIONID`) and an opt-in persistent login cookie (`pb-login`), both already documented on the linked privacy page. The claim was therefore inaccurate (as reported).

Reworded the German source to **"nur selbstgebackene Kekse"** (only home-baked cookies): accurate (all cookies are first-party/functional, no third-party trackers) while keeping the pun. All locale translations regenerated from it (the "self-baked = first-party" metaphor carries across languages — EN "homemade cookies", FR "biscuits faits maison", ES "galletas caseras", …).

## Build-tooling fix (commit 2)
While verifying the translations propagate, found that `Messages_*.properties` translation never ran during the build: the `tl-maven-plugin` `translate` goal has no default phase, so its `translate-messages` execution was never lifecycle-bound (only runnable by hand). Bound it to `process-resources`, matching the HTML/mail template translations which already run on build.

This execution lives inside the opt-in `with-deepl` profile, so it only takes effect for developers who enabled translation via `settings.xml`; a plain `master` checkout is unaffected. CLAUDE.md updated to describe the now-automatic behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)