### PR TITLE
dongle: fix network-reachable heap overflow in SIP response builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,38 @@ rc baseline plus only the target feature's hunks, dropping every reference to
 the unrelated change, then validate with a full `idf.py build` **and** the host
 test suite (`cd phoneblock-dongle/firmware/test && make test`) before pushing.
 
+### Dongle Firmware: Building Strings Safely
+
+**Never assemble a string with a running `snprintf` offset** — i.e. avoid
+`n += snprintf(buf + n, cap - n, ...)`. `snprintf` returns the length it
+*would* have written, so an over-long field pushes `n` past the buffer; the
+next call then gets a negative `cap - n` (a huge `size_t`) and overruns the
+allocation. This is exactly the heap-corruption bug fixed in the SIP response
+builder.
+
+For any **multi-step append**, use the bounded builder in
+`phoneblock-dongle/firmware/main/strbuf.h`:
+
+```c
+strbuf_t sb = sb_init(buf, sizeof(buf));
+sb_appendf(&sb, "REGISTER %s SIP/2.0\r\n", uri);
+sb_appendf(&sb, "Call-ID: %s\r\n", call_id);
+if (sb.truncated) { /* all-or-nothing: drop the message */ }
+int len = sb.len;                 // bytes written; buf is NUL-terminated
+```
+
+`sb_appendf()` never advances past the buffer (memory-safe by construction,
+however long the inputs) and records `sb.truncated`. Callers for whom a
+partial result is invalid (SIP messages — a dropped header is malformed, and
+on TCP a missing Content-Length mis-frames) check `sb.truncated` and send
+nothing; callers for whom a clamped result is fine (URLs, log lines) ignore it.
+
+A single bounded write — `snprintf(dst, sizeof dst, ...)` with the result
+checked or intentionally ignored — is fine; only the accumulator pattern is
+banned. `sprintf`/`vsprintf`/`strcat`/`gets` are hard-banned at compile time
+via `main/banned_apis.h` (included last in every `.c`); using one is a
+"poisoned" compile error that points you here.
+
 ### Database Migrations
 
 When adding schema changes:

--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "web_access.c" "net_local.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
+    SRCS "main.c" "sip_register.c" "sip_response.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "web_access.c" "net_local.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/index.html" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/announcement.c
+++ b/phoneblock-dongle/firmware/main/announcement.c
@@ -9,6 +9,9 @@
 #include "esp_log.h"
 #include "esp_spiffs.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "announcement";
 
 // EMBED_FILES in main/CMakeLists.txt makes the linker emit these.

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -16,6 +16,7 @@
 #include "mbedtls/sha1.h"
 
 #include "api_scan.h"
+#include "strbuf.h"
 #include "config.h"
 #include "http_util.h"
 #include "stats.h"
@@ -350,15 +351,11 @@ verdict_t phoneblock_check(const char *phone_number, pb_check_result_t *out,
     }
 
     char url[256];
-    int n = snprintf(url, sizeof(url),
-                     "%s/api/check-prefix?sha1=%s&format=json",
-                     config_phoneblock_base_url(), hash_full);
-    if (have_p10 && n < (int)sizeof(url)) {
-        n += snprintf(url + n, sizeof(url) - n, "&prefix10=%s", hash_p10);
-    }
-    if (have_p100 && n < (int)sizeof(url)) {
-        n += snprintf(url + n, sizeof(url) - n, "&prefix100=%s", hash_p100);
-    }
+    strbuf_t ub = sb_init(url, sizeof(url));
+    sb_appendf(&ub, "%s/api/check-prefix?sha1=%s&format=json",
+               config_phoneblock_base_url(), hash_full);
+    if (have_p10)  sb_appendf(&ub, "&prefix10=%s", hash_p10);
+    if (have_p100) sb_appendf(&ub, "&prefix100=%s", hash_p100);
 
     char auth_header[128];
     snprintf(auth_header, sizeof(auth_header), "Bearer %s", config_phoneblock_token());

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -21,6 +21,9 @@
 #include "http_util.h"
 #include "stats.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "api";
 
 // Live token-health flag, fed from every Bearer-authenticated call.

--- a/phoneblock-dongle/firmware/main/api_scan.c
+++ b/phoneblock-dongle/firmware/main/api_scan.c
@@ -4,6 +4,9 @@
 
 #include "cJSON.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 void api_scan_init(api_scan_t *s, const char *phone)
 {
     memset(s, 0, sizeof(*s));

--- a/phoneblock-dongle/firmware/main/audio.c
+++ b/phoneblock-dongle/firmware/main/audio.c
@@ -1,5 +1,8 @@
 #include "audio.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Straight implementation of the ITU-T G.711 A-law encoder:
 // 13-bit magnitude → 3-bit segment + 4-bit mantissa → XOR with 0x55
 // to flip even bits (and the sign bit for positives). Matches the

--- a/phoneblock-dongle/firmware/main/banned_apis.h
+++ b/phoneblock-dongle/firmware/main/banned_apis.h
@@ -1,0 +1,25 @@
+#pragma once
+//
+// Compile-time ban on string functions that have no safe bounded form. Any use
+// of one below becomes a hard error ("attempt to use poisoned ...") pointing
+// straight at the call site. Use instead:
+//
+//   * building/appending a string (esp. multi-step) -> strbuf.h:
+//         strbuf_t sb = sb_init(buf, sizeof buf);
+//         sb_appendf(&sb, "...", ...);   // never overruns; sets sb.truncated
+//   * a single bounded format  -> snprintf(dst, sizeof dst, ...)
+//   * a fixed-length copy      -> memcpy with an explicit length
+//
+// IMPORTANT: #pragma GCC poison bans the identifier for the REST of the
+// translation unit, including inside system headers. This header must
+// therefore be included LAST, after every <...> / IDF header. Included
+// earlier, the poison fires inside e.g. <stdio.h>'s own declaration.
+//
+// Deliberately NOT banned:
+//   * snprintf / vsnprintf — bounds-safe. The footgun was only feeding
+//     snprintf's return value into an accumulator offset
+//     (`n += snprintf(buf + n, cap - n, ...)`); that pattern now lives behind
+//     strbuf.h. New multi-step assembly must use strbuf, not raw snprintf.
+//   * strcpy — remaining uses are audited-safe (string literals / length-
+//     guarded escapes); prefer memcpy/snprintf for new code.
+#pragma GCC poison sprintf vsprintf strcat gets

--- a/phoneblock-dongle/firmware/main/blocklist_lookup.c
+++ b/phoneblock-dongle/firmware/main/blocklist_lookup.c
@@ -8,6 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Powers of 11 used in the base-11 key encoding. POW11[i] is the place
 // value of slot SLOTS - 1 - i, i.e. the contribution of a symbol at the
 // i-th least-significant slot. 11^16 ≈ 4.6e16 fits comfortably in 56 bits.

--- a/phoneblock-dongle/firmware/main/blocklist_lookup.c
+++ b/phoneblock-dongle/firmware/main/blocklist_lookup.c
@@ -137,7 +137,16 @@ blocklist_t *blocklist_open(const char *path_owned)
         fclose(f);
         return NULL;
     }
+    // Grab the real file size so the header's record counts can be sanity
+    // checked below.
+    long file_size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) {
+        file_size = ftell(f);
+    }
     fclose(f);
