### PR TITLE
Dongle: serve dashboard SPA gzip-compressed (~147 KB smaller app)

### DIFF
--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "web_access.c" "net_local.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
     INCLUDE_DIRS "."
-    EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
+    EMBED_FILES "audio/announcement.alaw" "web/ab-logo-bot.svg"
     REQUIRES
         esp_http_client
         esp_http_server
@@ -24,3 +24,20 @@ idf_component_register(
         espcoredump
         protocol_examples_common
 )
+
+# The dashboard SPA (web/index.html) is a self-contained ~204 KB blob whose
+# .rodata dominates the app image. Gzip it at build time and embed the .gz
+# instead of the raw file (~204 KB -> ~35 KB in flash); handle_root() in web.c
+# serves it with "Content-Encoding: gzip". `gzip -9 -n` (no name/timestamp)
+# keeps the output reproducible across builds. Regenerated automatically
+# whenever web/index.html changes (MAIN_DEPENDENCY on the source).
+set(index_html_src "${CMAKE_CURRENT_SOURCE_DIR}/web/index.html")
+set(index_html_gz "${CMAKE_CURRENT_BINARY_DIR}/index.html.gz")
+add_custom_command(
+    OUTPUT "${index_html_gz}"
+    COMMAND gzip -9 -n -c "${index_html_src}" > "${index_html_gz}"
+    MAIN_DEPENDENCY "${index_html_src}"
+    COMMENT "Gzipping dashboard SPA (web/index.html)"
+    VERBATIM)
+target_add_binary_data(${COMPONENT_LIB} "${index_html_gz}" BINARY
+    DEPENDS "${index_html_gz}")

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -106,8 +106,10 @@ static struct {
 // Embedded via EMBED_FILES in CMakeLists.txt; the linker emits
 // _binary_<file>_<ext>_{start,end} symbols which we alias to friendlier
 // C names.
-extern const uint8_t index_html_start[] asm("_binary_index_html_start");
-extern const uint8_t index_html_end[]   asm("_binary_index_html_end");
+// The dashboard SPA is embedded gzip-compressed (see main/CMakeLists.txt) and
+// served with Content-Encoding: gzip. Symbol name follows the .gz filename.
+extern const uint8_t index_html_gz_start[] asm("_binary_index_html_gz_start");
+extern const uint8_t index_html_gz_end[]   asm("_binary_index_html_gz_end");
 
 extern const uint8_t ab_logo_bot_svg_start[] asm("_binary_ab_logo_bot_svg_start");
 extern const uint8_t ab_logo_bot_svg_end[]   asm("_binary_ab_logo_bot_svg_end");
@@ -258,8 +260,12 @@ static esp_err_t handle_root(httpd_req_t *req)
     REQUIRE_LOCAL_HTML(req);
     set_pna_response_headers(req);
     httpd_resp_set_type(req, "text/html; charset=utf-8");
-    httpd_resp_send(req, (const char *)index_html_start,
-                    index_html_end - index_html_start);
+    // Served pre-compressed. Every browser that reaches this dashboard sends
+    // "Accept-Encoding: gzip", so we emit gzip unconditionally rather than
+    // embedding a second uncompressed copy (which would defeat the saving).
+    httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+    httpd_resp_send(req, (const char *)index_html_gz_start,
+                    index_html_gz_end - index_html_gz_start);
     return ESP_OK;
 }
 


### PR DESCRIPTION
## What

The dongle dashboard (`main/web/index.html`) is a self-contained ~204 KB SPA embedded raw in the app image, where its `.rodata` was the single largest contributor. This gzips it at build time and embeds the `.gz`; `handle_root()` serves it with `Content-Encoding: gzip`.

## Why

The app binary had grown to ~1.59 MB in the 1664 KB OTA slot — **~4.6% headroom**, and shrinking. Compressing the embedded dashboard is a safe, fleet-wide (rides normal app OTA), fully reversible way to buy runway.

## Impact (measured)

| | bytes |
|---|---:|
| `index.html` embedded: raw → gzip | 203,997 → **53,058** |
| app `.bin` | 1,625,872 → **1,474,992** (−150,880, ~147 KB) |
| slot headroom (1664 KB) | 4.6% → **13.4%** |

## How

- `main/CMakeLists.txt`: a `gzip -9 -n` custom command compresses `web/index.html` into the build dir; `target_add_binary_data` embeds the `.gz`. `-n` (no name/timestamp) keeps the blob reproducible; it regenerates automatically when the source changes.
- `main/web.c`: `handle_root()` references the `_binary_index_html_gz_*` symbols and sets `Content-Encoding: gzip`. Served unconditionally — every browser that reaches the dashboard sends `Accept-Encoding: gzip`, and embedding a second uncompressed copy would negate the saving.

## Test plan

- ✅ `idf.py build` green; embedded `.gz` decodes **byte-identical** to source (`gzip -dc | cmp`).
- ✅ Host test suite 8/8 (`firmware/test && make test`).
- ✅ **On hardware** (test dongle): `/` returns `Content-Encoding: gzip`, 53,058 B on the wire; a `--compressed` client decodes to the exact 203,997 B source page (`<title>PhoneBlock Dongle</title>`); other assets (`ab-logo-bot.svg`) unaffected.

Relates to #489 (dongle flash headroom / OTA layout research). The CA-bundle trim explored there was found unsafe and dropped; this gzip win covers the headroom need on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)