### PR TITLE
Dongle: fix TCP reconnect failing with EADDRINUSE

### DIFF
--- a/phoneblock-dongle/firmware/main/sip_transport.c
+++ b/phoneblock-dongle/firmware/main/sip_transport.c
@@ -229,21 +229,24 @@ static bool tcp_connect(sip_transport_t *t)
         return false;
     }
 
-    if (t->local_port > 0) {
-        struct sockaddr_in local = {
-            .sin_family      = AF_INET,
-            .sin_addr.s_addr = htonl(INADDR_ANY),
-            .sin_port        = htons(t->local_port),
-        };
-        int yes = 1;
-        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-        if (bind(sock, (struct sockaddr *)&local, sizeof(local)) < 0) {
-            // Non-fatal: kernel will pick an ephemeral port. Via/Contact
-            // get re-read below from getsockname() so consistency holds.
-            ESP_LOGW(TAG, "TCP bind %d failed (%s); using ephemeral",
-                     t->local_port, strerror(errno));
-        }
-    }
+    // Deliberately do NOT bind() the socket to the configured local port
+    // (t->local_port). Doing so pinned every connect to the same source
+    // port, so a reconnect to the same registrar produced a 4-tuple
+    // (localIP:15060 → registrarIP:5060) identical to the just-closed
+    // connection still lingering in TIME_WAIT — and connect() then failed
+    // with EADDRINUSE ("Address already in use"). SO_REUSEADDR lets you
+    // *bind* a TIME_WAIT port but does not relax the connect-side 4-tuple
+    // uniqueness check, so binding was the trap, not the cure.
+    //
+    // A fixed source port buys nothing here: the advertised Contact/Via
+    // port comes from config (advertised_port() in sip_register.c), and for
+    // connection-oriented SIP the registrar reuses THIS connection for
+    // responses and in-dialog requests (RFC 3261 §18.2 / RFC 5923) rather
+    // than dialing back to the advertised port. Letting the kernel assign a
+    // fresh ephemeral source port each connect means a reconnect draws a
+    // new 4-tuple that can't collide with the lingering TIME_WAIT one. This
+    // matches TLS, which already connects from an ephemeral port via
+    // esp-tls and reconnects without trouble.
 
     if (connect(sock, (struct sockaddr *)&t->registrar,
                 sizeof(t->registrar)) < 0) {
@@ -254,6 +257,10 @@ static bool tcp_connect(sip_transport_t *t)
 
     set_send_timeout(sock);
 
+    // Record the kernel-assigned ephemeral source port for diagnostics /
+    // the local-port accessor. It is NOT what gets advertised — Via/Contact
+    // use the configured port (advertised_port() in sip_register.c) — so a
+    // fresh port on each reconnect is expected and harmless.
     struct sockaddr_in actual = {0};
     socklen_t alen = sizeof(actual);
     if (getsockname(sock, (struct sockaddr *)&actual, &alen) == 0) {


### PR DESCRIPTION
## Problem

With **TCP** transport, reconnecting to the registrar (e.g. after a Fritz!Box drops the SIP connection) fails with:

```
[sip_transport] TCP connect failed: Address already in use
```

The dongle then can't re-register until the TIME_WAIT socket finally expires.

## Root cause

`tcp_connect()` bound each new socket to the **fixed** configured local port (`config_sip_local_port()`, default 15060) before `connect()`. On a reconnect to the same registrar, the previous connection's 4-tuple `(localIP:15060 → registrarIP:5060)` is still lingering in **TIME_WAIT**.

`SO_REUSEADDR` lets the `bind()` succeed — but the subsequent `connect()` reproduces the *exact same 4-tuple*, which the kernel rejects with **EADDRINUSE**. `SO_REUSEADDR` does **not** relax the connect-side 4-tuple uniqueness check. `getsockname()` then re-pinned the port to 15060, so every reconnect re-collided.

## Fix

Stop binding TCP to the fixed local port; let the kernel assign a fresh **ephemeral** source port on each connect. A different source port per reconnect means the new 4-tuple can't collide with the lingering TIME_WAIT one.

This is safe because a fixed source port buys nothing for TCP:
- The advertised Contact/Via port comes from config (`advertised_port()` in `sip_register.c`), **not** the socket.
- Connection-oriented SIP reuses the existing connection for responses / in-dialog requests (RFC 3261 §18.2 / RFC 5923); the registrar never dials back to the advertised port.
- **TLS already** connects from an ephemeral port via esp-tls and reconnects fine — this aligns TCP with the proven path.
- `sip_transport_local_port()` has no callers; the `getsockname()` readback is kept for diagnostics only.

## Testing

- `idf.py build` succeeds.
- Host test suite passes (8/8). The transport path has no host-test harness (needs real sockets); a live TCP reconnect on the dongle rig is the recommended final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)