+    if (file_size < BLOCKLIST_HEADER_SIZE) {
+        return NULL;
+    }
 
     uint32_t magic = read_u32(hdr);
     if (magic != BLOCKLIST_MAGIC) {
@@ -150,6 +159,18 @@ blocklist_t *blocklist_open(const char *path_owned)
     uint16_t prefix_lengths = read_u16(hdr + 6);
     uint32_t exact_count = read_u32(hdr + 8);
     uint32_t prefix_count = read_u32(hdr + 12);
+
+    // Reject a header whose record counts don't fit the actual file. A corrupt
+    // or hostile count would otherwise drive read_record()'s offset past 2 GiB,
+    // where the (long)off seek truncates on a 32-bit target and reads the wrong
+    // record. Bounding the counts by the real (sub-megabyte) file keeps every
+    // computed offset representable.
+    uint64_t need = (uint64_t)BLOCKLIST_HEADER_SIZE
+                  + ((uint64_t)exact_count + (uint64_t)prefix_count)
+                        * BLOCKLIST_RECORD_SIZE;
+    if (need > (uint64_t)file_size) {
+        return NULL;
+    }
 
     blocklist_t *bl = (blocklist_t *)calloc(1, sizeof(*bl));
     if (bl == NULL) {

--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -23,6 +23,9 @@
 #include "strbuf.h"
 #include "scheduler.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "blsync";
 
 // Stream-read chunk for the HTTPS download. Small to stay friendly with

--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "http_util.h"
+#include "strbuf.h"
 #include "scheduler.h"
 
 static const char *TAG = "blsync";
@@ -252,8 +253,9 @@ static bool sync_one(const char *type, const char *path, const char *tmp_path,
     unlink(path);
 
     char url[256];
-    int n = snprintf(url, sizeof(url), "%s/api/blocklist?format=binary&type=%s",
-                     config_phoneblock_base_url(), type);
+    strbuf_t ub = sb_init(url, sizeof(url));
+    sb_appendf(&ub, "%s/api/blocklist?format=binary&type=%s",
+               config_phoneblock_base_url(), type);
 
     // The community list carries no per-entry vote counts, so the server
     // applies our two thresholds at encode time. Send them so the
@@ -261,14 +263,14 @@ static bool sync_one(const char *type, const char *path, const char *tmp_path,
     // (api.c: direct >= min_direct, wildcard >= min_range) would decide.
     // The personal list is the user's explicit black/white set — no
     // thresholding, so no parameters.
-    if (strcmp(type, "community") == 0 && n > 0 && (size_t) n < sizeof(url)) {
+    if (strcmp(type, "community") == 0) {
         // maxBytes lets the server cap the (size-unbounded) community list to
         // our free flash: it keeps all wildcards + whitelist and truncates the
         // Heat-ranked direct numbers to fit. minDirect/minRange keep the
         // encoded verdict identical to the API-fallback path.
-        snprintf(url + n, sizeof(url) - n, "&minDirect=%d&minRange=%d&maxBytes=%lld",
-                 config_min_direct_votes(), config_min_range_votes(),
-                 (long long) community_budget_bytes());
+        sb_appendf(&ub, "&minDirect=%d&minRange=%d&maxBytes=%lld",
+                   config_min_direct_votes(), config_min_range_votes(),
+                   (long long) community_budget_bytes());
     }
 
     unlink(tmp_path);

--- a/phoneblock-dongle/firmware/main/config.c
+++ b/phoneblock-dongle/firmware/main/config.c
@@ -10,6 +10,9 @@
 
 #include "sdkconfig.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG  = "config";
 static const char *NS   = "phoneblock";
 

--- a/phoneblock-dongle/firmware/main/crashreport.c
+++ b/phoneblock-dongle/firmware/main/crashreport.c
@@ -19,6 +19,9 @@
 #include "config.h"
 #include "http_util.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "crashrep";
 
 // Hard cap matches the partition size (see partitions.csv: 0xD000 = 52 KB).

--- a/phoneblock-dongle/firmware/main/firmware_update.c
+++ b/phoneblock-dongle/firmware/main/firmware_update.c
@@ -27,6 +27,9 @@
 #include "config.h"
 #include "version_cmp.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "fwup";
 
 // ---------------------------------------------------------------------------

--- a/phoneblock-dongle/firmware/main/http_util.c
+++ b/phoneblock-dongle/firmware/main/http_util.c
@@ -7,6 +7,9 @@
 
 #include "config.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static char s_user_agent[120] = "";
 
 const char *http_util_user_agent(void)

--- a/phoneblock-dongle/firmware/main/improv.c
+++ b/phoneblock-dongle/firmware/main/improv.c
@@ -14,6 +14,9 @@
 #include "improv_proto.h"
 #include "wifi.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "improv";
 
 #define IMPROV_UART CONFIG_ESP_CONSOLE_UART_NUM

--- a/phoneblock-dongle/firmware/main/improv_proto.c
+++ b/phoneblock-dongle/firmware/main/improv_proto.c
@@ -2,6 +2,9 @@
 
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const uint8_t HEADER[6] = { 'I', 'M', 'P', 'R', 'O', 'V' };
 
 #define IMPROV_VERSION 1

--- a/phoneblock-dongle/firmware/main/log_capture.c
+++ b/phoneblock-dongle/firmware/main/log_capture.c
@@ -177,6 +177,9 @@ int log_capture_suppressed(char level, const char *tag, const char *msg)
 #include "config.h"
 #include "stats.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Previous (console) sink, so the serial log stays fully intact.
 static vprintf_like_t s_console;
 

--- a/phoneblock-dongle/firmware/main/logreport.c
+++ b/phoneblock-dongle/firmware/main/logreport.c
@@ -12,6 +12,9 @@
 #include "stats.h"
 #include "wifi.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "logreport";
 
 // Same heap headroom rationale as crashreport.c: a full TLS handshake to

--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -26,6 +26,9 @@
 #include "time_sync.h"
 #include "wifi.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "mail";
 
 // Same heap headroom rationale as crashreport.c / logreport.c: the TLS

--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -455,7 +455,7 @@ static size_t append_calls_html(char *body, size_t cap, size_t len,
     for (int i = 0; i < ncalls && len < cap - 400; i++) {
         const stats_call_t *c = &calls[i];
         char when[24]; format_event_time(c->at_us, when, sizeof(when));
-        char vl[48];   verdict_label(c, vl, sizeof(vl));
+        char vl[64];   verdict_label(c, vl, sizeof(vl));
         // API-checked entries carry a PhoneBlock label/location; phone-book
         // and internal-code entries fall back to the raw number/display.
         bool checked     = c->label[0] != '\0';

--- a/phoneblock-dongle/firmware/main/mail_html.c
+++ b/phoneblock-dongle/firmware/main/mail_html.c
@@ -1,5 +1,8 @@
 #include "mail_html.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Each builder writes a terminating '\0' at body[len] before returning, so
 // the buffer is always a valid C string after any call. This matters
 // because the assembled body is consumed as a C string (smtp_encode_body

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -31,6 +31,9 @@
 #include "web.h"
 #include "wifi.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "phoneblock";
 
 // Announce the dongle on the LAN as "answerbot" via mDNS. The matching

--- a/phoneblock-dongle/firmware/main/net_local.c
+++ b/phoneblock-dongle/firmware/main/net_local.c
@@ -9,6 +9,9 @@
 #include "lwip/sockets.h"
 #else
 #include <arpa/inet.h>
+
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
 #endif
 
 // --- Parsing --------------------------------------------------------

--- a/phoneblock-dongle/firmware/main/phone_norm.c
+++ b/phoneblock-dongle/firmware/main/phone_norm.c
@@ -4,6 +4,9 @@
 #include <stdio.h>
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // True if `s` is non-empty and every character is an ASCII digit.
 static bool all_digits(const char *s)
 {

--- a/phoneblock-dongle/firmware/main/report_queue.c
+++ b/phoneblock-dongle/firmware/main/report_queue.c
@@ -11,6 +11,9 @@
 #include "api.h"
 #include "rtp.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "report_q";
 
 // Phone numbers in the queue are E.164 / "00" form, never longer

--- a/phoneblock-dongle/firmware/main/rtp.c
+++ b/phoneblock-dongle/firmware/main/rtp.c
@@ -16,6 +16,9 @@
 
 #include "srtp.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "rtp";
 
 // Singleton RTP socket, created once and reused for every call: the STUN

--- a/phoneblock-dongle/firmware/main/sched_time.c
+++ b/phoneblock-dongle/firmware/main/sched_time.c
@@ -1,5 +1,8 @@
 #include "sched_time.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 long seconds_until_daily(time_t now, int at_hour, int at_minute)
 {
     struct tm lt;

--- a/phoneblock-dongle/firmware/main/scheduler.c
+++ b/phoneblock-dongle/firmware/main/scheduler.c
@@ -20,6 +20,9 @@
 #include "ticks_util.h"
 #include "time_sync.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "scheduler";
 
 // 24 h between scheduled runs, with ±30 min skew so a fleet-wide power

--- a/phoneblock-dongle/firmware/main/selftest.c
+++ b/phoneblock-dongle/firmware/main/selftest.c
@@ -8,6 +8,9 @@
 #include "config.h"
 #include "logreport.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "selftest";
 
 void selftest_run(void)

--- a/phoneblock-dongle/firmware/main/sip_auth.c
+++ b/phoneblock-dongle/firmware/main/sip_auth.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <strings.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static void copy_value(const char *src, size_t src_len, char *dst, size_t dst_cap)
 {
     size_t n = src_len < dst_cap - 1 ? src_len : dst_cap - 1;

--- a/phoneblock-dongle/firmware/main/sip_frame.c
+++ b/phoneblock-dongle/firmware/main/sip_frame.c
@@ -4,6 +4,9 @@
 
 #include "sip_parse.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 void sip_framer_init(sip_framer_t *f, char *buf, int cap)
 {
     f->buf = buf;

--- a/phoneblock-dongle/firmware/main/sip_parse.c
+++ b/phoneblock-dongle/firmware/main/sip_parse.c
@@ -5,6 +5,9 @@
 #include <string.h>
 #include <strings.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 const char *find_header(const char *msg, int msg_len, const char *name)
 {
     size_t name_len = strlen(name);

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -831,6 +831,15 @@ static void send_response(sip_ctx_t *c, const struct sockaddr_in *peer,
                                     current_identity_user(),
                                     advertised_host(c), advertised_port(),
                                     tx, SIP_TX_BUF_SIZE);
+    if (tx_len < 0) {
+        // The request's headers were too large to echo into a complete
+        // response. Send nothing rather than a partial, invalid message —
+        // only reachable from a malformed/oversized request.
+        ESP_LOGW(TAG, "dropping %d %s: response exceeds %d-byte buffer",
+                 status, reason, SIP_TX_BUF_SIZE);
+        free(tx);
+        return;
+    }
     ESP_LOGI(TAG, "→ %d %s (%d bytes):\n%.*s", status, reason, tx_len, tx_len, tx);
     sip_transport_send_to(c->transport, peer, tx, tx_len);
     free(tx);

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -33,6 +33,9 @@
 #include "rtp.h"
 #include "stats.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "sip";
 
 // The local SIP port (bound + advertised) is configurable via

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -25,6 +25,7 @@
 #include "announcement.h"
 #include "report_queue.h"
 #include "sip_parse.h"
+#include "sip_response.h"
 #include "sip_auth.h"
 #include "sip_transport.h"
 #include "sip_srv.h"
@@ -799,55 +800,17 @@ cleanup:
 // Incoming request handling
 // ---------------------------------------------------------------------------
 
-// Copy one full "Name: value\r\n" line from req into out. Returns bytes
-// written (0 if the header is absent or doesn't fit).
-static int echo_header_line(const char *req, int req_len, const char *name,
-                            char *out, int out_cap)
-{
-    const char *val = find_header(req, req_len, name);
-    if (!val) return 0;
-
-    // Scan forward to end of line.
-    const char *end = req + req_len;
-    const char *eol = val;
-    while (eol < end && *eol != '\r' && *eol != '\n') eol++;
-    int val_len = (int)(eol - val);
-
-    int written = snprintf(out, out_cap, "%s: %.*s\r\n", name, val_len, val);
-    return written > 0 && written < out_cap ? written : 0;
-}
-
-// Like echo_header_line, but appends ";tag=<our_tag>" to the To-header's
-// URI part (for generating a valid UAS response to a dialog-forming request).
-static int echo_to_with_tag(const char *req, int req_len,
-                            const char *our_tag, char *out, int out_cap)
-{
-    const char *val = find_header(req, req_len, "To");
-    if (!val) return 0;
-    const char *end = req + req_len;
-    const char *eol = val;
-    while (eol < end && *eol != '\r' && *eol != '\n') eol++;
-    int val_len = (int)(eol - val);
-
-    // Check if the request already has a tag (some re-INVITEs do).
-    if (memmem(val, val_len, ";tag=", 5)) {
-        return snprintf(out, out_cap, "To: %.*s\r\n", val_len, val);
-    }
-    int written = snprintf(out, out_cap, "To: %.*s;tag=%s\r\n",
-                           val_len, val, our_tag);
-    return written > 0 && written < out_cap ? written : 0;
-}
-
-// Build a SIP response that echoes routing headers (Via/From/To/Call-ID/
-// CSeq) from the request, adds Contact + Allow + User-Agent, an optional
-// SDP body, and a matching Content-Length. Caller provides the status line,
-// an optional fixed To-tag (NULL → generate a fresh one, for stateless
-// responses like OPTIONS), and an optional body (NULL → empty).
-static int build_response(sip_ctx_t *c, const char *req, int req_len,
+// The SIP response builder (echo Via/From/To/Call-ID/CSeq, add Contact +
+// Allow + User-Agent + optional SDP) lives in sip_response.c so its buffer
+// arithmetic can be unit-tested on the host — see sip_response.h and
+// test/test_sip_response.c. send_response() resolves the local identity /
+// advertised host+port and, for stateless responses (no override tag),
+// mints a fresh To-tag, then hands everything to sip_response_build().
+static void send_response(sip_ctx_t *c, const struct sockaddr_in *peer,
+                          const char *req, int req_len,
                           int status, const char *reason,
                           const char *our_tag_override,
-                          const char *body,
-                          char *out, int out_cap)
+                          const char *body)
 {
     char tag_buf[20];
     const char *our_tag;
@@ -858,45 +821,16 @@ static int build_response(sip_ctx_t *c, const char *req, int req_len,
         our_tag = tag_buf;
     }
 
-    int body_len = body ? (int)strlen(body) : 0;
-
-    int n = snprintf(out, out_cap, "SIP/2.0 %d %s\r\n", status, reason);
-    n += echo_header_line(req, req_len, "Via", out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "From", out + n, out_cap - n);
-    n += echo_to_with_tag(req, req_len, our_tag, out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "Call-ID", out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "CSeq", out + n, out_cap - n);
-    n += snprintf(out + n, out_cap - n,
-        "Contact: <sip:%s@%s:%d>\r\n"
-        "Allow: INVITE, ACK, CANCEL, BYE, OPTIONS\r\n"
-        "User-Agent: phoneblock-dongle/0.1\r\n",
-        current_identity_user(), advertised_host(c), advertised_port());
-
-    if (body_len > 0) {
-        n += snprintf(out + n, out_cap - n,
-            "Content-Type: application/sdp\r\n"
-            "Content-Length: %d\r\n\r\n%s",
-            body_len, body);
-    } else {
-        n += snprintf(out + n, out_cap - n,
-            "Content-Length: 0\r\n\r\n");
-    }
-    return n;
-}
-
-static void send_response(sip_ctx_t *c, const struct sockaddr_in *peer,
-                          const char *req, int req_len,
-                          int status, const char *reason,
-                          const char *our_tag_override,
-                          const char *body)
-{
     char *tx = malloc(SIP_TX_BUF_SIZE);
     if (!tx) {
         ESP_LOGE(TAG, "malloc failed for response buffer");
         return;
     }
-    int tx_len = build_response(c, req, req_len, status, reason,
-                                our_tag_override, body, tx, SIP_TX_BUF_SIZE);
+    int tx_len = sip_response_build(req, req_len, status, reason,
+                                    our_tag, body,
+                                    current_identity_user(),
+                                    advertised_host(c), advertised_port(),
+                                    tx, SIP_TX_BUF_SIZE);
     ESP_LOGI(TAG, "→ %d %s (%d bytes):\n%.*s", status, reason, tx_len, tx_len, tx);
     sip_transport_send_to(c->transport, peer, tx, tx_len);
     free(tx);

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -26,6 +26,7 @@
 #include "report_queue.h"
 #include "sip_parse.h"
 #include "sip_response.h"
+#include "strbuf.h"
 #include "sip_auth.h"
 #include "sip_transport.h"
 #include "sip_srv.h"
@@ -478,7 +479,8 @@ static int build_register(sip_ctx_t *c, char *buf, int cap, bool with_auth)
         instance[0] = '\0';
     }
 
-    int n = snprintf(buf, cap,
+    strbuf_t sb = sb_init(buf, cap);
+    sb_appendf(&sb,
         "REGISTER %s SIP/2.0\r\n"
         "Via: SIP/2.0/%s %s:%d;branch=z9hG4bK%s;rport\r\n"
         "Max-Forwards: 70\r\n"
@@ -514,7 +516,7 @@ static int build_register(sip_ctx_t *c, char *buf, int cap, bool with_auth)
             qop, nc, cnonce,
             response);
 
-        n += snprintf(buf + n, cap - n,
+        sb_appendf(&sb,
             "Authorization: Digest username=\"%s\", realm=\"%s\", "
             "nonce=\"%s\", uri=\"%s\", response=\"%s\", algorithm=%s",
             auth_user, realm,
@@ -522,19 +524,21 @@ static int build_register(sip_ctx_t *c, char *buf, int cap, bool with_auth)
             response, c->challenge.algorithm);
 
         if (qop[0]) {
-            n += snprintf(buf + n, cap - n,
+            sb_appendf(&sb,
                 ", qop=%s, nc=%s, cnonce=\"%s\"",
                 qop, nc, cnonce);
         }
         if (c->challenge.opaque[0]) {
-            n += snprintf(buf + n, cap - n,
+            sb_appendf(&sb,
                 ", opaque=\"%s\"", c->challenge.opaque);
         }
-        n += snprintf(buf + n, cap - n, "\r\n");
+        sb_appendf(&sb, "\r\n");
     }
 
-    n += snprintf(buf + n, cap - n, "Content-Length: 0\r\n\r\n");
-    return n;
+    sb_appendf(&sb, "Content-Length: 0\r\n\r\n");
+    // A truncated REGISTER would be malformed; report it un-buildable so the
+    // caller doesn't put a partial request on the wire.
+    return sb.truncated ? -1 : sb.len;
 }
 
 // ---------------------------------------------------------------------------
@@ -652,6 +656,12 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
     register_outcome_t result = REGISTER_DEFINITIVE;
     c->cseq++;
     int tx_len = build_register(c, tx, SIP_TX_BUF_SIZE, false);
+    if (tx_len < 0) {
+        ESP_LOGE(TAG, "REGISTER exceeds %d-byte buffer", SIP_TX_BUF_SIZE);
+        if (err) snprintf(err, err_cap, "REGISTER aborted: request too large");
+        result = REGISTER_DEFINITIVE;
+        goto cleanup;
+    }
     ESP_LOGI(TAG, "→ REGISTER (%d bytes):\n%.*s", tx_len, tx_len, tx);
     int rx_len = sip_send_recv(c, tx, tx_len, rx, SIP_RX_BUF_SIZE);
     if (rx_len < 0) {
@@ -720,6 +730,14 @@ static register_outcome_t do_register(sip_ctx_t *c, int *granted_expires,
     for (int stale_retry = 0; ; stale_retry++) {
         c->cseq++;
         tx_len = build_register(c, tx, SIP_TX_BUF_SIZE, true);
+        if (tx_len < 0) {
+            ESP_LOGE(TAG, "REGISTER (with auth) exceeds %d-byte buffer",
+                     SIP_TX_BUF_SIZE);
+            if (err) snprintf(err, err_cap,
+                "REGISTER aborted: authenticated request too large");
+            result = REGISTER_DEFINITIVE;
+            goto cleanup;
+        }
         ESP_LOGI(TAG, "→ REGISTER with auth (%d bytes):\n%.*s",
                  tx_len, tx_len, tx);
         rx_len = sip_send_recv(c, tx, tx_len, rx, SIP_RX_BUF_SIZE);
@@ -860,7 +878,8 @@ static int build_sdp_body(const char *fallback_ip, const dialog_t *d,
     const char *ip = (d && d->media_ip[0]) ? d->media_ip : fallback_ip;
     int port       = (d && d->media_port > 0) ? d->media_port : config_rtp_port();
 
-    int n = snprintf(out, cap,
+    strbuf_t sb = sb_init(out, cap);
+    sb_appendf(&sb,
         "v=0\r\n"
         "o=phoneblock-dongle 0 0 IN IP4 %s\r\n"
         "s=-\r\n"
@@ -878,14 +897,14 @@ static int build_sdp_body(const char *fallback_ip, const dialog_t *d,
         if (mbedtls_base64_encode((unsigned char *)key_b64, sizeof(key_b64),
                                   &b64_len, d->srtp_tx_key,
                                   RTP_SRTP_KEY_LEN) == 0) {
-            n += snprintf(out + n, cap - n,
+            sb_appendf(&sb,
                 "a=crypto:%d AES_CM_128_HMAC_SHA1_80 inline:%.*s\r\n",
                 d->srtp_tag, (int)b64_len, key_b64);
         }
     }
 
-    n += snprintf(out + n, cap - n, "a=sendrecv\r\n");
-    return n;
+    sb_appendf(&sb, "a=sendrecv\r\n");
+    return sb.len;
 }
 
 // Decide the IP:port to advertise as our media endpoint in the SDP answer,

--- a/phoneblock-dongle/firmware/main/sip_response.c
+++ b/phoneblock-dongle/firmware/main/sip_response.c
@@ -6,6 +6,9 @@
 #include "sip_parse.h"   // find_header
 #include "strbuf.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Echo one full "Name: value\r\n" line from req into the builder. A missing
 // header is simply skipped; if the header is present but does not fit, the
 // builder records the truncation (checked once at the end).

--- a/phoneblock-dongle/firmware/main/sip_response.c
+++ b/phoneblock-dongle/firmware/main/sip_response.c
@@ -7,29 +7,31 @@
 
 #include "sip_parse.h"   // find_header
 
-// Append a formatted fragment at `out` (capacity `cap`, incl. NUL) and return
-// the number of bytes written — but ONLY if the whole fragment fit. If it
-// would not fit (or cap <= 0), nothing usable is emitted and 0 is returned.
+// Format one fragment at `out` (capacity `cap`, incl. NUL). Returns the number
+// of bytes written on success, or -1 if the fragment did not fit entirely (or
+// cap <= 0). vsnprintf never writes more than `cap` bytes, so this can't
+// overrun `out`; the -1 lets the builder abandon a response that would be
+// truncated instead of emitting a partial (and, on TCP, mis-framed) one.
 //
-// This is the invariant the whole builder rests on: because a fragment that
-// doesn't fit contributes 0, a running accumulator `n` can never be advanced
-// past `out_cap - 1`. Every subsequent `out + n` therefore stays inside the
-// buffer and every `out_cap - n` stays >= 1. snprintf's return value (the
-// length it WOULD have written) is deliberately not trusted as the advance —
-// that unclamped value on the ";tag=" path is what previously ran the cursor
-// off the end and smashed adjacent heap metadata.
+// IMPORTANT: a caller must treat -1 as "stop" and must NOT fold it into a
+// running length with `n += append_fmt(...)`. Doing so would move the cursor
+// *backwards*, and repeated failures would drive it negative — pointing
+// `out + n` before the buffer and making `cap - n` larger than the buffer,
+// i.e. reintroducing the very overflow this guards against. sip_response_build
+// routes every call through the ADD() macro so the check cannot be skipped.
 static int append_fmt(char *out, int cap, const char *fmt, ...)
 {
-    if (cap <= 0) return 0;
+    if (cap <= 0) return -1;
     va_list ap;
     va_start(ap, fmt);
     int w = vsnprintf(out, (size_t)cap, fmt, ap);
     va_end(ap);
-    return (w > 0 && w < cap) ? w : 0;
+    return (w >= 0 && w < cap) ? w : -1;
 }
 
 // Copy one full "Name: value\r\n" line from req into out. Returns bytes
-// written (0 if the header is absent or doesn't fit).
+// written, 0 if the header is absent (nothing to echo — not an error), or -1
+// if the header is present but does not fit.
 static int echo_header_line(const char *req, int req_len, const char *name,
                             char *out, int out_cap)
 {
@@ -45,8 +47,8 @@ static int echo_header_line(const char *req, int req_len, const char *name,
 }
 
 // Like echo_header_line, but for the To header of a dialog-forming request:
-// if the To has no tag yet, append ";tag=<our_tag>". Both branches go through
-// append_fmt, so an over-long To is dropped whole rather than overrunning.
+// if the To has no tag yet, append ";tag=<our_tag>". Returns bytes written,
+// 0 if there is no To header, or -1 if the To does not fit.
 static int echo_to_with_tag(const char *req, int req_len,
                             const char *our_tag, char *out, int out_cap)
 {
@@ -71,33 +73,47 @@ int sip_response_build(const char *req, int req_len,
                        int contact_port,
                        char *out, int out_cap)
 {
-    if (out_cap <= 0) return 0;
+    if (out_cap <= 0) return -1;
     int body_len = body ? (int)strlen(body) : 0;
 
     int n = 0;
-    n += append_fmt(out + n, out_cap - n, "SIP/2.0 %d %s\r\n", status, reason);
-    n += echo_header_line(req, req_len, "Via",     out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "From",    out + n, out_cap - n);
-    n += echo_to_with_tag(req, req_len, our_tag,   out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "Call-ID", out + n, out_cap - n);
-    n += echo_header_line(req, req_len, "CSeq",    out + n, out_cap - n);
-    n += append_fmt(out + n, out_cap - n,
+
+    // Append a fragment (or the result of an echo_* helper) and advance the
+    // cursor — but abandon the whole response if it did not fit. Because n is
+    // only ever advanced by a non-negative amount, it stays within
+    // [0, out_cap - 1], so every `out + n` / `out_cap - n` below is in range.
+    // Skipping the `< 0` check on any single call would break that invariant
+    // (see append_fmt()'s note), so every append MUST go through this macro.
+    #define ADD(expr) do {          \
+        int w_ = (expr);            \
+        if (w_ < 0) return -1;      \
+        n += w_;                    \
+    } while (0)
+
+    ADD(append_fmt(out + n, out_cap - n, "SIP/2.0 %d %s\r\n", status, reason));
+    ADD(echo_header_line(req, req_len, "Via",     out + n, out_cap - n));
+    ADD(echo_header_line(req, req_len, "From",    out + n, out_cap - n));
+    ADD(echo_to_with_tag(req, req_len, our_tag,   out + n, out_cap - n));
+    ADD(echo_header_line(req, req_len, "Call-ID", out + n, out_cap - n));
+    ADD(echo_header_line(req, req_len, "CSeq",    out + n, out_cap - n));
+    ADD(append_fmt(out + n, out_cap - n,
         "Contact: <sip:%s@%s:%d>\r\n"
         "Allow: INVITE, ACK, CANCEL, BYE, OPTIONS\r\n"
         "User-Agent: phoneblock-dongle/0.1\r\n",
-        contact_user, contact_host, contact_port);
+        contact_user, contact_host, contact_port));
 
     if (body_len > 0) {
-        n += append_fmt(out + n, out_cap - n,
+        ADD(append_fmt(out + n, out_cap - n,
             "Content-Type: application/sdp\r\n"
             "Content-Length: %d\r\n\r\n%s",
-            body_len, body);
+            body_len, body));
     } else {
-        n += append_fmt(out + n, out_cap - n,
-            "Content-Length: 0\r\n\r\n");
+        ADD(append_fmt(out + n, out_cap - n,
+            "Content-Length: 0\r\n\r\n"));
     }
 
-    // n is always <= out_cap - 1; guarantee a terminator regardless.
-    out[n < out_cap ? n : out_cap - 1] = '\0';
+    #undef ADD
+
+    out[n] = '\0';   // n is in [0, out_cap - 1]
     return n;
 }

--- a/phoneblock-dongle/firmware/main/sip_response.c
+++ b/phoneblock-dongle/firmware/main/sip_response.c
@@ -1,69 +1,44 @@
 #define _GNU_SOURCE   // memmem
 #include "sip_response.h"
 
-#include <stdarg.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "sip_parse.h"   // find_header
+#include "strbuf.h"
 
-// Format one fragment at `out` (capacity `cap`, incl. NUL). Returns the number
-// of bytes written on success, or -1 if the fragment did not fit entirely (or
-// cap <= 0). vsnprintf never writes more than `cap` bytes, so this can't
-// overrun `out`; the -1 lets the builder abandon a response that would be
-// truncated instead of emitting a partial (and, on TCP, mis-framed) one.
-//
-// IMPORTANT: a caller must treat -1 as "stop" and must NOT fold it into a
-// running length with `n += append_fmt(...)`. Doing so would move the cursor
-// *backwards*, and repeated failures would drive it negative — pointing
-// `out + n` before the buffer and making `cap - n` larger than the buffer,
-// i.e. reintroducing the very overflow this guards against. sip_response_build
-// routes every call through the ADD() macro so the check cannot be skipped.
-static int append_fmt(char *out, int cap, const char *fmt, ...)
-{
-    if (cap <= 0) return -1;
-    va_list ap;
-    va_start(ap, fmt);
-    int w = vsnprintf(out, (size_t)cap, fmt, ap);
-    va_end(ap);
-    return (w >= 0 && w < cap) ? w : -1;
-}
-
-// Copy one full "Name: value\r\n" line from req into out. Returns bytes
-// written, 0 if the header is absent (nothing to echo — not an error), or -1
-// if the header is present but does not fit.
-static int echo_header_line(const char *req, int req_len, const char *name,
-                            char *out, int out_cap)
+// Echo one full "Name: value\r\n" line from req into the builder. A missing
+// header is simply skipped; if the header is present but does not fit, the
+// builder records the truncation (checked once at the end).
+static void echo_header_line(strbuf_t *sb, const char *req, int req_len,
+                             const char *name)
 {
     const char *val = find_header(req, req_len, name);
-    if (!val) return 0;
+    if (!val) return;
 
     const char *end = req + req_len;
     const char *eol = val;
     while (eol < end && *eol != '\r' && *eol != '\n') eol++;
     int val_len = (int)(eol - val);
 
-    return append_fmt(out, out_cap, "%s: %.*s\r\n", name, val_len, val);
+    sb_appendf(sb, "%s: %.*s\r\n", name, val_len, val);
 }
 
-// Like echo_header_line, but for the To header of a dialog-forming request:
-// if the To has no tag yet, append ";tag=<our_tag>". Returns bytes written,
-// 0 if there is no To header, or -1 if the To does not fit.
-static int echo_to_with_tag(const char *req, int req_len,
-                            const char *our_tag, char *out, int out_cap)
+// Echo the To header, appending ";tag=<our_tag>" when it has no tag yet.
+static void echo_to_with_tag(strbuf_t *sb, const char *req, int req_len,
+                             const char *our_tag)
 {
     const char *val = find_header(req, req_len, "To");
-    if (!val) return 0;
+    if (!val) return;
     const char *end = req + req_len;
     const char *eol = val;
     while (eol < end && *eol != '\r' && *eol != '\n') eol++;
     int val_len = (int)(eol - val);
 
     if (memmem(val, val_len, ";tag=", 5)) {
-        return append_fmt(out, out_cap, "To: %.*s\r\n", val_len, val);
+        sb_appendf(sb, "To: %.*s\r\n", val_len, val);
+    } else {
+        sb_appendf(sb, "To: %.*s;tag=%s\r\n", val_len, val, our_tag);
     }
-    return append_fmt(out, out_cap, "To: %.*s;tag=%s\r\n",
-                      val_len, val, our_tag);
 }
 
 int sip_response_build(const char *req, int req_len,
@@ -76,44 +51,31 @@ int sip_response_build(const char *req, int req_len,
     if (out_cap <= 0) return -1;
     int body_len = body ? (int)strlen(body) : 0;
 
-    int n = 0;
-
-    // Append a fragment (or the result of an echo_* helper) and advance the
-    // cursor — but abandon the whole response if it did not fit. Because n is
-    // only ever advanced by a non-negative amount, it stays within
-    // [0, out_cap - 1], so every `out + n` / `out_cap - n` below is in range.
-    // Skipping the `< 0` check on any single call would break that invariant
-    // (see append_fmt()'s note), so every append MUST go through this macro.
-    #define ADD(expr) do {          \
-        int w_ = (expr);            \
-        if (w_ < 0) return -1;      \
-        n += w_;                    \
-    } while (0)
-
-    ADD(append_fmt(out + n, out_cap - n, "SIP/2.0 %d %s\r\n", status, reason));
-    ADD(echo_header_line(req, req_len, "Via",     out + n, out_cap - n));
-    ADD(echo_header_line(req, req_len, "From",    out + n, out_cap - n));
-    ADD(echo_to_with_tag(req, req_len, our_tag,   out + n, out_cap - n));
-    ADD(echo_header_line(req, req_len, "Call-ID", out + n, out_cap - n));
-    ADD(echo_header_line(req, req_len, "CSeq",    out + n, out_cap - n));
-    ADD(append_fmt(out + n, out_cap - n,
+    strbuf_t sb = sb_init(out, out_cap);
+    sb_appendf(&sb, "SIP/2.0 %d %s\r\n", status, reason);
+    echo_header_line(&sb, req, req_len, "Via");
+    echo_header_line(&sb, req, req_len, "From");
+    echo_to_with_tag(&sb, req, req_len, our_tag);
+    echo_header_line(&sb, req, req_len, "Call-ID");
+    echo_header_line(&sb, req, req_len, "CSeq");
+    sb_appendf(&sb,
         "Contact: <sip:%s@%s:%d>\r\n"
         "Allow: INVITE, ACK, CANCEL, BYE, OPTIONS\r\n"
         "User-Agent: phoneblock-dongle/0.1\r\n",
-        contact_user, contact_host, contact_port));
+        contact_user, contact_host, contact_port);
 
     if (body_len > 0) {
-        ADD(append_fmt(out + n, out_cap - n,
+        sb_appendf(&sb,
             "Content-Type: application/sdp\r\n"
             "Content-Length: %d\r\n\r\n%s",
-            body_len, body));
+            body_len, body);
     } else {
-        ADD(append_fmt(out + n, out_cap - n,
-            "Content-Length: 0\r\n\r\n"));
+        sb_appendf(&sb, "Content-Length: 0\r\n\r\n");
     }
 
-    #undef ADD
-
-    out[n] = '\0';   // n is in [0, out_cap - 1]
-    return n;
+    // All-or-nothing: a response with a header dropped from the middle is
+    // invalid SIP (and on TCP a Content-Length framing hazard), so if anything
+    // did not fit, report it un-buildable and let the caller send nothing.
+    if (sb.truncated) return -1;
+    return sb.len;
 }

--- a/phoneblock-dongle/firmware/main/sip_response.c
+++ b/phoneblock-dongle/firmware/main/sip_response.c
@@ -1,0 +1,103 @@
+#define _GNU_SOURCE   // memmem
+#include "sip_response.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "sip_parse.h"   // find_header
+
+// Append a formatted fragment at `out` (capacity `cap`, incl. NUL) and return
+// the number of bytes written — but ONLY if the whole fragment fit. If it
+// would not fit (or cap <= 0), nothing usable is emitted and 0 is returned.
+//
+// This is the invariant the whole builder rests on: because a fragment that
+// doesn't fit contributes 0, a running accumulator `n` can never be advanced
+// past `out_cap - 1`. Every subsequent `out + n` therefore stays inside the
+// buffer and every `out_cap - n` stays >= 1. snprintf's return value (the
+// length it WOULD have written) is deliberately not trusted as the advance —
+// that unclamped value on the ";tag=" path is what previously ran the cursor
+// off the end and smashed adjacent heap metadata.
+static int append_fmt(char *out, int cap, const char *fmt, ...)
+{
+    if (cap <= 0) return 0;
+    va_list ap;
+    va_start(ap, fmt);
+    int w = vsnprintf(out, (size_t)cap, fmt, ap);
+    va_end(ap);
+    return (w > 0 && w < cap) ? w : 0;
+}
+
+// Copy one full "Name: value\r\n" line from req into out. Returns bytes
+// written (0 if the header is absent or doesn't fit).
+static int echo_header_line(const char *req, int req_len, const char *name,
+                            char *out, int out_cap)
+{
+    const char *val = find_header(req, req_len, name);
+    if (!val) return 0;
+
+    const char *end = req + req_len;
+    const char *eol = val;
+    while (eol < end && *eol != '\r' && *eol != '\n') eol++;
+    int val_len = (int)(eol - val);
+
+    return append_fmt(out, out_cap, "%s: %.*s\r\n", name, val_len, val);
+}
+
+// Like echo_header_line, but for the To header of a dialog-forming request:
+// if the To has no tag yet, append ";tag=<our_tag>". Both branches go through
+// append_fmt, so an over-long To is dropped whole rather than overrunning.
+static int echo_to_with_tag(const char *req, int req_len,
+                            const char *our_tag, char *out, int out_cap)
+{
+    const char *val = find_header(req, req_len, "To");
+    if (!val) return 0;
+    const char *end = req + req_len;
+    const char *eol = val;
+    while (eol < end && *eol != '\r' && *eol != '\n') eol++;
+    int val_len = (int)(eol - val);
+
+    if (memmem(val, val_len, ";tag=", 5)) {
+        return append_fmt(out, out_cap, "To: %.*s\r\n", val_len, val);
+    }
+    return append_fmt(out, out_cap, "To: %.*s;tag=%s\r\n",
+                      val_len, val, our_tag);
+}
+
+int sip_response_build(const char *req, int req_len,
+                       int status, const char *reason,
+                       const char *our_tag, const char *body,
+                       const char *contact_user, const char *contact_host,
+                       int contact_port,
+                       char *out, int out_cap)
+{
+    if (out_cap <= 0) return 0;
+    int body_len = body ? (int)strlen(body) : 0;
+
+    int n = 0;
+    n += append_fmt(out + n, out_cap - n, "SIP/2.0 %d %s\r\n", status, reason);
+    n += echo_header_line(req, req_len, "Via",     out + n, out_cap - n);
+    n += echo_header_line(req, req_len, "From",    out + n, out_cap - n);
+    n += echo_to_with_tag(req, req_len, our_tag,   out + n, out_cap - n);
+    n += echo_header_line(req, req_len, "Call-ID", out + n, out_cap - n);
+    n += echo_header_line(req, req_len, "CSeq",    out + n, out_cap - n);
+    n += append_fmt(out + n, out_cap - n,
+        "Contact: <sip:%s@%s:%d>\r\n"
+        "Allow: INVITE, ACK, CANCEL, BYE, OPTIONS\r\n"
+        "User-Agent: phoneblock-dongle/0.1\r\n",
+        contact_user, contact_host, contact_port);
+
+    if (body_len > 0) {
+        n += append_fmt(out + n, out_cap - n,
+            "Content-Type: application/sdp\r\n"
+            "Content-Length: %d\r\n\r\n%s",
+            body_len, body);
+    } else {
+        n += append_fmt(out + n, out_cap - n,
+            "Content-Length: 0\r\n\r\n");
+    }
+
+    // n is always <= out_cap - 1; guarantee a terminator regardless.
+    out[n < out_cap ? n : out_cap - 1] = '\0';
+    return n;
+}

--- a/phoneblock-dongle/firmware/main/sip_response.h
+++ b/phoneblock-dongle/firmware/main/sip_response.h
@@ -16,10 +16,14 @@
 // no tag yet, ";tag=<our_tag>" is appended to the echoed To. Callers that
 // need a fresh stateless tag (e.g. OPTIONS) generate one and pass it in.
 //
-// Returns the number of bytes written (always strictly < out_cap). The
-// result is NUL-terminated. The function never writes outside `out`, no
-// matter how long the request's headers are — every field that does not fit
-// in the remaining space is dropped whole rather than truncated mid-write.
+// Returns the number of bytes written (NUL-terminated, always < out_cap) on
+// success, or -1 if the complete response does not fit in `out`. It is
+// all-or-nothing: rather than emit a response with a header dropped from the
+// middle (invalid SIP, and on TCP a Content-Length framing hazard), a request
+// whose echoed headers overflow the buffer yields -1 and the caller must send
+// nothing. The function never writes outside `out` regardless of input. A
+// legitimate request always fits comfortably; -1 only happens for a
+// pathologically oversized (malformed/hostile) request.
 int sip_response_build(const char *req, int req_len,
                        int status, const char *reason,
                        const char *our_tag, const char *body,

--- a/phoneblock-dongle/firmware/main/sip_response.h
+++ b/phoneblock-dongle/firmware/main/sip_response.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Builds SIP responses that echo the routing headers (Via/From/To/Call-ID/
+// CSeq) from a received request. Split out of sip_register.c so the buffer
+// arithmetic can be unit-tested on the host (see test/test_sip_response.c):
+// a hostile request with oversized headers must never overrun the fixed
+// response buffer.
+
+// Assemble a SIP response into `out` (capacity `out_cap`, including the
+// terminating NUL). Echoes Via/From/To/Call-ID/CSeq from `req`, appends a
+// Contact built from `contact_user`/`contact_host`/`contact_port`, the
+// standard Allow/User-Agent, and either an SDP `body` (NULL → none) with a
+// matching Content-Length or an empty body.
+//
+// `our_tag` must be non-NULL: for a dialog-forming request whose To carries
+// no tag yet, ";tag=<our_tag>" is appended to the echoed To. Callers that
+// need a fresh stateless tag (e.g. OPTIONS) generate one and pass it in.
+//
+// Returns the number of bytes written (always strictly < out_cap). The
+// result is NUL-terminated. The function never writes outside `out`, no
+// matter how long the request's headers are — every field that does not fit
+// in the remaining space is dropped whole rather than truncated mid-write.
+int sip_response_build(const char *req, int req_len,
+                       int status, const char *reason,
+                       const char *our_tag, const char *body,
+                       const char *contact_user, const char *contact_host,
+                       int contact_port,
+                       char *out, int out_cap);

--- a/phoneblock-dongle/firmware/main/sip_srv.c
+++ b/phoneblock-dongle/firmware/main/sip_srv.c
@@ -164,6 +164,9 @@ int sip_srv_pick(const sip_srv_record_t *records, int n, uint32_t rnd)
 #include "lwip/inet.h"
 #include "lwip/ip_addr.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "sip_srv";
 
 // Encode "_sips._tcp.tel.t-online.de" into DNS labels:

--- a/phoneblock-dongle/firmware/main/sip_transport.c
+++ b/phoneblock-dongle/firmware/main/sip_transport.c
@@ -15,6 +15,9 @@
 
 #include "sip_frame.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "sip_transport";
 
 // Per-message reassembly window for stream transports. 4 KiB matches

--- a/phoneblock-dongle/firmware/main/smtp_body.c
+++ b/phoneblock-dongle/firmware/main/smtp_body.c
@@ -2,6 +2,9 @@
 
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 int smtp_encode_body(const char *body, smtp_body_sink sink, void *ctx)
 {
     for (const char *p = body; *p; ) {

--- a/phoneblock-dongle/firmware/main/stats.c
+++ b/phoneblock-dongle/firmware/main/stats.c
@@ -6,6 +6,9 @@
 #include "freertos/semphr.h"
 #include "esp_timer.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // All mutable state lives here and is guarded by s_mutex. Callers
 // either record an event (briefly lock, mutate, unlock) or take a
 // snapshot (briefly lock, memcpy, unlock). Snapshots mean the web

--- a/phoneblock-dongle/firmware/main/status_led.c
+++ b/phoneblock-dongle/firmware/main/status_led.c
@@ -14,6 +14,9 @@
 #include "sip_register.h"
 #include "wifi.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "status_led";
 
 #define TICK_MS 50

--- a/phoneblock-dongle/firmware/main/strbuf.h
+++ b/phoneblock-dongle/firmware/main/strbuf.h
@@ -1,0 +1,77 @@
+#pragma once
+
+// Bounded string builder for assembling text into a fixed buffer.
+//
+// It hides the one dangerous part of the snprintf() API — the return value,
+// which is the length snprintf WOULD have written, not what it did. Feeding
+// that unclamped value into a running offset (`n += snprintf(buf + n, cap - n,
+// ...)`) is how an over-long field runs the cursor past the buffer end, after
+// which the next write gets a negative `cap - n` (a huge size_t) and overruns
+// the allocation. sb_appendf() never exposes that value: it advances the
+// cursor by at most the space left, so the builder is memory-safe no matter
+// how long the inputs are, and records whether anything had to be dropped.
+//
+// Usage:
+//     strbuf_t sb = sb_init(buf, sizeof(buf));
+//     sb_appendf(&sb, "hello %s", name);
+//     sb_appendf(&sb, " x=%d", x);
+//     // sb.len  = bytes written (buf is NUL-terminated)
+//     // sb.truncated = true if any append did not fit entirely
+//
+// Callers that must be all-or-nothing (e.g. a SIP message that would become
+// invalid or mis-framed if a header were dropped) check sb.truncated at the
+// end and discard the result. Callers for whom a clamped result is acceptable
+// (log lines, best-effort URLs) can ignore it.
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+typedef struct {
+    char *buf;        // destination buffer
+    int   cap;        // capacity in bytes, including the terminating NUL
+    int   len;        // bytes written so far (always < cap; buf[len] == '\0')
+    bool  truncated;  // set once any append could not be written in full
+} strbuf_t;
+
+// Initialise a builder over `buf` (capacity `cap`, including the NUL). The
+// buffer is NUL-terminated immediately so a builder to which nothing is
+// appended still yields a valid empty string.
+static inline strbuf_t sb_init(char *buf, int cap)
+{
+    if (cap > 0) buf[0] = '\0';
+    strbuf_t sb = { buf, cap, 0, false };
+    return sb;
+}
+
+// Append the formatted text. If it does not fit entirely, as much as fits is
+// written (the buffer stays NUL-terminated) and sb->truncated is set. The
+// cursor is only ever advanced by bytes actually written, so sb->len stays in
+// [0, cap - 1] and no write can leave the buffer.
+static inline void sb_vappendf(strbuf_t *sb, const char *fmt, va_list ap)
+{
+    int room = sb->cap - sb->len;          // includes space for the NUL
+    if (room <= 0) { sb->truncated = true; return; }
+
+    int w = vsnprintf(sb->buf + sb->len, (size_t)room, fmt, ap);
+    if (w < 0) {                           // encoding error
+        sb->truncated = true;
+    } else if (w >= room) {                // didn't fit: filled to the brim
+        sb->len = sb->cap - 1;
+        sb->truncated = true;
+    } else {
+        sb->len += w;
+    }
+}
+
+static inline void sb_appendf(strbuf_t *sb, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+
+static inline void sb_appendf(strbuf_t *sb, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    sb_vappendf(sb, fmt, ap);
+    va_end(ap);
+}

--- a/phoneblock-dongle/firmware/main/sync.c
+++ b/phoneblock-dongle/firmware/main/sync.c
@@ -21,6 +21,9 @@
 #include "tr064.h"
 #include "tr064_parse.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "sync";
 
 // The 24 h cadence and the manual-trigger wakeup now live in the shared

--- a/phoneblock-dongle/firmware/main/time_sync.c
+++ b/phoneblock-dongle/firmware/main/time_sync.c
@@ -12,6 +12,9 @@
 #include "config.h"
 #include "scheduler.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "time_sync";
 
 // Static SNTP servers we register: the default gateway and pool.ntp.org.

--- a/phoneblock-dongle/firmware/main/tr064.c
+++ b/phoneblock-dongle/firmware/main/tr064.c
@@ -17,6 +17,9 @@
 #include "http_util.h"
 #include "tr064_parse.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Short aliases for the parser helpers — keeps call sites compact.
 #define xml_find_text(...)       tr064_xml_find_text(__VA_ARGS__)
 #define xml_unescape_inplace(...) tr064_xml_unescape_inplace(__VA_ARGS__)

--- a/phoneblock-dongle/firmware/main/tr064_parse.c
+++ b/phoneblock-dongle/firmware/main/tr064_parse.c
@@ -152,6 +152,10 @@ int tr064_parse_phonebook_contacts(char *xml, int xml_len,
     while (remaining > 0) {
         char *open = memmem(p, remaining, "<contact", 8);
         if (!open) break;
+        // Need at least one byte after "<contact" to classify the tag. If the
+        // match sits flush against the buffer end, reading open[8] would run
+        // one past it (and no complete <contact…>…</contact> can follow).
+        if ((open - xml) + 8 >= xml_len) break;
         char after = open[8];
         if (after != '>' && after != ' ' && after != '\t'
             && after != '\r' && after != '\n') {

--- a/phoneblock-dongle/firmware/main/tr064_parse.c
+++ b/phoneblock-dongle/firmware/main/tr064_parse.c
@@ -10,6 +10,9 @@
 
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 int tr064_xml_find_text(const char *xml, const char *tag,
                         char *out, size_t cap)
 {

--- a/phoneblock-dongle/firmware/main/version_cmp.c
+++ b/phoneblock-dongle/firmware/main/version_cmp.c
@@ -4,6 +4,9 @@
 #include <stdio.h>
 #include <string.h>
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 // Natural compare of two pre-release identifiers (the part after the
 // first '-', e.g. "rc1", "rc2", "rc10", "dev"). Non-digit runs compare
 // byte-wise; digit runs compare numerically (leading zeros ignored), so

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -39,6 +39,9 @@
 #include "tr064.h"
 #include "web_auth.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "web";
 
 static httpd_handle_t s_server = NULL;

--- a/phoneblock-dongle/firmware/main/web_access.c
+++ b/phoneblock-dongle/firmware/main/web_access.c
@@ -8,6 +8,9 @@
 
 #include "net_local.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "web_access";
 
 // Read the request's immediate TCP peer into `out` (v4-mapped

--- a/phoneblock-dongle/firmware/main/web_auth.c
+++ b/phoneblock-dongle/firmware/main/web_auth.c
@@ -13,6 +13,9 @@
 #include "web.h"
 #include "web_access.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "web_auth";
 
 // --- Session store --------------------------------------------------

--- a/phoneblock-dongle/firmware/main/wifi.c
+++ b/phoneblock-dongle/firmware/main/wifi.c
@@ -13,6 +13,9 @@
 #include "freertos/task.h"
 #include "sdkconfig.h"
 
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
 static const char *TAG = "wifi";
 
 #define WIFI_CONNECTED_BIT BIT0

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_sip_response test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local
+BINS = test_strbuf test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_sip_response test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -58,6 +58,11 @@ test_version_cmp: test_version_cmp.c ../main/version_cmp.c ../main/version_cmp.h
 
 test_net_local: test_net_local.c ../main/net_local.c ../main/net_local.h
 	$(CC) $(CFLAGS) test_net_local.c ../main/net_local.c -o $@
+
+# strbuf.h is header-only; build its test with AddressSanitizer so any overrun
+# of the (malloc'd) destination buffer aborts.
+test_strbuf: test_strbuf.c ../main/strbuf.h
+	$(CC) $(CFLAGS) -fsanitize=address test_strbuf.c -o $@
 
 # Built with AddressSanitizer: this test exists to catch buffer overruns in
 # the SIP response builder, so the sanitizer must be active for it to mean

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local
+BINS = test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_sip_response test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -58,6 +58,13 @@ test_version_cmp: test_version_cmp.c ../main/version_cmp.c ../main/version_cmp.h
 
 test_net_local: test_net_local.c ../main/net_local.c ../main/net_local.h
 	$(CC) $(CFLAGS) test_net_local.c ../main/net_local.c -o $@
+
+# Built with AddressSanitizer: this test exists to catch buffer overruns in
+# the SIP response builder, so the sanitizer must be active for it to mean
+# anything. sip_response.c / the test define _GNU_SOURCE themselves (memmem).
+test_sip_response: test_sip_response.c ../main/sip_response.c ../main/sip_response.h \
+                   ../main/sip_parse.c ../main/sip_parse.h ../main/audio.c
+	$(CC) $(CFLAGS) -fsanitize=address test_sip_response.c ../main/sip_response.c ../main/sip_parse.c ../main/audio.c -o $@
 
 test: $(BINS)
 	@set -e; for b in $(BINS); do echo "→ $$b"; ./$$b; done

--- a/phoneblock-dongle/firmware/test/test_sip_response.c
+++ b/phoneblock-dongle/firmware/test/test_sip_response.c
@@ -4,8 +4,8 @@
 // buffer that send_response() allocates on the device.
 //
 // Build with AddressSanitizer (see Makefile). Before the fix, test_oversized_
-// to_with_tag() overruns the heap buffer and ASan aborts; after the fix it
-// passes with a cleanly truncated response.
+// to_with_tag() overruns the heap buffer and ASan aborts; after the fix the
+// builder reports -1 (all-or-nothing) and send_response drops the message.
 
 #define _GNU_SOURCE
 #include <assert.h>
@@ -57,7 +57,8 @@ static void test_normal_bye(void)
 // the 2048-byte buffer. The pre-fix echo_to_with_tag() returned the
 // unclamped snprintf length here, inflating the accumulator past the buffer
 // end so the following Call-ID/Contact writes ran off the allocation and
-// smashed adjacent heap metadata. The builder must instead stay in-bounds.
+// smashed adjacent heap metadata. The builder must now report -1 (drop the
+// whole response) rather than write past the buffer or emit a partial one.
 static void test_oversized_to_with_tag(void)
 {
     printf("test_oversized_to_with_tag\n");
@@ -84,36 +85,48 @@ static void test_oversized_to_with_tag(void)
     char *tx = malloc(TX_CAP);   // ASan-guarded: any OOB write aborts here
     int n = sip_response_build(req, r, 200, "OK", "dongle01", NULL,
                                "620", "192.168.178.68", 15060, tx, TX_CAP);
-    // If we get here without ASan aborting, the write stayed in-bounds.
-    CHECK(n >= 0 && n < TX_CAP, "oversized request stays within buffer");
-    CHECK(tx[n] == '\0', "NUL terminated even when truncated");
+    // All-or-nothing: the oversized request is reported un-buildable, not
+    // written partially. (ASan independently guards against any stray write.)
+    CHECK(n < 0, "oversized request dropped (returns -1)");
     free(tx);
 }
 
-// A tiny buffer must not be overrun regardless of how the fields land.
-static void test_tiny_buffer(void)
+// Across every buffer size the builder either produces a complete, terminated
+// response strictly within cap, or reports -1 — never a partial write, and
+// never an out-of-bounds one (ASan-checked). This is the property that would
+// break if any append_fmt() result went unchecked and drove the cursor
+// negative.
+static void test_all_or_nothing_across_sizes(void)
 {
-    printf("test_tiny_buffer\n");
+    printf("test_all_or_nothing_across_sizes\n");
     const char *req =
         "BYE sip:620@fritz.box SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP 192.168.178.1:5060;branch=z9hG4bKabc\r\n"
+        "From: <sip:+491234@fritz.box>;tag=caller99\r\n"
         "To: <sip:620@fritz.box>;tag=dongle01\r\n"
-        "Call-ID: x@y\r\n"
+        "Call-ID: 12345@fritz.box\r\n"
         "CSeq: 2 BYE\r\n\r\n";
-    for (int cap = 1; cap <= 200; cap++) {
+    int first_ok = -1;
+    for (int cap = 1; cap <= 400; cap++) {
         char *tx = malloc(cap);
         int n = sip_response_build(req, (int)strlen(req), 200, "OK",
                                    "dongle01", NULL, "620", "h", 5060, tx, cap);
-        CHECK(n >= 0 && n < cap, "n within cap");
-        CHECK(tx[n] == '\0', "terminated");
+        int ok = (n < 0) || (n > 0 && n < cap && tx[n] == '\0');
+        if (!ok) { CHECK(0, "complete-or-dropped"); free(tx); return; }
+        if (n >= 0 && first_ok < 0) first_ok = cap;
         free(tx);
     }
+    CHECK(first_ok > 0, "some buffer size builds a complete response");
+    // Once it fits, larger buffers keep fitting (monotonic), and the smallest
+    // fitting size is well under the device's 2048-byte buffer.
+    CHECK(first_ok < TX_CAP, "complete response fits well within 2048 bytes");
 }
 
 int main(void)
 {
     test_normal_bye();
     test_oversized_to_with_tag();
-    test_tiny_buffer();
+    test_all_or_nothing_across_sizes();
     printf("\n%d checks, %d failed\n", tests_run, tests_failed);
     return tests_failed ? 1 : 0;
 }

--- a/phoneblock-dongle/firmware/test/test_sip_response.c
+++ b/phoneblock-dongle/firmware/test/test_sip_response.c
@@ -1,0 +1,119 @@
+// Host test for sip_response_build() — the SIP response builder split out of
+// sip_register.c. The point of interest is memory safety: a received request
+// with oversized headers must never overrun the fixed 2048-byte response
+// buffer that send_response() allocates on the device.
+//
+// Build with AddressSanitizer (see Makefile). Before the fix, test_oversized_
+// to_with_tag() overruns the heap buffer and ASan aborts; after the fix it
+// passes with a cleanly truncated response.
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../main/sip_response.h"
+
+// Same size as SIP_TX_BUF_SIZE in sip_register.c.
+#define TX_CAP 2048
+
+static int tests_run, tests_failed;
+#define CHECK(cond, msg) do {                                   \
+    tests_run++;                                                \
+    if (!(cond)) { tests_failed++;                              \
+        printf("  FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);\
+    } else printf("  ok: %s\n", msg);                           \
+} while (0)
+
+// A normal in-dialog BYE produces a well-formed 200 OK that echoes the
+// routing headers unchanged.
+static void test_normal_bye(void)
+{
+    printf("test_normal_bye\n");
+    const char *req =
+        "BYE sip:620@fritz.box SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP 192.168.178.1:5060;branch=z9hG4bKabc\r\n"
+        "From: <sip:+491234@fritz.box>;tag=caller99\r\n"
+        "To: <sip:620@fritz.box>;tag=dongle01\r\n"
+        "Call-ID: 12345@fritz.box\r\n"
+        "CSeq: 2 BYE\r\n"
+        "\r\n";
+    char *tx = malloc(TX_CAP);
+    int n = sip_response_build(req, (int)strlen(req), 200, "OK",
+                               "dongle01", NULL,
+                               "620", "192.168.178.68", 15060, tx, TX_CAP);
+    CHECK(n > 0 && n < TX_CAP, "length within buffer");
+    CHECK(strncmp(tx, "SIP/2.0 200 OK\r\n", 16) == 0, "status line");
+    CHECK(strstr(tx, "Call-ID: 12345@fritz.box\r\n") != NULL, "Call-ID echoed");
+    CHECK(strstr(tx, "To: <sip:620@fritz.box>;tag=dongle01\r\n") != NULL,
+          "tagged To echoed verbatim");
+    CHECK(tx[n] == '\0', "NUL terminated");
+    free(tx);
+}
+
+// The regression case: a request whose To header ALREADY carries ;tag= (any
+// in-dialog request does) and is large enough that the echoed headers exceed
+// the 2048-byte buffer. The pre-fix echo_to_with_tag() returned the
+// unclamped snprintf length here, inflating the accumulator past the buffer
+// end so the following Call-ID/Contact writes ran off the allocation and
+// smashed adjacent heap metadata. The builder must instead stay in-bounds.
+static void test_oversized_to_with_tag(void)
+{
+    printf("test_oversized_to_with_tag\n");
+    // ~1900-byte To display name, plus a real ;tag= so the vulnerable branch
+    // is taken. Uppercase filler mirrors the field crash signature.
+    char big_to[2000];
+    int p = 0;
+    p += sprintf(big_to + p, "To: \"");
+    memset(big_to + p, 'A', 1900); p += 1900;
+    p += sprintf(big_to + p, "\" <sip:620@fritz.box>;tag=dongle01");
+    big_to[p] = '\0';
+
+    char req[4096];
+    int r = snprintf(req, sizeof(req),
+        "BYE sip:620@fritz.box SIP/2.0\r\n"
+        "Via: SIP/2.0/UDP 192.168.178.1:5060;branch=z9hG4bKabc\r\n"
+        "From: <sip:+491234@fritz.box>;tag=caller99\r\n"
+        "%s\r\n"
+        "Call-ID: aaaaaaaaaaaaaaaaaaaa@fritz.box\r\n"
+        "CSeq: 2 BYE\r\n"
+        "\r\n", big_to);
+    assert(r > 0 && r < (int)sizeof(req));
+
+    char *tx = malloc(TX_CAP);   // ASan-guarded: any OOB write aborts here
+    int n = sip_response_build(req, r, 200, "OK", "dongle01", NULL,
+                               "620", "192.168.178.68", 15060, tx, TX_CAP);
+    // If we get here without ASan aborting, the write stayed in-bounds.
+    CHECK(n >= 0 && n < TX_CAP, "oversized request stays within buffer");
+    CHECK(tx[n] == '\0', "NUL terminated even when truncated");
+    free(tx);
+}
+
+// A tiny buffer must not be overrun regardless of how the fields land.
+static void test_tiny_buffer(void)
+{
+    printf("test_tiny_buffer\n");
+    const char *req =
+        "BYE sip:620@fritz.box SIP/2.0\r\n"
+        "To: <sip:620@fritz.box>;tag=dongle01\r\n"
+        "Call-ID: x@y\r\n"
+        "CSeq: 2 BYE\r\n\r\n";
+    for (int cap = 1; cap <= 200; cap++) {
+        char *tx = malloc(cap);
+        int n = sip_response_build(req, (int)strlen(req), 200, "OK",
+                                   "dongle01", NULL, "620", "h", 5060, tx, cap);
+        CHECK(n >= 0 && n < cap, "n within cap");
+        CHECK(tx[n] == '\0', "terminated");
+        free(tx);
+    }
+}
+
+int main(void)
+{
+    test_normal_bye();
+    test_oversized_to_with_tag();
+    test_tiny_buffer();
+    printf("\n%d checks, %d failed\n", tests_run, tests_failed);
+    return tests_failed ? 1 : 0;
+}

--- a/phoneblock-dongle/firmware/test/test_strbuf.c
+++ b/phoneblock-dongle/firmware/test/test_strbuf.c
@@ -1,0 +1,108 @@
+// Host test for strbuf.h — the bounded string builder. Built with
+// AddressSanitizer (see Makefile): the buffer is malloc'd so any write past
+// the requested capacity aborts, proving the builder never overruns however
+// long the appended text is.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../main/strbuf.h"
+
+static int tests_run, tests_failed;
+#define CHECK(cond, msg) do {                                   \
+    tests_run++;                                                \
+    if (!(cond)) { tests_failed++;                              \
+        printf("  FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);\
+    } else printf("  ok: %s\n", msg);                           \
+} while (0)
+
+static void test_basic(void)
+{
+    printf("test_basic\n");
+    char *buf = malloc(64);
+    strbuf_t sb = sb_init(buf, 64);
+    CHECK(sb.len == 0 && !sb.truncated && buf[0] == '\0', "empty after init");
+    sb_appendf(&sb, "hello %s", "world");
+    sb_appendf(&sb, " x=%d", 42);
+    CHECK(strcmp(buf, "hello world x=42") == 0, "content correct");
+    CHECK(sb.len == (int)strlen(buf), "len matches strlen");
+    CHECK(!sb.truncated, "not truncated");
+    free(buf);
+}
+
+static void test_exact_fit(void)
+{
+    printf("test_exact_fit\n");
+    // "abc" needs 4 bytes incl NUL; cap 4 fits exactly, cap 3 truncates.
+    char *b4 = malloc(4);
+    strbuf_t s4 = sb_init(b4, 4);
+    sb_appendf(&s4, "abc");
+    CHECK(!s4.truncated && s4.len == 3 && strcmp(b4, "abc") == 0, "exact fit");
+    free(b4);
+
+    char *b3 = malloc(3);
+    strbuf_t s3 = sb_init(b3, 3);
+    sb_appendf(&s3, "abc");
+    CHECK(s3.truncated && s3.len == 2 && b3[2] == '\0', "one short truncates");
+    free(b3);
+}
+
+// The core safety property: appending far more than the buffer holds must
+// never write past it, must set truncated, and must leave len at cap-1.
+static void test_overflow_is_contained(void)
+{
+    printf("test_overflow_is_contained\n");
+    char *buf = malloc(16);   // ASan-guarded
+    strbuf_t sb = sb_init(buf, 16);
+    sb_appendf(&sb, "%s", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");  // 40 A's
+    CHECK(sb.truncated, "truncated flag set");
+    CHECK(sb.len == 15, "len saturated at cap-1");
+    CHECK(buf[15] == '\0', "NUL terminated");
+    // Further appends after truncation stay safe and no-op the content.
+    sb_appendf(&sb, "more");
+    CHECK(sb.len == 15 && buf[15] == '\0', "post-overflow append is safe");
+    free(buf);
+}
+
+// Sweep: for every capacity, a chain of appends is either fully present or
+// marked truncated — never a partial write past the buffer (ASan-checked).
+static void test_accumulator_sweep(void)
+{
+    printf("test_accumulator_sweep\n");
+    int first_complete = -1;
+    for (int cap = 1; cap <= 128; cap++) {
+        char *buf = malloc(cap);
+        strbuf_t sb = sb_init(buf, cap);
+        sb_appendf(&sb, "GET /path?a=%d", 1);
+        sb_appendf(&sb, "&b=%s", "value");
+        sb_appendf(&sb, "&c=%d\r\n", 999);
+        int ok = (sb.len >= 0 && sb.len < cap && buf[sb.len] == '\0');
+        if (!ok) { CHECK(0, "len in range + terminated"); free(buf); return; }
+        if (!sb.truncated && first_complete < 0) first_complete = cap;
+        free(buf);
+    }
+    CHECK(first_complete > 0, "some capacity holds the full string");
+}
+
+static void test_zero_cap(void)
+{
+    printf("test_zero_cap\n");
+    char dummy = 'x';
+    strbuf_t sb = sb_init(&dummy, 0);   // cap 0: cannot even hold a NUL
+    sb_appendf(&sb, "anything");
+    CHECK(sb.truncated && sb.len == 0, "zero cap: truncated, nothing written");
+    free(NULL);
+}
+
+int main(void)
+{
+    test_basic();
+    test_exact_fit();
+    test_overflow_is_contained();
+    test_accumulator_sweep();
+    test_zero_cap();
+    printf("\n%d checks, %d failed\n", tests_run, tests_failed);
+    return tests_failed ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Fixes a network-reachable heap-buffer-overflow in the answer-bot dongle firmware's SIP response builder — the cause of the 1.5.0 field crash coredump (heap block metadata overwritten with SIP header ASCII, surfacing later as a crash while walking the heap in the `/api/status` handler).

**Root cause:** `echo_to_with_tag()` returned `snprintf`'s *would-have-been* length unclamped on the `;tag=` branch. `build_response()` added that to its cursor, so an oversized in-dialog request (a `To` header carrying `;tag=` plus headers totalling >2 KB) ran the cursor past the 2048-byte response buffer; the following `Call-ID`/`CSeq`/`Contact` writes then overran the allocation into adjacent heap blocks. `handle_bye()` answers any BYE before dialog validation, so it's reachable from a crafted in-dialog request over the registrar (TCP) connection. Rare in the field because normal Fritz!Box traffic never sends multi-kilobyte in-dialog requests.

## Changes (commit by commit)

1. **Fix the overflow** — split the response builder into `sip_response.c` (host-testable) and make it overflow-proof; `test_sip_response.c` reproduces the overflow under AddressSanitizer (aborts on the old code, passes on the new).
2. **Minor hardening** from the audit — `blocklist_lookup.c` (validate record counts vs file size before a 32-bit `(long)` seek), `tr064_parse.c` (guard a 1-byte over-read), `mail.c` (widen an under-sized label buffer).
3. **All-or-nothing** — a response that would drop a header from the middle is invalid SIP (and mis-frames on TCP), so the builder now reports truncation and `send_response` transmits nothing instead of a partial message.
4. **`strbuf.h`** — a bounded string builder that hides `snprintf`'s footgun return value; all multi-step `n += snprintf(buf+n, cap-n, ...)` accumulators (`build_register`, `build_sdp_body`, the API/blocklist URL builders) migrated onto it — memory-safe by construction.
5. **`banned_apis.h`** — `#pragma GCC poison` on `sprintf`/`vsprintf`/`strcat`/`gets` (zero uses today; pure prevention), wired last-include into every `main/*.c`; plus a CLAUDE.md note directing new multi-step string assembly to `strbuf`.

## Testing

- **Host suite** (`firmware/test`, `make test`): all pass, incl. new `test_strbuf` and `test_sip_response` under AddressSanitizer.
- **Full `idf.py build`**: clean.
- **Live on hardware** (answerbot): flashed the fixed build; it boots, registers (exercises `build_register`/strbuf), and returns a correct `200 OK` to a crafted BYE (exercises `build_response`/strbuf). Note: the >2 KB overflow itself can't be delivered over UDP (the dongle has `CONFIG_LWIP_IP4_REASSEMBLY` off, so oversized fragments are dropped) and there's no TCP listener to inject into — so the overflow's non-crash is proven by the deterministic ASAN test, and the real attack surface is the TCP registrar path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)