### PR TITLE
Mobile: pin auto-translate-arb to the published 1.1.1

### DIFF
--- a/phoneblock_mobile/build.gradle
+++ b/phoneblock_mobile/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.haumacher.auto-translate-arb' version '1.1.0'
+    id 'de.haumacher.auto-translate-arb' version '1.1.1'
 }
 
 translateArb {


### PR DESCRIPTION
phoneblock_mobile pinned `de.haumacher.auto-translate-arb` **1.1.0**, which is not published on the Gradle Plugin Portal (only **1.1.1** is), so `./gradlew translateArb` cannot resolve the plugin. Bump to **1.1.1** — the version that actually resolves via `gradlePluginPortal()` — matching the dongle work in #460.

Verified: `gradle help` configures the project and resolves 1.1.1 from the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)