### PR TITLE
Dongle 1.5.2: heap-corruption sentinel + chunked-reply fix

### DIFF
--- a/phoneblock-dongle/firmware/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/CMakeLists.txt
@@ -27,7 +27,16 @@ endif()
 # only compute one here when version.txt is absent (i.e. dev builds).
 # If git is unavailable or no tag matches, PROJECT_VER stays unset and
 # ESP-IDF's own fallback applies — no regression.
-if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/version.txt")
+# Either way the chosen version and where it came from is printed, because a
+# version.txt that outlived its release run wins silently over git describe and
+# then mis-stamps every build in the workspace — including the version under
+# which a crash report gets filed, which is what a dump is symbolized against.
+# One STATUS line makes that visible instead of mysterious.
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/version.txt")
+    file(STRINGS "${CMAKE_CURRENT_LIST_DIR}/version.txt" dongle_ver_file
+         LIMIT_COUNT 1)
+    message(STATUS "Dongle version: ${dongle_ver_file} (from version.txt)")
+else()
     find_package(Git QUIET)
     if(Git_FOUND)
         execute_process(
@@ -41,6 +50,7 @@ if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/version.txt")
             string(REGEX REPLACE "^dongle-v" "" PROJECT_VER "${dongle_ver}")
         endif()
     endif()
+    message(STATUS "Dongle version: ${PROJECT_VER} (from git describe)")
 endif()
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)

--- a/phoneblock-dongle/firmware/main/CMakeLists.txt
+++ b/phoneblock-dongle/firmware/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "main.c" "sip_register.c" "sip_response.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "web_access.c" "net_local.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c"
+    SRCS "main.c" "sip_register.c" "sip_response.c" "sip_transport.c" "sip_frame.c" "sip_srv.c" "sip_auth.c" "api.c" "api_scan.c" "sip_parse.c" "audio.c" "rtp.c" "stats.c" "log_capture.c" "config.c" "smtp_body.c" "web.c" "web_auth.c" "web_access.c" "net_local.c" "tr064.c" "tr064_parse.c" "announcement.c" "scheduler.c" "sched_time.c" "time_sync.c" "mail.c" "mail_html.c" "sync.c" "phone_norm.c" "selftest.c" "firmware_update.c" "version_cmp.c" "report_queue.c" "http_util.c" "wifi.c" "status_led.c" "crashreport.c" "logreport.c" "improv.c" "improv_proto.c" "blocklist_lookup.c" "blocklist_sync.c" "heap_guard.c" "heap_guard_scan.c"
     INCLUDE_DIRS "."
     EMBED_FILES "audio/announcement.alaw" "web/ab-logo-bot.svg"
     REQUIRES

--- a/phoneblock-dongle/firmware/main/Kconfig.projbuild
+++ b/phoneblock-dongle/firmware/main/Kconfig.projbuild
@@ -214,4 +214,54 @@ menu "PhoneBlock Dongle"
             The HTML section is also hidden by JS unless the status
             JSON reports the feature as on.
 
+    config HEAP_GUARD_ENABLE
+        bool "Heap-corruption sentinel"
+        default y
+        help
+            Walk the heap periodically and, on finding a block header
+            that cannot be true, copy the surrounding bytes onto the
+            stack and panic deliberately.
+
+            This exists because 1.5.0 and 1.5.1 both crashed inside
+            tlsf_walk_pool while the dashboard read heap statistics —
+            the first code to touch an already-corrupted heap, so the
+            backtrace named the victim and never the culprit. A core
+            dump preserves task stacks but not the heap, so the
+            evidence has to be copied onto a stack to survive; the
+            deliberate panic is what puts it there, and the reboot
+            reinitialises the heap a corrupted dongle cannot recover
+            from anyway.
+
+            Leave enabled until the corruption is found. It allocates
+            nothing and costs one short heap walk per interval.
+
+    config HEAP_GUARD_INTERVAL_S
+        int "Seconds between heap walks"
+        depends on HEAP_GUARD_ENABLE
+        default 5
+        range 1 3600
+        help
+            Shorter is better while hunting: the bytes that identify
+            the writer are only evidence until that memory is freed
+            and reused, which happens on a millisecond timescale. The
+            walk holds the heap's spinlock, so it runs with interrupts
+            disabled — the boot self-test logs the measured duration
+            and block count so the real cost is known per device. A
+            walk is deferred while a call is streaming RTP and runs on
+            the first tick afterwards instead.
+
+    config HEAP_GUARD_MAX_PANICS
+        int "Self-triggered panics allowed per power cycle"
+        depends on HEAP_GUARD_ENABLE
+        default 3
+        range 1 100
+        help
+            A reboot clears the corruption, but not a trigger that
+            recurs every boot. Since the daily firmware-update check
+            never runs on a device that reboots more often than once a
+            day, such a device could never be fixed remotely — so
+            after this many self-triggered panics the sentinel stops
+            panicking and only logs. The counter lives in RTC memory:
+            it survives a reboot but is cleared by a power cycle.
+
 endmenu

--- a/phoneblock-dongle/firmware/main/Kconfig.projbuild
+++ b/phoneblock-dongle/firmware/main/Kconfig.projbuild
@@ -250,18 +250,4 @@ menu "PhoneBlock Dongle"
             walk is deferred while a call is streaming RTP and runs on
             the first tick afterwards instead.
 
-    config HEAP_GUARD_MAX_PANICS
-        int "Self-triggered panics allowed per power cycle"
-        depends on HEAP_GUARD_ENABLE
-        default 3
-        range 1 100
-        help
-            A reboot clears the corruption, but not a trigger that
-            recurs every boot. Since the daily firmware-update check
-            never runs on a device that reboots more often than once a
-            day, such a device could never be fixed remotely — so
-            after this many self-triggered panics the sentinel stops
-            panicking and only logs. The counter lives in RTC memory:
-            it survives a reboot but is cleared by a power cycle.
-
 endmenu

--- a/phoneblock-dongle/firmware/main/api.c
+++ b/phoneblock-dongle/firmware/main/api.c
@@ -75,7 +75,12 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
 {
     response_buffer_t *resp = (response_buffer_t *)evt->user_data;
 
-    if (evt->event_id == HTTP_EVENT_ON_DATA && !esp_http_client_is_chunked_response(evt->client)) {
+    // No is_chunked_response() gate: esp_http_client de-chunks the body before
+    // ON_DATA fires, so gating on it drops exactly the payloads we need the
+    // moment the server answers with Transfer-Encoding: chunked — leaving an
+    // empty body that reads as a parse failure. sync.c hit this and documents
+    // it; this handler had the same gate.
+    if (evt->event_id == HTTP_EVENT_ON_DATA) {
         int remaining = resp->cap - resp->len - 1;
         int copy = evt->data_len < remaining ? evt->data_len : remaining;
         if (copy > 0) {
@@ -175,7 +180,9 @@ static esp_err_t http_event_shared(esp_http_client_event_t *evt)
     case HTTP_EVENT_ON_DATA:
         if (sink->kind == PB_SINK_SCAN) {
             api_scan_feed(sink->scan, (const char *)evt->data, evt->data_len);
-        } else if (!esp_http_client_is_chunked_response(evt->client)) {
+        } else {
+            // Copy unconditionally — see http_event_handler() above on why an
+            // is_chunked_response() gate silently discards chunked bodies.
             response_buffer_t *resp = sink->buf;
             int remaining = resp->cap - resp->len - 1;
             int copy = evt->data_len < remaining ? evt->data_len : remaining;

--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -19,6 +19,7 @@
 #include "esp_spiffs.h"
 
 #include "config.h"
+#include "heap_guard.h"
 #include "http_util.h"
 #include "strbuf.h"
 #include "scheduler.h"
@@ -372,6 +373,10 @@ void blocklist_sync_run(void)
     if (s_lock == NULL) {
         return;
     }
+    // Breadcrumb for the heap sentinel: downloads and parses a large blob from
+    // the CDN into heap buffers, so it is worth being able to place a
+    // corruption relative to it.
+    heap_guard_note("blocklist:sync");
     if (!config_blocklist_enabled()) {
         // Feature switched off in the web UI: don't refresh the on-flash
         // files. The existing files stay put but are never consulted (the

--- a/phoneblock-dongle/firmware/main/heap_guard.c
+++ b/phoneblock-dongle/firmware/main/heap_guard.c
@@ -1,0 +1,435 @@
+#include "heap_guard.h"
+
+#include "esp_log.h"
+
+// Must be last: bans unsafe string APIs for the rest of this file.
+// (Placed after every <...> / IDF include below.)
+
+#if CONFIG_HEAP_GUARD_ENABLE
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_attr.h"
+#include "esp_core_dump.h"
+#include "esp_err.h"
+#include "esp_heap_caps.h"
+#include "esp_system.h"
+#include "esp_timer.h"
+
+#include "heap_guard_scan.h"
+#include "rtp.h"
+#include "strbuf.h"
+
+#include "banned_apis.h"
+
+static const char *TAG = "heap_guard";
+
+// How much of the neighbourhood to preserve. The bytes *before* the smashed
+// block are the tail of the allocation that overran it — that is where the
+// payload identifying the writer lives — plus the smashed header itself. The
+// bytes after are for context.
+#define HG_WIN_BEFORE   192
+#define HG_WIN_AFTER     64
+
+// Boot-walk duration worth complaining about. The heap lock is a portMUX
+// spinlock, so the whole walk runs with interrupts disabled on this core; the
+// measured figure is logged on every boot so the real cost comes back from the
+// field rather than being estimated here.
+#define HG_WALK_BUDGET_US 2000
+
+// Marker at the head of the capture so the evidence can be found in a core
+// dump with `strings` alone, without gdb or a matching ELF.
+#define HG_MAGIC "PBHEAPGUARD1"
+
+// Everything worth knowing about the corruption, laid out to be readable
+// straight out of the crashed task's stack. Lives as a local of the function
+// that panics: a core dump preserves live task stacks, which is the only part
+// of RAM it does preserve (the heap is absent, and capturing all of DRAM does
+// not fit the 52 KB coredump partition).
+typedef struct {
+    char      magic[16];
+    char      summary[320];   // human-readable diagnosis, also the abort reason
+    uintptr_t heap_start;
+    uintptr_t heap_end;
+    uintptr_t prev_ptr;       // the allocation that presumably overran
+    uint32_t  prev_size;
+    uint32_t  prev_used;
+    uint32_t  have_prev;
+    uintptr_t bad_ptr;        // the block whose header no longer makes sense
+    uint32_t  bad_size;
+    uint32_t  bad_used;
+    uint32_t  blocks;         // blocks walked before the bad one
+    uint32_t  verdict;        // hg_verdict_t
+    uintptr_t win_from;
+    uint32_t  win_len;
+    uint8_t   win[HG_WIN_BEFORE + HG_WIN_AFTER];
+} hg_capture_t;
+
+// Walk state threaded through the callback.
+typedef struct {
+    hg_pool_t     pool;       // bounds of the heap currently being walked
+    bool          have_prev;
+    uintptr_t     prev_ptr;
+    size_t        prev_size;
+    bool          prev_used;
+    uint32_t      blocks;
+    hg_verdict_t  verdict;    // HG_OK unless the walk was stopped
+    uintptr_t     bad_ptr;    // set alongside `verdict`
+    size_t        bad_size;
+    hg_capture_t *cap;        // NULL for the boot self-test: judge, don't copy
+} hg_walk_t;
+
+// Survives a warm reboot but not a power cycle — exactly the right lifetime for
+// "how many times have I panicked myself": it bounds a self-inflicted reboot
+// loop, and a user pulling the plug gets a clean slate.
+#define HG_RTC_MAGIC 0x48475031u   // 'HGP1'
+static RTC_NOINIT_ATTR uint32_t s_rtc_magic;
+static RTC_NOINIT_ATTR uint32_t s_rtc_panics;
+
+static bool               s_armed;
+static bool               s_deferred;
+static esp_timer_handle_t s_timer;
+
+// A ring rather than a single "last operation": the dashboard polls
+// /api/status every few seconds, so one slot would be permanently stamped
+// "http" and would mask the operation that actually mattered.
+//
+// Each field is a single word, so a reader never sees a half-written pointer.
+// Two tasks noting at the same instant can land in the same slot and lose one
+// entry — that costs a line of context in a diagnostic, which is not worth a
+// lock on a path meant to be free.
+#define HG_NOTES 4
+typedef struct {
+    const char *what;
+    int64_t     at_us;
+} hg_note_t;
+static volatile hg_note_t s_notes[HG_NOTES];
+static volatile uint32_t  s_note_next;
+
+void heap_guard_note(const char *what)
+{
+    uint32_t i = s_note_next++ % HG_NOTES;
+    s_notes[i].what  = what ? what : "?";
+    s_notes[i].at_us = esp_timer_get_time();
+}
+
+static bool hg_walker(walker_heap_into_t heap, walker_block_info_t blk,
+                      void *user)
+{
+    hg_walk_t *w = (hg_walk_t *)user;
+
+    // heap_caps_walk_all() visits each registered heap in turn. New bounds mean
+    // a new pool, so the predecessor chain restarts — a block is only ever the
+    // successor of one in the same heap.
+    if ((uintptr_t)heap.start != w->pool.start ||
+        (uintptr_t)heap.end   != w->pool.end) {
+        w->pool.start = (uintptr_t)heap.start;
+        w->pool.end   = (uintptr_t)heap.end;
+        w->have_prev  = false;
+    }
+    w->blocks++;
+
+    hg_verdict_t v = hg_classify(w->pool, (uintptr_t)blk.ptr, blk.size);
+    if (v == HG_OK) {
+        w->prev_ptr  = (uintptr_t)blk.ptr;
+        w->prev_size = blk.size;
+        w->prev_used = blk.used;
+        w->have_prev = true;
+        return true;                 // keep walking
+    }
+
+    w->verdict  = v;
+    w->bad_ptr  = (uintptr_t)blk.ptr;
+    w->bad_size = blk.size;
+
+    // Snapshot the evidence here, while the heap lock is still held: the moment
+    // this returns the lock drops and another task can allocate over the very
+    // bytes that identify the writer. Only scalar stores and one memcpy — no
+    // formatting, no logging, no allocation, because this runs inside a portMUX
+    // critical section with interrupts disabled.
+    hg_capture_t *c = w->cap;
+    if (c) {
+        c->heap_start = w->pool.start;
+        c->heap_end   = w->pool.end;
+        c->bad_ptr    = (uintptr_t)blk.ptr;
+        c->bad_size   = (uint32_t)blk.size;
+        c->bad_used   = blk.used ? 1u : 0u;
+        c->blocks     = w->blocks;
+        c->verdict    = (uint32_t)v;
+        c->have_prev  = w->have_prev ? 1u : 0u;
+        c->prev_ptr   = w->have_prev ? w->prev_ptr : 0;
+        c->prev_size  = w->have_prev ? (uint32_t)w->prev_size : 0;
+        c->prev_used  = (w->have_prev && w->prev_used) ? 1u : 0u;
+
+        // Anchor on the smashed block, whose header the preceding allocation
+        // ran into. If that pointer is itself wild there is nothing safe to
+        // read there, so fall back to the last block we trusted.
+        uintptr_t centre = (v == HG_BAD_PTR && w->have_prev)
+                         ? w->prev_ptr : (uintptr_t)blk.ptr;
+        uintptr_t from = 0;
+        size_t    len  = 0;
+        hg_window(w->pool, centre, HG_WIN_BEFORE, HG_WIN_AFTER, &from, &len);
+        if (len > sizeof(c->win)) len = sizeof(c->win);
+        c->win_from = from;
+        c->win_len  = (uint32_t)len;
+        if (len) memcpy(c->win, (const void *)from, len);
+    }
+
+    // Stops tlsf_walk_pool before it steps onto the bad block — this is what
+    // turns the fault that killed 1.5.0 and 1.5.1 into a clean detection.
+    return false;
+}
+
+static void hg_summarise(hg_capture_t *c)
+{
+    strbuf_t sb = sb_init(c->summary, sizeof c->summary);
+    sb_appendf(&sb, "heap corruption: %s; ",
+               hg_verdict_str((hg_verdict_t)c->verdict));
+    sb_appendf(&sb, "bad blk=0x%08x size=%u %s; ",
+               (unsigned)c->bad_ptr, (unsigned)c->bad_size,
+               c->bad_used ? "used" : "free");
+    if (c->have_prev)
+        sb_appendf(&sb, "prev blk=0x%08x size=%u %s; ",
+                   (unsigned)c->prev_ptr, (unsigned)c->prev_size,
+                   c->prev_used ? "used" : "free");
+    else
+        sb_appendf(&sb, "prev none; ");
+    sb_appendf(&sb, "heap=0x%08x..0x%08x blocks=%u; win=0x%08x+%u; ",
+               (unsigned)c->heap_start, (unsigned)c->heap_end,
+               (unsigned)c->blocks, (unsigned)c->win_from,
+               (unsigned)c->win_len);
+    int64_t now = esp_timer_get_time();
+    sb_appendf(&sb, "up=%llds; recent:", (long long)(now / 1000000));
+
+    // Newest first, with each entry's age — this is the attribution: it names
+    // what the dongle was doing in the seconds before the heap went bad.
+    for (uint32_t k = 1; k <= HG_NOTES; k++) {
+        uint32_t i = (s_note_next - k) % HG_NOTES;
+        const char *what = s_notes[i].what;
+        if (!what) continue;
+        sb_appendf(&sb, " %s@-%llums", what,
+                   (unsigned long long)((now - s_notes[i].at_us) / 1000));
+    }
+}
+
+// noinline so the capture cannot be optimised out of the caller's frame: its
+// address escapes into a function the compiler cannot see through, which is
+// what guarantees the evidence really is on the stack the core dump preserves.
+static void __attribute__((noinline, noreturn))
+hg_panic_with_evidence(hg_capture_t *c)
+{
+    ESP_LOGE(TAG, "%s", c->summary);
+    esp_system_abort(c->summary);
+}
+
+static void hg_check(void)
+{
+    if (!s_armed) return;
+
+    // An answered call is streaming RTP. The heap lock disables interrupts for
+    // the length of the walk, so defer rather than walk mid-frame — and defer
+    // rather than skip, because call handling is one of the heap-heavy paths
+    // most worth covering. The walk then runs on the first tick after streaming
+    // stops, tagged so the capture says so.
+    if (rtp_streaming_active()) {
+        s_deferred = true;
+        return;
+    }
+
+    if (s_deferred) {
+        s_deferred = false;
+        heap_guard_note("post-call");
+    }
+
+    hg_capture_t cap;
+    memset(&cap, 0, sizeof cap);
+    memcpy(cap.magic, HG_MAGIC, sizeof HG_MAGIC);
+
+    hg_walk_t w = { .cap = &cap };
+    heap_caps_walk_all(hg_walker, &w);
+    if (w.verdict == HG_OK) return;
+
+    hg_summarise(&cap);
+
+    // A dump from an earlier panic is still waiting to be uploaded. Panicking
+    // again would overwrite it (CONFIG_ESP_COREDUMP_FLASH_NO_OVERWRITE is off)
+    // and trade the first, best evidence for a duplicate of it.
+    if (esp_core_dump_image_check() == ESP_OK) {
+        ESP_LOGE(TAG, "%s -- staying up: an earlier dump is still pending upload",
+                 cap.summary);
+        s_armed = false;
+        return;
+    }
+
+    // Bound a self-inflicted reboot loop. The daily firmware-update check never
+    // runs on a device that reboots more often than once a day, so a dongle that
+    // keeps re-corrupting itself has to be left up eventually or it can never be
+    // fixed remotely. The dumps already captured carry the same evidence.
+    if (s_rtc_panics >= CONFIG_HEAP_GUARD_MAX_PANICS) {
+        ESP_LOGE(TAG, "%s -- staying up: already panicked %u times since power-on",
+                 cap.summary, (unsigned)s_rtc_panics);
+        s_armed = false;
+        return;
+    }
+
+    s_rtc_panics++;
+    hg_panic_with_evidence(&cap);
+}
+
+static void hg_timer_cb(void *arg)
+{
+    (void)arg;
+    hg_check();
+}
+
+#if CONFIG_CRASH_TEST_ENABLE
+// Rehearse the detection against a heap corrupted on purpose, so a dev build
+// proves the sentinel actually fires — the boot self-test above only proves it
+// stays quiet, and a detector never observed detecting is not worth shipping.
+//
+// The corruption is the real shape of the bug: write past the end of one
+// allocation into the header of the one that follows. No knowledge of the
+// allocator's internals is used, which is the whole point — that is precisely
+// what the guard has to catch without it.
+//
+// The overwritten bytes are saved and put back, so the heap ends as it started,
+// and the smashed span is bounded to lie strictly inside the two allocations we
+// own. Between smash and restore the heap really is corrupt: another task
+// allocating in that window could fault. The window is microseconds during
+// early boot, and this is compiled in only under CONFIG_CRASH_TEST_ENABLE,
+// never in production.
+static void hg_rehearse(void)
+{
+    const size_t n = 64;
+    uint8_t *a = malloc(n);
+    uint8_t *b = malloc(n);
+    if (!a || !b) {
+        free(a); free(b);
+        ESP_LOGW(TAG, "rehearsal skipped: allocation failed");
+        return;
+    }
+
+    // Only proceed if the two allocations really are neighbours, so the span we
+    // scribble over (the gap holding b's header, plus the first bytes of b's
+    // payload) is memory we own. Otherwise there is no safe way to stage an
+    // overflow without guessing at the allocator's layout.
+    if (b <= a || (size_t)(b - a) > n + 32) {
+        free(b); free(a);
+        ESP_LOGW(TAG, "rehearsal skipped: allocations are not adjacent");
+        return;
+    }
+    size_t span = (size_t)(b - a) - n + 4;
+
+    uint8_t saved[36];
+    if (span > sizeof saved) span = sizeof saved;
+
+    // Launder the address through a volatile so the compiler stops tying it to
+    // the 64-byte object: writing past `a` is undefined behaviour by the
+    // language and is precisely the bug being staged, so GCC is right to reject
+    // the plain form (-Werror=maybe-uninitialized) and this says "yes, meant
+    // it" without weakening the flag for the whole file.
+    volatile uintptr_t tail_addr = (uintptr_t)a + n;
+    uint8_t *tail = (uint8_t *)tail_addr;
+
+    memcpy(saved, tail, span);
+    memset(tail, 'X', span);             // the overflow
+
+    hg_walk_t w = { 0 };
+    heap_caps_walk_all(hg_walker, &w);
+    hg_verdict_t detected = w.verdict;
+
+    memcpy(tail, saved, span);           // undo before anything else notices
+
+    hg_walk_t after = { 0 };
+    heap_caps_walk_all(hg_walker, &after);
+
+    free(b);
+    free(a);
+
+    if (detected != HG_OK && after.verdict == HG_OK)
+        ESP_LOGI(TAG, "rehearsal passed: %zu-byte overflow detected (%s), "
+                      "heap clean again afterwards",
+                 span, hg_verdict_str(detected));
+    else
+        ESP_LOGE(TAG, "rehearsal FAILED: detected=%s, after restore=%s -- the "
+                      "sentinel would not catch a real overflow",
+                 hg_verdict_str(detected), hg_verdict_str(after.verdict));
+}
+#endif
+
+void heap_guard_start(void)
+{
+    if (s_rtc_magic != HG_RTC_MAGIC) {      // cold boot: RTC RAM is undefined
+        s_rtc_magic  = HG_RTC_MAGIC;
+        s_rtc_panics = 0;
+    }
+
+    // Prove the predicate against a heap known to be intact before arming
+    // anything. If a healthy heap trips it, the assumption is wrong rather than
+    // the heap — an IDF upgrade changing the walker's contract, say — and arming
+    // would reboot healthy dongles every few seconds.
+    int64_t  t0 = esp_timer_get_time();
+    hg_walk_t w = { 0 };
+    heap_caps_walk_all(hg_walker, &w);
+    int64_t us = esp_timer_get_time() - t0;
+
+    if (w.blocks == 0) {
+        ESP_LOGE(TAG, "not arming: the heap walker reported no blocks at all");
+        return;
+    }
+    if (w.verdict != HG_OK) {
+        ESP_LOGE(TAG, "not arming: an intact heap fails the check (%s) at "
+                      "blk=0x%08x size=%u after %u blocks -- the predicate is "
+                      "wrong, not the heap",
+                 hg_verdict_str(w.verdict), (unsigned)w.bad_ptr,
+                 (unsigned)w.bad_size, (unsigned)w.blocks);
+        return;
+    }
+    if (us > HG_WALK_BUDGET_US)
+        ESP_LOGW(TAG, "boot walk took %lld us for %u blocks -- that is time with "
+                      "interrupts disabled; consider a longer interval",
+                 (long long)us, (unsigned)w.blocks);
+
+#if CONFIG_CRASH_TEST_ENABLE
+    hg_rehearse();          // dev builds only; proves the detection really fires
+#endif
+
+    const esp_timer_create_args_t args = {
+        .callback        = hg_timer_cb,
+        .name            = "heap_guard",
+        .dispatch_method = ESP_TIMER_TASK,
+    };
+    esp_err_t err = esp_timer_create(&args, &s_timer);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "not arming: timer create: %s", esp_err_to_name(err));
+        return;
+    }
+    err = esp_timer_start_periodic(
+        s_timer, (uint64_t)CONFIG_HEAP_GUARD_INTERVAL_S * 1000000);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "not arming: timer start: %s", esp_err_to_name(err));
+        return;
+    }
+
+    s_armed = true;
+    ESP_LOGI(TAG, "armed: %u blocks in %lld us, checking every %d s "
+                  "(%u self-triggered panics since power-on)",
+             (unsigned)w.blocks, (long long)us,
+             CONFIG_HEAP_GUARD_INTERVAL_S, (unsigned)s_rtc_panics);
+}
+
+#else  /* !CONFIG_HEAP_GUARD_ENABLE */
+
+void heap_guard_start(void)
+{
+    ESP_LOGI("heap_guard", "disabled at build time");
+}
+
+void heap_guard_note(const char *what)
+{
+    (void)what;
+}
+
+#endif

--- a/phoneblock-dongle/firmware/main/heap_guard.c
+++ b/phoneblock-dongle/firmware/main/heap_guard.c
@@ -312,38 +312,60 @@ bool heap_guard_rehearse(char *out, size_t cap)
 {
     strbuf_t sb = sb_init(out, (int)cap);
 
-    const size_t n = 64;
-    uint8_t *a = malloc(n);
-    uint8_t *b = malloc(n);
-    if (!a || !b) {
-        free(a); free(b);
-        sb_appendf(&sb, "skipped: allocation failed");
-        ESP_LOGW(TAG, "rehearsal skipped: allocation failed");
+    // Two successive malloc()s are NOT reliably neighbours. Measured on real
+    // hardware, two 64-byte blocks came back 4632 bytes apart (repeatably) —
+    // TLSF served them from different free-list bins, so the earlier version of
+    // this rehearsal skipped every time and never exercised the detection at
+    // all. Allocate a batch and *search* for a neighbouring pair instead of
+    // assuming one, and say so plainly if the heap does not offer one.
+    //
+    // Every block stays allocated across the test, so nothing coalesces and
+    // shifts the layout under us between the smash and the restore.
+    enum { HG_R_N = 32, HG_R_SZ = 64, HG_R_MAX_OVERHEAD = 32 };
+    uint8_t *p[HG_R_N] = { 0 };
+    for (int i = 0; i < HG_R_N; i++) {
+        p[i] = malloc(HG_R_SZ);
+        if (!p[i]) {
+            for (int j = 0; j < i; j++) free(p[j]);
+            sb_appendf(&sb, "skipped: allocation %d of %d failed", i, HG_R_N);
+            ESP_LOGW(TAG, "rehearsal skipped: allocation failed");
+            return false;
+        }
+    }
+
+    // A genuine neighbour sits exactly one payload plus the allocator's
+    // per-block overhead above its predecessor, so take the closest such pair.
+    int lo = -1, hi = -1;
+    size_t delta = 0;
+    for (int i = 0; i < HG_R_N; i++) {
+        for (int j = 0; j < HG_R_N; j++) {
+            if (i == j || p[j] <= p[i]) continue;
+            size_t d = (size_t)(p[j] - p[i]);
+            if (d < HG_R_SZ || d > HG_R_SZ + HG_R_MAX_OVERHEAD) continue;
+            if (lo < 0 || d < delta) { lo = i; hi = j; delta = d; }
+        }
+    }
+    if (lo < 0) {
+        for (int i = 0; i < HG_R_N; i++) free(p[i]);
+        sb_appendf(&sb, "skipped: no adjacent pair among %d allocations",
+                   HG_R_N);
+        ESP_LOGW(TAG, "rehearsal skipped: no adjacent pair found");
         return false;
     }
 
-    // Only proceed if the two allocations really are neighbours, so the span we
-    // scribble over (the gap holding b's header, plus the first bytes of b's
-    // payload) is memory we own. Otherwise there is no safe way to stage an
-    // overflow without guessing at the allocator's layout.
-    if (b <= a || (size_t)(b - a) > n + 32) {
-        free(b); free(a);
-        sb_appendf(&sb, "skipped: allocations are not adjacent (delta=%d)",
-                   (int)(b - a));
-        ESP_LOGW(TAG, "rehearsal skipped: allocations are not adjacent");
-        return false;
-    }
-    size_t span = (size_t)(b - a) - n + 4;
-
-    uint8_t saved[36];
+    // Scribble from the end of the lower block across the gap that holds the
+    // upper block's header and a few bytes into its payload — all of it memory
+    // this function owns, so the staged overflow cannot touch anything else.
+    size_t span = delta - HG_R_SZ + 4;
+    uint8_t saved[HG_R_MAX_OVERHEAD + 4];
     if (span > sizeof saved) span = sizeof saved;
 
     // Launder the address through a volatile so the compiler stops tying it to
-    // the 64-byte object: writing past `a` is undefined behaviour by the
+    // the 64-byte object: writing past p[lo] is undefined behaviour by the
     // language and is precisely the bug being staged, so GCC is right to reject
     // the plain form (-Werror=maybe-uninitialized) and this says "yes, meant
     // it" without weakening the flag for the whole file.
-    volatile uintptr_t tail_addr = (uintptr_t)a + n;
+    volatile uintptr_t tail_addr = (uintptr_t)p[lo] + HG_R_SZ;
     uint8_t *tail = (uint8_t *)tail_addr;
 
     memcpy(saved, tail, span);
@@ -358,13 +380,14 @@ bool heap_guard_rehearse(char *out, size_t cap)
     hg_walk_t after = { 0 };
     heap_caps_walk_all(hg_walker, &after);
 
-    free(b);
-    free(a);
+    (void)hi;
+    for (int i = 0; i < HG_R_N; i++) free(p[i]);
 
     bool passed = (detected != HG_OK && after.verdict == HG_OK);
     if (passed) {
-        sb_appendf(&sb, "passed: %u-byte overflow detected (%s), heap clean "
-                        "again afterwards", (unsigned)span,
+        sb_appendf(&sb, "passed: %u-byte overflow across a %u-byte block gap "
+                        "detected (%s), heap clean again afterwards",
+                   (unsigned)span, (unsigned)delta,
                    hg_verdict_str(detected));
         ESP_LOGI(TAG, "rehearsal %s", out);
     } else {

--- a/phoneblock-dongle/firmware/main/heap_guard.c
+++ b/phoneblock-dongle/firmware/main/heap_guard.c
@@ -34,11 +34,17 @@ static const char *TAG = "heap_guard";
 #define HG_WIN_BEFORE   192
 #define HG_WIN_AFTER     64
 
-// Boot-walk duration worth complaining about. The heap lock is a portMUX
-// spinlock, so the whole walk runs with interrupts disabled on this core; the
-// measured figure is logged on every boot so the real cost comes back from the
-// field rather than being estimated here.
-#define HG_WALK_BUDGET_US 2000
+// The heap lock is a portMUX spinlock, so the whole walk runs with interrupts
+// disabled on this core. The measured duration is logged on every boot, so the
+// real cost comes back from the field rather than being estimated here: ~600 us
+// for 500-900 blocks on an ESP32-PICO-D4.
+//
+// It is not worth warning about a slow one. Any flash write disables the cache,
+// and the stall lands inside our critical section — so a walk that overlaps the
+// daily blocklist sync, an OTA, or (as at boot) the core-dump upload measures
+// tens of milliseconds instead. That is routine rather than pathological, and
+// harmless: the interrupt watchdog sits at 300 ms and nothing else on the device
+// cares about tens of milliseconds.
 
 // Marker at the head of the capture so the evidence can be found in a core
 // dump with `strings` alone, without gdb or a matching ELF.
@@ -353,11 +359,6 @@ void heap_guard_start(void)
                  (unsigned)w.bad_size, (unsigned)w.blocks);
         return;
     }
-    if (us > HG_WALK_BUDGET_US)
-        ESP_LOGW(TAG, "boot walk took %lld us for %u blocks -- that is time with "
-                      "interrupts disabled; consider a longer interval",
-                 (long long)us, (unsigned)w.blocks);
-
     const esp_timer_create_args_t args = {
         .callback        = hg_timer_cb,
         .name            = "heap_guard",

--- a/phoneblock-dongle/firmware/main/heap_guard.c
+++ b/phoneblock-dongle/firmware/main/heap_guard.c
@@ -1,5 +1,7 @@
 #include "heap_guard.h"
 
+#include <stdio.h>
+
 #include "esp_log.h"
 
 // Must be last: bans unsafe string APIs for the rest of this file.
@@ -289,6 +291,12 @@ static void hg_timer_cb(void *arg)
 // proves the sentinel actually fires — the boot self-test above only proves it
 // stays quiet, and a detector never observed detecting is not worth shipping.
 //
+// Triggered on demand (POST /api/dev/heap-rehearse), deliberately *not* run at
+// boot. app_main calls esp_ota_mark_app_valid_cancel_rollback() long before
+// heap_guard_start(), so a rehearsal that panicked during its corrupted window
+// would leave a committed image crash-looping with no rollback left. On demand,
+// the same failure just reboots into a device that does not rehearse again.
+//
 // The corruption is the real shape of the bug: write past the end of one
 // allocation into the header of the one that follows. No knowledge of the
 // allocator's internals is used, which is the whole point — that is precisely
@@ -300,15 +308,18 @@ static void hg_timer_cb(void *arg)
 // allocating in that window could fault. The window is microseconds during
 // early boot, and this is compiled in only under CONFIG_CRASH_TEST_ENABLE,
 // never in production.
-static void hg_rehearse(void)
+bool heap_guard_rehearse(char *out, size_t cap)
 {
+    strbuf_t sb = sb_init(out, (int)cap);
+
     const size_t n = 64;
     uint8_t *a = malloc(n);
     uint8_t *b = malloc(n);
     if (!a || !b) {
         free(a); free(b);
+        sb_appendf(&sb, "skipped: allocation failed");
         ESP_LOGW(TAG, "rehearsal skipped: allocation failed");
-        return;
+        return false;
     }
 
     // Only proceed if the two allocations really are neighbours, so the span we
@@ -317,8 +328,10 @@ static void hg_rehearse(void)
     // overflow without guessing at the allocator's layout.
     if (b <= a || (size_t)(b - a) > n + 32) {
         free(b); free(a);
+        sb_appendf(&sb, "skipped: allocations are not adjacent (delta=%d)",
+                   (int)(b - a));
         ESP_LOGW(TAG, "rehearsal skipped: allocations are not adjacent");
-        return;
+        return false;
     }
     size_t span = (size_t)(b - a) - n + 4;
 
@@ -348,14 +361,19 @@ static void hg_rehearse(void)
     free(b);
     free(a);
 
-    if (detected != HG_OK && after.verdict == HG_OK)
-        ESP_LOGI(TAG, "rehearsal passed: %zu-byte overflow detected (%s), "
-                      "heap clean again afterwards",
-                 span, hg_verdict_str(detected));
-    else
-        ESP_LOGE(TAG, "rehearsal FAILED: detected=%s, after restore=%s -- the "
-                      "sentinel would not catch a real overflow",
-                 hg_verdict_str(detected), hg_verdict_str(after.verdict));
+    bool passed = (detected != HG_OK && after.verdict == HG_OK);
+    if (passed) {
+        sb_appendf(&sb, "passed: %u-byte overflow detected (%s), heap clean "
+                        "again afterwards", (unsigned)span,
+                   hg_verdict_str(detected));
+        ESP_LOGI(TAG, "rehearsal %s", out);
+    } else {
+        sb_appendf(&sb, "FAILED: detected=%s, after restore=%s -- the sentinel "
+                        "would not catch a real overflow",
+                   hg_verdict_str(detected), hg_verdict_str(after.verdict));
+        ESP_LOGE(TAG, "rehearsal %s", out);
+    }
+    return passed;
 }
 #endif
 
@@ -392,10 +410,6 @@ void heap_guard_start(void)
                       "interrupts disabled; consider a longer interval",
                  (long long)us, (unsigned)w.blocks);
 
-#if CONFIG_CRASH_TEST_ENABLE
-    hg_rehearse();          // dev builds only; proves the detection really fires
-#endif
-
     const esp_timer_create_args_t args = {
         .callback        = hg_timer_cb,
         .name            = "heap_guard",
@@ -431,5 +445,14 @@ void heap_guard_note(const char *what)
 {
     (void)what;
 }
+
+#if CONFIG_CRASH_TEST_ENABLE
+// A bench build with the sentinel compiled out still links the dev endpoint.
+bool heap_guard_rehearse(char *out, size_t cap)
+{
+    if (cap) snprintf(out, cap, "skipped: sentinel disabled at build time");
+    return false;
+}
+#endif
 
 #endif

--- a/phoneblock-dongle/firmware/main/heap_guard.c
+++ b/phoneblock-dongle/firmware/main/heap_guard.c
@@ -13,7 +13,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "esp_attr.h"
 #include "esp_core_dump.h"
 #include "esp_err.h"
 #include "esp_heap_caps.h"
@@ -82,13 +81,6 @@ typedef struct {
     size_t        bad_size;
     hg_capture_t *cap;        // NULL for the boot self-test: judge, don't copy
 } hg_walk_t;
-
-// Survives a warm reboot but not a power cycle — exactly the right lifetime for
-// "how many times have I panicked myself": it bounds a self-inflicted reboot
-// loop, and a user pulling the plug gets a clean slate.
-#define HG_RTC_MAGIC 0x48475031u   // 'HGP1'
-static RTC_NOINIT_ATTR uint32_t s_rtc_magic;
-static RTC_NOINIT_ATTR uint32_t s_rtc_panics;
 
 static bool               s_armed;
 static bool               s_deferred;
@@ -265,18 +257,6 @@ static void hg_check(void)
         return;
     }
 
-    // Bound a self-inflicted reboot loop. The daily firmware-update check never
-    // runs on a device that reboots more often than once a day, so a dongle that
-    // keeps re-corrupting itself has to be left up eventually or it can never be
-    // fixed remotely. The dumps already captured carry the same evidence.
-    if (s_rtc_panics >= CONFIG_HEAP_GUARD_MAX_PANICS) {
-        ESP_LOGE(TAG, "%s -- staying up: already panicked %u times since power-on",
-                 cap.summary, (unsigned)s_rtc_panics);
-        s_armed = false;
-        return;
-    }
-
-    s_rtc_panics++;
     hg_panic_with_evidence(&cap);
 }
 
@@ -287,126 +267,71 @@ static void hg_timer_cb(void *arg)
 }
 
 #if CONFIG_CRASH_TEST_ENABLE
-// Rehearse the detection against a heap corrupted on purpose, so a dev build
-// proves the sentinel actually fires — the boot self-test above only proves it
-// stays quiet, and a detector never observed detecting is not worth shipping.
+// Introduce a real heap corruption and leave it there: overflow the end of one
+// allocation into the header of its neighbour, exactly as the hunted bug does.
+// The sentinel picks it up on its next tick and takes it from there — capture,
+// deliberate panic, core dump, upload on the next boot. Running it that way
+// round is the only thing that proves the evidence survives into a dump, which
+// is the whole point of the feature.
 //
-// Triggered on demand (POST /api/dev/heap-rehearse), deliberately *not* run at
-// boot. app_main calls esp_ota_mark_app_valid_cancel_rollback() long before
-// heap_guard_start(), so a rehearsal that panicked during its corrupted window
-// would leave a committed image crash-looping with no rollback left. On demand,
-// the same failure just reboots into a device that does not rehearse again.
-//
-// The corruption is the real shape of the bug: write past the end of one
-// allocation into the header of the one that follows. No knowledge of the
-// allocator's internals is used, which is the whole point — that is precisely
-// what the guard has to catch without it.
-//
-// The overwritten bytes are saved and put back, so the heap ends as it started,
-// and the smashed span is bounded to lie strictly inside the two allocations we
-// own. Between smash and restore the heap really is corrupt: another task
-// allocating in that window could fault. The window is microseconds during
-// early boot, and this is compiled in only under CONFIG_CRASH_TEST_ENABLE,
-// never in production.
-bool heap_guard_rehearse(char *out, size_t cap)
+// Two successive malloc()s are not reliably neighbours: measured on hardware,
+// two 64-byte blocks came back 4632 bytes apart because TLSF served them from
+// different free-list bins. So allocate a batch and look for an adjacent pair.
+// The blocks are never freed, deliberately — nothing may coalesce over the
+// corruption before the sentinel sees it, and the device is about to reboot.
+bool heap_guard_smash(char *out, size_t cap)
 {
     strbuf_t sb = sb_init(out, (int)cap);
 
-    // Two successive malloc()s are NOT reliably neighbours. Measured on real
-    // hardware, two 64-byte blocks came back 4632 bytes apart (repeatably) —
-    // TLSF served them from different free-list bins, so the earlier version of
-    // this rehearsal skipped every time and never exercised the detection at
-    // all. Allocate a batch and *search* for a neighbouring pair instead of
-    // assuming one, and say so plainly if the heap does not offer one.
-    //
-    // Every block stays allocated across the test, so nothing coalesces and
-    // shifts the layout under us between the smash and the restore.
-    enum { HG_R_N = 32, HG_R_SZ = 64, HG_R_MAX_OVERHEAD = 32 };
-    uint8_t *p[HG_R_N] = { 0 };
-    for (int i = 0; i < HG_R_N; i++) {
-        p[i] = malloc(HG_R_SZ);
+    enum { N = 32, SZ = 64, MAX_OVERHEAD = 32 };
+    uint8_t *p[N] = { 0 };
+    for (int i = 0; i < N; i++) {
+        p[i] = malloc(SZ);
         if (!p[i]) {
-            for (int j = 0; j < i; j++) free(p[j]);
-            sb_appendf(&sb, "skipped: allocation %d of %d failed", i, HG_R_N);
-            ESP_LOGW(TAG, "rehearsal skipped: allocation failed");
+            sb_appendf(&sb, "allocation %d of %d failed", i, N);
+            ESP_LOGW(TAG, "smash: %s", out);
             return false;
         }
     }
 
-    // A genuine neighbour sits exactly one payload plus the allocator's
-    // per-block overhead above its predecessor, so take the closest such pair.
-    int lo = -1, hi = -1;
+    // A real neighbour sits one payload plus the allocator's per-block overhead
+    // above its predecessor, so take the closest such pair.
+    int lo = -1;
     size_t delta = 0;
-    for (int i = 0; i < HG_R_N; i++) {
-        for (int j = 0; j < HG_R_N; j++) {
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
             if (i == j || p[j] <= p[i]) continue;
             size_t d = (size_t)(p[j] - p[i]);
-            if (d < HG_R_SZ || d > HG_R_SZ + HG_R_MAX_OVERHEAD) continue;
-            if (lo < 0 || d < delta) { lo = i; hi = j; delta = d; }
+            if (d < SZ || d > SZ + MAX_OVERHEAD) continue;
+            if (lo < 0 || d < delta) { lo = i; delta = d; }
         }
     }
     if (lo < 0) {
-        for (int i = 0; i < HG_R_N; i++) free(p[i]);
-        sb_appendf(&sb, "skipped: no adjacent pair among %d allocations",
-                   HG_R_N);
-        ESP_LOGW(TAG, "rehearsal skipped: no adjacent pair found");
+        sb_appendf(&sb, "no adjacent pair among %d allocations", N);
+        ESP_LOGW(TAG, "smash: %s", out);
         return false;
     }
-
-    // Scribble from the end of the lower block across the gap that holds the
-    // upper block's header and a few bytes into its payload — all of it memory
-    // this function owns, so the staged overflow cannot touch anything else.
-    size_t span = delta - HG_R_SZ + 4;
-    uint8_t saved[HG_R_MAX_OVERHEAD + 4];
-    if (span > sizeof saved) span = sizeof saved;
 
     // Launder the address through a volatile so the compiler stops tying it to
     // the 64-byte object: writing past p[lo] is undefined behaviour by the
     // language and is precisely the bug being staged, so GCC is right to reject
-    // the plain form (-Werror=maybe-uninitialized) and this says "yes, meant
-    // it" without weakening the flag for the whole file.
-    volatile uintptr_t tail_addr = (uintptr_t)p[lo] + HG_R_SZ;
-    uint8_t *tail = (uint8_t *)tail_addr;
+    // the plain form (-Werror=maybe-uninitialized) and this says "yes, meant it"
+    // without weakening the flag for the whole file.
+    size_t span = delta - SZ + 4;
+    volatile uintptr_t tail_addr = (uintptr_t)p[lo] + SZ;
+    memset((uint8_t *)tail_addr, 'X', span);
 
-    memcpy(saved, tail, span);
-    memset(tail, 'X', span);             // the overflow
-
-    hg_walk_t w = { 0 };
-    heap_caps_walk_all(hg_walker, &w);
-    hg_verdict_t detected = w.verdict;
-
-    memcpy(tail, saved, span);           // undo before anything else notices
-
-    hg_walk_t after = { 0 };
-    heap_caps_walk_all(hg_walker, &after);
-
-    (void)hi;
-    for (int i = 0; i < HG_R_N; i++) free(p[i]);
-
-    bool passed = (detected != HG_OK && after.verdict == HG_OK);
-    if (passed) {
-        sb_appendf(&sb, "passed: %u-byte overflow across a %u-byte block gap "
-                        "detected (%s), heap clean again afterwards",
-                   (unsigned)span, (unsigned)delta,
-                   hg_verdict_str(detected));
-        ESP_LOGI(TAG, "rehearsal %s", out);
-    } else {
-        sb_appendf(&sb, "FAILED: detected=%s, after restore=%s -- the sentinel "
-                        "would not catch a real overflow",
-                   hg_verdict_str(detected), hg_verdict_str(after.verdict));
-        ESP_LOGE(TAG, "rehearsal %s", out);
-    }
-    return passed;
+    sb_appendf(&sb, "%u bytes of 'X' written across a %u-byte block gap at "
+                    "0x%08x -- panic expected within %d s",
+               (unsigned)span, (unsigned)delta, (unsigned)tail_addr,
+               CONFIG_HEAP_GUARD_INTERVAL_S);
+    ESP_LOGW(TAG, "smash: %s", out);
+    return true;
 }
 #endif
 
 void heap_guard_start(void)
 {
-    if (s_rtc_magic != HG_RTC_MAGIC) {      // cold boot: RTC RAM is undefined
-        s_rtc_magic  = HG_RTC_MAGIC;
-        s_rtc_panics = 0;
-    }
-
     // Prove the predicate against a heap known to be intact before arming
     // anything. If a healthy heap trips it, the assumption is wrong rather than
     // the heap — an IDF upgrade changing the walker's contract, say — and arming
@@ -451,10 +376,8 @@ void heap_guard_start(void)
     }
 
     s_armed = true;
-    ESP_LOGI(TAG, "armed: %u blocks in %lld us, checking every %d s "
-                  "(%u self-triggered panics since power-on)",
-             (unsigned)w.blocks, (long long)us,
-             CONFIG_HEAP_GUARD_INTERVAL_S, (unsigned)s_rtc_panics);
+    ESP_LOGI(TAG, "armed: %u blocks in %lld us, checking every %d s",
+             (unsigned)w.blocks, (long long)us, CONFIG_HEAP_GUARD_INTERVAL_S);
 }
 
 #else  /* !CONFIG_HEAP_GUARD_ENABLE */
@@ -471,9 +394,11 @@ void heap_guard_note(const char *what)
 
 #if CONFIG_CRASH_TEST_ENABLE
 // A bench build with the sentinel compiled out still links the dev endpoint.
-bool heap_guard_rehearse(char *out, size_t cap)
+// Corrupting the heap with nothing watching for it would just crash the device
+// somewhere random, so refuse.
+bool heap_guard_smash(char *out, size_t cap)
 {
-    if (cap) snprintf(out, cap, "skipped: sentinel disabled at build time");
+    if (cap) snprintf(out, cap, "refused: sentinel disabled at build time");
     return false;
 }
 #endif

--- a/phoneblock-dongle/firmware/main/heap_guard.h
+++ b/phoneblock-dongle/firmware/main/heap_guard.h
@@ -33,6 +33,7 @@
 // heap-heavy moments that most need covering.
 
 #include <stdbool.h>
+#include <stddef.h>
 
 // Validate the predicate against the (healthy) heap and, if it holds, arm the
 // periodic sentinel. Refuses to arm if a healthy heap trips the predicate —
@@ -57,3 +58,22 @@ void heap_guard_start(void);
 // `what` must be a string literal or otherwise outlive the device — only the
 // pointer is kept, never a copy, and it is read much later from a core dump.
 void heap_guard_note(const char *what);
+
+#if CONFIG_CRASH_TEST_ENABLE
+// Prove the sentinel actually fires: stage a real overflow across two of this
+// function's own adjacent allocations, check that the walk catches it, put the
+// bytes back and check the heap reads clean again. Writes a one-line outcome
+// into `out` and returns true only if both halves held.
+//
+// This is the one part of the sentinel the host tests cannot reach — they cover
+// the predicate, not the integration with heap_caps_walk_all(). Run it on the
+// bench after any change to the walk.
+//
+// On demand rather than at boot on purpose: app_main cancels OTA rollback long
+// before the sentinel is armed, so a rehearsal that panicked inside its briefly
+// corrupted window would leave a committed image crash-looping with no rollback
+// left. Between the smash and the restore the heap really is corrupt — a few
+// microseconds in which another task allocating could fault — so this exists
+// only in CONFIG_CRASH_TEST_ENABLE builds, never in production.
+bool heap_guard_rehearse(char *out, size_t cap);
+#endif

--- a/phoneblock-dongle/firmware/main/heap_guard.h
+++ b/phoneblock-dongle/firmware/main/heap_guard.h
@@ -60,20 +60,14 @@ void heap_guard_start(void);
 void heap_guard_note(const char *what);
 
 #if CONFIG_CRASH_TEST_ENABLE
-// Prove the sentinel actually fires: stage a real overflow across two of this
-// function's own adjacent allocations, check that the walk catches it, put the
-// bytes back and check the heap reads clean again. Writes a one-line outcome
-// into `out` and returns true only if both halves held.
+// Introduce a real heap corruption — overflow one allocation into the header of
+// its neighbour — and leave it there. The sentinel finds it on its next tick and
+// runs the whole path: capture, deliberate panic, core dump, upload on the next
+// boot. That is what proves the evidence survives into a dump, which the host
+// tests cannot reach (they cover the predicate, not the integration).
 //
-// This is the one part of the sentinel the host tests cannot reach — they cover
-// the predicate, not the integration with heap_caps_walk_all(). Run it on the
-// bench after any change to the walk.
-//
-// On demand rather than at boot on purpose: app_main cancels OTA rollback long
-// before the sentinel is armed, so a rehearsal that panicked inside its briefly
-// corrupted window would leave a committed image crash-looping with no rollback
-// left. Between the smash and the restore the heap really is corrupt — a few
-// microseconds in which another task allocating could fault — so this exists
-// only in CONFIG_CRASH_TEST_ENABLE builds, never in production.
-bool heap_guard_rehearse(char *out, size_t cap);
+// Panics the device a few seconds after returning. Writes a one-line outcome
+// into `out`; returns false if the heap offered no adjacent pair to overflow
+// across, in which case nothing was corrupted. Bench builds only.
+bool heap_guard_smash(char *out, size_t cap);
 #endif

--- a/phoneblock-dongle/firmware/main/heap_guard.h
+++ b/phoneblock-dongle/firmware/main/heap_guard.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// Heap-corruption sentinel.
+//
+// Why this exists: firmware 1.5.0 and 1.5.1 both crashed in tlsf_walk_pool,
+// reached from heap_caps_get_largest_free_block() while httpd served
+// GET /api/status. That code only *reads* heap metadata — it was the first
+// thing to walk an already-corrupted heap, so the backtrace names the victim
+// and never the culprit. Two things made those dumps nearly useless:
+//
+//   * detection was unbounded in time — the smashed block sat there until
+//     somebody happened to open the dashboard, by which point the payload
+//     that identified the writer had long been freed and reused; and
+//   * the core dump holds only task stacks and TCBs, so the heap itself —
+//     the actual evidence — is absent. Capturing all of DRAM is not an
+//     option either: the coredump partition is 52 KB wedged in the alignment
+//     gap before ota_0, and enlarging it means a USB reflash of every dongle
+//     in the field (see partitions.csv).
+//
+// So this sentinel walks the heap every few seconds, and when it finds a
+// block whose header can no longer be true it copies the bytes *around* that
+// block onto its own stack before deliberately panicking. Task stacks are
+// what a core dump preserves, so the evidence rides out in the dump — headed
+// by the ASCII marker "PBHEAPGUARD1" and a one-line summary, both findable
+// with `strings` alone. The panic is not a cost: a dongle with a corrupted
+// heap is already doomed and meanwhile answers calls from an undefined state,
+// and the reboot reinitialises the heap. What the sentinel buys is *when* the
+// crash happens and what it carries.
+//
+// The walk is deliberately cheap and allocates nothing, so it is safe to run
+// often. It runs from an esp_timer callback rather than the scheduler task,
+// which blocks for minutes inside OTA downloads and SMTP sends — exactly the
+// heap-heavy moments that most need covering.
+
+#include <stdbool.h>
+
+// Validate the predicate against the (healthy) heap and, if it holds, arm the
+// periodic sentinel. Refuses to arm if a healthy heap trips the predicate —
+// that would mean the assumption is wrong rather than the heap, and arming
+// would reboot working dongles every few seconds. Logs the measured walk
+// duration and block count either way, which is how the real interrupts-off
+// cost gets reported from the field instead of estimated here.
+//
+// Call after crashreport_upload_async(), so a dump from the previous boot gets
+// its chance to upload before this can produce another.
+void heap_guard_start(void);
+
+// Leave a breadcrumb naming an operation, so a capture can say what the dongle
+// was doing in the seconds before the heap went bad — which is the attribution
+// that turns "the heap is corrupt" into "audit this subsystem". Call it freely
+// around anything that parses external data into heap buffers; it costs a
+// pointer store and a timestamp, takes no lock and cannot fail.
+//
+// The last few notes are kept, not just one, so a frequent caller (the
+// dashboard polling /api/status) cannot mask a rarer, more interesting one.
+//
+// `what` must be a string literal or otherwise outlive the device — only the
+// pointer is kept, never a copy, and it is read much later from a core dump.
+void heap_guard_note(const char *what);

--- a/phoneblock-dongle/firmware/main/heap_guard_scan.c
+++ b/phoneblock-dongle/firmware/main/heap_guard_scan.c
@@ -1,0 +1,66 @@
+#include "heap_guard_scan.h"
+
+// Must be last: bans unsafe string APIs for the rest of this file.
+#include "banned_apis.h"
+
+// TLSF aligns every block size and payload pointer to 4 bytes on a 32-bit
+// target (ALIGN_SIZE). A violation means the header no longer describes a real
+// block — and a misaligned successor would fault with LoadStoreAlignment
+// instead of LoadProhibited, so it is worth catching separately.
+#define HG_ALIGN 4u
+
+hg_verdict_t hg_classify(hg_pool_t pool, uintptr_t ptr, size_t size)
+{
+    // Order matters: the bounds test below subtracts `ptr` from `pool.end`, so
+    // the pointer has to be known good first.
+    if (ptr < pool.start || ptr >= pool.end)
+        return HG_BAD_PTR;
+
+    // The walker stops at the last block, whose stored size is zero, so a
+    // zero-size block never reaches a callback on a healthy heap.
+    if (size == 0)
+        return HG_BAD_SIZE;
+
+    // The step the walker is about to take. Compared rather than added, so a
+    // wild size cannot overflow the arithmetic and wrap back into range.
+    if (size > (size_t)(pool.end - ptr))
+        return HG_BAD_BOUNDS;
+
+    if ((ptr % HG_ALIGN) != 0 || (size % HG_ALIGN) != 0)
+        return HG_BAD_ALIGN;
+
+    return HG_OK;
+}
+
+const char *hg_verdict_str(hg_verdict_t v)
+{
+    switch (v) {
+    case HG_OK:         return "ok";
+    case HG_BAD_PTR:    return "block outside heap";
+    case HG_BAD_SIZE:   return "zero-size block";
+    case HG_BAD_BOUNDS: return "block extends past heap end";
+    case HG_BAD_ALIGN:  return "misaligned block";
+    default:            return "unknown";
+    }
+}
+
+void hg_window(hg_pool_t pool, uintptr_t center, size_t before, size_t after,
+               uintptr_t *out_from, size_t *out_len)
+{
+    *out_from = 0;
+    *out_len  = 0;
+
+    if (center < pool.start || center >= pool.end)
+        return;                                  // nothing safe to copy
+
+    // Clamp both ends into the heap. Written as comparisons against the
+    // available distance so neither side can under- or overflow.
+    uintptr_t from = (before > (size_t)(center - pool.start))
+                   ? pool.start : center - before;
+
+    size_t room = (size_t)(pool.end - center);
+    uintptr_t to = (after > room) ? pool.end : center + after;
+
+    *out_from = from;
+    *out_len  = (size_t)(to - from);
+}

--- a/phoneblock-dongle/firmware/main/heap_guard_scan.h
+++ b/phoneblock-dongle/firmware/main/heap_guard_scan.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Block-sanity judgement for the heap sentinel (heap_guard.c), kept free of
+// every ESP-IDF dependency so the host test suite can cover it.
+//
+// This is the whole decision behind a deliberate panic, which is why it lives
+// on its own: a false positive reboots a perfectly healthy dongle. Every
+// predicate below is one that a healthy TLSF heap cannot violate, and
+// heap_guard_start() proves that empirically on each boot by running the same
+// walk over the known-good heap before arming the sentinel.
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Bounds of the heap a block belongs to, as reported to a heap_caps_walk()
+// callback in walker_heap_into_t. `end` is exclusive.
+typedef struct {
+    uintptr_t start;
+    uintptr_t end;
+} hg_pool_t;
+
+typedef enum {
+    HG_OK = 0,
+    HG_BAD_PTR,     // block payload lies outside its own heap
+    HG_BAD_SIZE,    // zero-length block (the walker never reports the last one)
+    HG_BAD_BOUNDS,  // block claims to extend past the end of the heap
+    HG_BAD_ALIGN,   // payload pointer or size not 4-byte aligned
+} hg_verdict_t;
+
+// Judge one block as reported by the heap walker. `size` is the block size
+// TLSF has stored in the block header, i.e. exactly the value the walker will
+// use to step to the next block — so HG_BAD_BOUNDS is the case that would
+// otherwise fault on the following iteration.
+hg_verdict_t hg_classify(hg_pool_t pool, uintptr_t ptr, size_t size);
+
+const char *hg_verdict_str(hg_verdict_t v);
+
+// Compute the byte range to snapshot as evidence: `before` bytes ahead of
+// `center` through `after` bytes past it, clamped to the heap's own bounds so
+// the resulting memcpy can never read outside mapped RAM.
+//
+// `center` is the payload pointer of the block whose header was found smashed.
+// The bytes *before* it are the tail of the preceding allocation — the payload
+// that overran — plus the smashed header itself, which is the evidence that
+// names the writer. Yields *out_len == 0 when `center` is not inside the heap,
+// leaving the caller nothing to copy.
+void hg_window(hg_pool_t pool, uintptr_t center, size_t before, size_t after,
+               uintptr_t *out_from, size_t *out_len);

--- a/phoneblock-dongle/firmware/main/mail.c
+++ b/phoneblock-dongle/firmware/main/mail.c
@@ -20,6 +20,7 @@
 #include "mbedtls/ssl.h"
 
 #include "config.h"
+#include "heap_guard.h"
 #include "mail_html.h"
 #include "smtp_body.h"
 #include "stats.h"
@@ -203,6 +204,9 @@ static bool mail_send(const char *subject, const char *content_type, const char 
         ESP_LOGW(TAG, "mail not configured (host/user/pass/recipient)");
         return false;
     }
+    // Breadcrumb for the heap sentinel: assembles a multi-KB body and runs an
+    // SMTP/TLS conversation, both heap-heavy.
+    heap_guard_note("mail:send");
     if (!wifi_has_ip()) {
         ESP_LOGW(TAG, "no network — mail not sent");
         return false;

--- a/phoneblock-dongle/firmware/main/main.c
+++ b/phoneblock-dongle/firmware/main/main.c
@@ -19,6 +19,7 @@
 #include "api.h"
 #include "config.h"
 #include "crashreport.h"
+#include "heap_guard.h"
 #include "improv.h"
 #include "log_capture.h"
 #include "mail.h"
@@ -192,4 +193,11 @@ void app_main(void)
     // last_failed_ota guard (cleared above on a healthy boot) still
     // keeps a brick-and-rollback build from being re-tried in a loop.
     scheduler_start();
+
+    // Arm the heap-corruption sentinel last, once every subsystem has taken
+    // its allocations: the boot walk it validates the predicate against then
+    // covers a heap in its normal shape. After crashreport_upload_async(), so
+    // a dump from the previous boot gets its chance to upload before this can
+    // ever produce another.
+    heap_guard_start();
 }

--- a/phoneblock-dongle/firmware/main/sip_register.c
+++ b/phoneblock-dongle/firmware/main/sip_register.c
@@ -22,6 +22,7 @@
 #include "api.h"
 #include "blocklist_sync.h"
 #include "config.h"
+#include "heap_guard.h"
 #include "announcement.h"
 #include "report_queue.h"
 #include "sip_parse.h"
@@ -2087,6 +2088,10 @@ static void sip_task(void *arg)
 
         // Incoming packet.
         rx[n] = '\0';
+        // Breadcrumb for the heap sentinel: this is where network-supplied
+        // text gets parsed and echoed into replies, so if the heap goes bad
+        // shortly after, the capture should say so.
+        heap_guard_note("sip:rx");
         handle_incoming(&ctx, rx, n, &from);
     }
 }

--- a/phoneblock-dongle/firmware/main/tr064.c
+++ b/phoneblock-dongle/firmware/main/tr064.c
@@ -92,8 +92,11 @@ typedef struct {
 static esp_err_t http_evt_cb(esp_http_client_event_t *evt)
 {
     resp_buf_t *r = evt->user_data;
-    if (evt->event_id == HTTP_EVENT_ON_DATA
-        && !esp_http_client_is_chunked_response(evt->client)) {
+    // No is_chunked_response() gate: esp_http_client de-chunks the body before
+    // ON_DATA fires, so gating on it drops the whole SOAP response whenever the
+    // Fritz!Box answers chunked — which surfaces as an unexplained "parse
+    // failed" rather than as a transport error. Same bug sync.c documents.
+    if (evt->event_id == HTTP_EVENT_ON_DATA) {
         int remaining = r->cap - r->len - 1;
         int copy = evt->data_len < remaining ? evt->data_len : remaining;
         if (copy > 0) {

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -27,6 +27,7 @@
 #include "api.h"
 #include "blocklist_sync.h"
 #include "config.h"
+#include "heap_guard.h"
 #include "firmware_update.h"
 #include "log_capture.h"
 #include "mail.h"
@@ -52,10 +53,16 @@ static httpd_handle_t s_server = NULL;
 // — index.html itself renders the in-page login state) or to a 401
 // (API). The do/while wrapper keeps the macro safe inside an
 // if/else without braces.
+//
+// These macros also carry the heap sentinel's breadcrumb: every handler opens
+// with one of them, which makes them the only central "a request is being
+// served" hook short of touching each handler individually. See heap_guard.h.
 #define REQUIRE_AUTH_HTML(req) do { \
+    heap_guard_note("http:html"); \
     if (!web_auth_required((req), false)) return ESP_OK; \
 } while (0)
 #define REQUIRE_AUTH_API(req) do { \
+    heap_guard_note("http:api"); \
     if (!web_auth_required((req), true)) return ESP_OK; \
 } while (0)
 // For the intentionally-public routes: LAN-only when the gate is off,

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -1940,6 +1940,28 @@ static esp_err_t handle_crash_test(httpd_req_t *req)
     xTaskCreate(crash_test_task, "crash_test", 2048, NULL, 5, NULL);
     return ESP_OK;
 }
+
+// POST /api/dev/heap-rehearse — prove the heap sentinel actually fires, by
+// staging a real overflow across two of its own adjacent allocations and
+// checking it is caught (see heap_guard_rehearse). Only compiled in when
+// CONFIG_CRASH_TEST_ENABLE=y.
+//
+// No confirmation nonce, unlike /api/dev/crash: on success this neither reboots
+// nor changes any state, so a stale browser replay is harmless. It does corrupt
+// the heap for a few microseconds, which is why it is a bench-only route.
+static esp_err_t handle_heap_rehearse(httpd_req_t *req)
+{
+    REQUIRE_AUTH_API(req);
+
+    char detail[160] = "";
+    bool ok = heap_guard_rehearse(detail, sizeof(detail));
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject  (root, "ok", ok);
+    cJSON_AddStringToObject(root, "message", detail);
+    send_json(req, root);
+    return ESP_OK;
+}
 #endif // CONFIG_CRASH_TEST_ENABLE
 
 // POST /api/sync/run — trigger an immediate blocklist sync.
@@ -2060,6 +2082,7 @@ static const httpd_uri_t URIS[] = {
     { .uri = "/api/factory-reset",   .method = HTTP_POST, .handler = handle_factory_reset,  .user_ctx = NULL },
 #ifdef CONFIG_CRASH_TEST_ENABLE
     { .uri = "/api/dev/crash",       .method = HTTP_POST, .handler = handle_crash_test,     .user_ctx = NULL },
+    { .uri = "/api/dev/heap-rehearse", .method = HTTP_POST, .handler = handle_heap_rehearse, .user_ctx = NULL },
 #endif
     { .uri = "/api/firmware",         .method = HTTP_POST, .handler = handle_firmware_upload,  .user_ctx = NULL },
     { .uri = "/api/firmware/check",   .method = HTTP_POST, .handler = handle_firmware_check,   .user_ctx = NULL },

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -1941,20 +1941,16 @@ static esp_err_t handle_crash_test(httpd_req_t *req)
     return ESP_OK;
 }
 
-// POST /api/dev/heap-rehearse — prove the heap sentinel actually fires, by
-// staging a real overflow across two of its own adjacent allocations and
-// checking it is caught (see heap_guard_rehearse). Only compiled in when
-// CONFIG_CRASH_TEST_ENABLE=y.
-//
-// No confirmation nonce, unlike /api/dev/crash: on success this neither reboots
-// nor changes any state, so a stale browser replay is harmless. It does corrupt
-// the heap for a few microseconds, which is why it is a bench-only route.
-static esp_err_t handle_heap_rehearse(httpd_req_t *req)
+// POST /api/dev/heap-smash — corrupt the heap for real and let the sentinel take
+// it from there: it detects, captures the evidence and panics, and the next boot
+// uploads the core dump. Exercises the whole pipeline the way a genuine
+// corruption would. Only compiled in when CONFIG_CRASH_TEST_ENABLE=y.
+static esp_err_t handle_heap_smash(httpd_req_t *req)
 {
     REQUIRE_AUTH_API(req);
 
     char detail[160] = "";
-    bool ok = heap_guard_rehearse(detail, sizeof(detail));
+    bool ok = heap_guard_smash(detail, sizeof(detail));
 
     cJSON *root = cJSON_CreateObject();
     cJSON_AddBoolToObject  (root, "ok", ok);
@@ -2082,7 +2078,7 @@ static const httpd_uri_t URIS[] = {
     { .uri = "/api/factory-reset",   .method = HTTP_POST, .handler = handle_factory_reset,  .user_ctx = NULL },
 #ifdef CONFIG_CRASH_TEST_ENABLE
     { .uri = "/api/dev/crash",       .method = HTTP_POST, .handler = handle_crash_test,     .user_ctx = NULL },
-    { .uri = "/api/dev/heap-rehearse", .method = HTTP_POST, .handler = handle_heap_rehearse, .user_ctx = NULL },
+    { .uri = "/api/dev/heap-smash",   .method = HTTP_POST, .handler = handle_heap_smash,     .user_ctx = NULL },
 #endif
     { .uri = "/api/firmware",         .method = HTTP_POST, .handler = handle_firmware_upload,  .user_ctx = NULL },
     { .uri = "/api/firmware/check",   .method = HTTP_POST, .handler = handle_firmware_check,   .user_ctx = NULL },

--- a/phoneblock-dongle/firmware/release-notes/1.5.2.md
+++ b/phoneblock-dongle/firmware/release-notes/1.5.2.md
@@ -1,0 +1,45 @@
+# PhoneBlock Dongle 1.5.2
+
+*2026-07-27*
+
+## Fixed
+
+- **The dongle no longer discards server replies that arrive in "chunked"
+  form.** Whether a reply is sent in one piece or split into chunks is
+  entirely the server's choice, and it can change from one day to the next
+  after an update on the server or anywhere along the way. The dongle threw
+  such replies away instead of reading them, and then reported the empty
+  result as if the reply had been unreadable. That affected the spam verdict
+  for a call, the token self-test, the daily log and status uploads, and
+  every exchange with the Fritz!Box — the setup wizard and the phone-book
+  sync. The effect was the worst kind: a dongle that had worked for months
+  suddenly stopped screening calls, with nothing in its log to explain why,
+  and nothing the user could do about it. Replies are now always read, in
+  whichever form they arrive.
+
+## Added
+
+- **The dongle now recognises damaged memory, reports it, and restarts
+  itself.** Some 1.5.0 and 1.5.1 dongles rebooted with a crash report that
+  pointed at the code which reads the memory statistics for the web
+  interface. That code was not at fault: the damage had been done earlier by
+  something else, and merely came to light when this code was the first to
+  read across the damaged area — much like discovering a broken step only
+  when somebody finally walks up the stairs. So the reports named the
+  witness instead of the culprit, and by the time one arrived the traces had
+  long been overwritten.
+
+  The dongle now examines its own memory every few seconds. On finding
+  damage it copies the surrounding data, plus a note of what it was doing
+  just beforehand, into its crash report, and then restarts deliberately.
+  Nothing is lost by that restart: a dongle with damaged memory is already
+  unreliable — it may mis-screen calls or fail in some other unpredictable
+  way — and restarting is what puts its memory back in order. What changes
+  is that the fault is now noticed within seconds rather than whenever
+  somebody happens to open the dashboard, and that the report finally
+  contains what is needed to track down the cause.
+
+  For an affected dongle this can mean a restart sooner, and possibly more
+  often, than before — each one leaving the device working again. Dongles
+  that are not affected notice nothing at all. The underlying cause of the
+  damage has not been found yet; this change is what will identify it.

--- a/phoneblock-dongle/firmware/scripts/release.sh
+++ b/phoneblock-dongle/firmware/scripts/release.sh
@@ -116,8 +116,6 @@ fi
 # 2. Build firmware. ESP-IDF reads version from version.txt next to CMakeLists,
 #    which lands in esp_app_desc_t.version and the /api/status payload.
 # ---------------------------------------------------------------------------
-echo "$VERSION" > "${FIRMWARE_DIR}/version.txt"
-
 # Move local build state out of the way so the release is built from
 # sdkconfig.defaults alone — gitignored sticky config has no business
 # in a CDN artifact:
@@ -142,6 +140,13 @@ cleanup() {
     done
 }
 trap cleanup EXIT
+
+# Only now, with cleanup armed, write the file — it must not outlive this
+# script. Written before the trap it could be orphaned by any early exit in
+# between, including the leftover-stash check just below, and a stale
+# version.txt then silently overrides `git describe` for every later dev build
+# in this workspace (that is how a 1.4.1 file came to stamp 1.5.x builds).
+echo "$VERSION" > "${FIRMWARE_DIR}/version.txt"
 
 for f in "${FIRMWARE_DIR}/sdkconfig" "${FIRMWARE_DIR}/sdkconfig.defaults.local"; do
     # Refuse to run if a previous release.sh died before its trap got

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -249,11 +249,10 @@ CONFIG_RTP_PLAY_ANNOUNCEMENT=y
 # for production; flipped to y in sdkconfig.defaults.local for
 # bench builds.
 #
-# It also compiles in the heap sentinel's boot rehearsal, which stages a
-# real overflow against two of its own allocations and checks that the
-# sentinel catches it — the one part of heap_guard.c that cannot be
-# covered by the host tests. Worth running on the bench after any change
-# to the walk.
+# It also compiles in POST /api/dev/heap-smash, which corrupts the heap for
+# real and lets the sentinel detect it, capture the evidence and panic —
+# exercising the whole pipeline end to end, which the host tests cannot
+# reach. Worth running on the bench after any change to the walk.
 CONFIG_CRASH_TEST_ENABLE=n
 
 # Heap-corruption sentinel (main/heap_guard.c). Walks the heap every few
@@ -266,4 +265,3 @@ CONFIG_CRASH_TEST_ENABLE=n
 # that corruption is found.
 CONFIG_HEAP_GUARD_ENABLE=y
 CONFIG_HEAP_GUARD_INTERVAL_S=5
-CONFIG_HEAP_GUARD_MAX_PANICS=3

--- a/phoneblock-dongle/firmware/sdkconfig.defaults
+++ b/phoneblock-dongle/firmware/sdkconfig.defaults
@@ -248,4 +248,22 @@ CONFIG_RTP_PLAY_ANNOUNCEMENT=y
 # exercise the coredump-and-upload pipeline end-to-end. MUST stay n
 # for production; flipped to y in sdkconfig.defaults.local for
 # bench builds.
+#
+# It also compiles in the heap sentinel's boot rehearsal, which stages a
+# real overflow against two of its own allocations and checks that the
+# sentinel catches it — the one part of heap_guard.c that cannot be
+# covered by the host tests. Worth running on the bench after any change
+# to the walk.
 CONFIG_CRASH_TEST_ENABLE=n
+
+# Heap-corruption sentinel (main/heap_guard.c). Walks the heap every few
+# seconds; on finding a block header that cannot be true it copies the
+# surrounding bytes onto its stack and panics deliberately, so the core
+# dump carries the evidence a dump otherwise never holds (it preserves
+# task stacks, not the heap). Present because 1.5.0 and 1.5.1 both
+# crashed inside tlsf_walk_pool on an already-corrupted heap, where the
+# backtrace names the victim and never the culprit. Keep enabled until
+# that corruption is found.
+CONFIG_HEAP_GUARD_ENABLE=y
+CONFIG_HEAP_GUARD_INTERVAL_S=5
+CONFIG_HEAP_GUARD_MAX_PANICS=3

--- a/phoneblock-dongle/firmware/test/Makefile
+++ b/phoneblock-dongle/firmware/test/Makefile
@@ -7,7 +7,7 @@ CFLAGS  ?= -Wall -Wextra -Werror -O0 -g -I../main
 IDF_PATH ?= $(HOME)/tools/esp/esp-idf
 CJSON_DIR := $(IDF_PATH)/components/json/cJSON
 
-BINS = test_strbuf test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_sip_response test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local
+BINS = test_strbuf test_sip_parse test_sip_frame test_sip_srv test_sip_auth test_sip_response test_tr064_parse test_phone_norm test_api_scan test_log_capture test_improv_proto test_blocklist_lookup test_sched_time test_smtp_body test_mail_html test_version_cmp test_net_local test_heap_guard
 
 test_sip_parse: test_sip_parse.c ../main/sip_parse.c ../main/sip_parse.h \
                 ../main/audio.c ../main/audio.h
@@ -58,6 +58,9 @@ test_version_cmp: test_version_cmp.c ../main/version_cmp.c ../main/version_cmp.h
 
 test_net_local: test_net_local.c ../main/net_local.c ../main/net_local.h
 	$(CC) $(CFLAGS) test_net_local.c ../main/net_local.c -o $@
+
+test_heap_guard: test_heap_guard.c ../main/heap_guard_scan.c ../main/heap_guard_scan.h
+	$(CC) $(CFLAGS) test_heap_guard.c ../main/heap_guard_scan.c -o $@
 
 # strbuf.h is header-only; build its test with AddressSanitizer so any overrun
 # of the (malloc'd) destination buffer aborts.

--- a/phoneblock-dongle/firmware/test/test_heap_guard.c
+++ b/phoneblock-dongle/firmware/test/test_heap_guard.c
@@ -1,0 +1,147 @@
+// Host test for heap_guard_scan.c — the block-sanity predicate behind the
+// heap sentinel's deliberate panic.
+//
+// Two properties matter and are tested from both sides:
+//   * it must never accuse a healthy block, because a false positive reboots a
+//     working dongle (and would do so every few seconds); and
+//   * it must catch the step that actually crashed dongle 1.5.1, whose figures
+//     are pinned in test_regression_1_5_1() straight from the core dump.
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../main/heap_guard_scan.h"
+
+static int tests_run, tests_failed;
+#define CHECK(cond, msg) do {                                   \
+    tests_run++;                                                \
+    if (!(cond)) { tests_failed++;                              \
+        printf("  FAIL: %s (%s:%d)\n", msg, __FILE__, __LINE__);\
+    } else printf("  ok: %s\n", msg);                           \
+} while (0)
+
+// Bounds in the shape the ESP32 reports them: the internal DRAM heap of the
+// dongle that produced the 1.5.1 dump started at .dram0.heap_start.
+static const hg_pool_t POOL = { 0x3ffbf3c0u, 0x3ffe0000u };
+
+static void test_healthy(void)
+{
+    printf("test_healthy\n");
+    CHECK(hg_classify(POOL, 0x3ffd0008u, 64) == HG_OK, "ordinary block");
+    CHECK(hg_classify(POOL, POOL.start, 16) == HG_OK, "block at heap start");
+    CHECK(hg_classify(POOL, 0x3ffd0008u, 4) == HG_OK, "smallest aligned block");
+
+    // A block that reaches exactly to the last byte of the heap is legal — the
+    // final allocation in a pool looks like this, and accusing it would panic
+    // every few seconds on a healthy device.
+    uintptr_t ptr = 0x3ffdf000u;
+    CHECK(hg_classify(POOL, ptr, (size_t)(POOL.end - ptr)) == HG_OK,
+          "block ending exactly at heap end");
+
+    // Sweep a synthetic pool the way the walker would, to be sure nothing in
+    // the ordinary range trips the predicate.
+    int bad = 0;
+    for (uintptr_t p = POOL.start; p + 128 < POOL.end; p += 128)
+        if (hg_classify(POOL, p, 128) != HG_OK) bad++;
+    CHECK(bad == 0, "sweep of aligned blocks yields no verdict");
+}
+
+static void test_regression_1_5_1(void)
+{
+    printf("test_regression_1_5_1\n");
+    // From the core dump: tlsf_walk_pool stepped to block 0xb26c6190 and
+    // faulted reading its size (excvaddr 0xb26c6194, LoadProhibited). That
+    // successor is prev + prev_size, so the block reported just before the
+    // fault carried this size. The predicate has to reject it *before* the
+    // walker takes the step.
+    uintptr_t ptr  = 0x3ffd0008u;
+    size_t    size = 0xb26c6190u - 0x3ffd0000u;
+    CHECK(hg_classify(POOL, ptr, size) == HG_BAD_BOUNDS,
+          "1.5.1 wild successor rejected as out of bounds");
+
+    // And the evidence window around it stays inside the heap.
+    uintptr_t from; size_t len;
+    hg_window(POOL, ptr, 192, 64, &from, &len);
+    CHECK(from >= POOL.start && from + len <= POOL.end,
+          "1.5.1 evidence window stays within the heap");
+    CHECK(len == 192 + 64, "1.5.1 evidence window is full size");
+}
+
+static void test_rejections(void)
+{
+    printf("test_rejections\n");
+    CHECK(hg_classify(POOL, POOL.start - 4, 16) == HG_BAD_PTR, "below heap");
+    CHECK(hg_classify(POOL, POOL.end, 16) == HG_BAD_PTR, "at heap end");
+    CHECK(hg_classify(POOL, 0x8d513e90u, 16) == HG_BAD_PTR, "wild pointer");
+    CHECK(hg_classify(POOL, 0x3ffd0008u, 0) == HG_BAD_SIZE, "zero size");
+
+    uintptr_t ptr = 0x3ffdf000u;
+    CHECK(hg_classify(POOL, ptr, (size_t)(POOL.end - ptr) + 4) == HG_BAD_BOUNDS,
+          "one aligned step past heap end");
+
+    // A wild size must be rejected, not wrapped back into range by overflow.
+    CHECK(hg_classify(POOL, 0x3ffdfff0u, SIZE_MAX) == HG_BAD_BOUNDS,
+          "SIZE_MAX does not wrap into range");
+
+    CHECK(hg_classify(POOL, 0x3ffd0009u, 64) == HG_BAD_ALIGN, "misaligned ptr");
+    CHECK(hg_classify(POOL, 0x3ffd0008u, 63) == HG_BAD_ALIGN, "misaligned size");
+}
+
+static void test_window(void)
+{
+    printf("test_window\n");
+    uintptr_t from; size_t len;
+
+    hg_window(POOL, 0x3ffd0000u, 192, 64, &from, &len);
+    CHECK(from == 0x3ffd0000u - 192 && len == 256, "window centred in heap");
+
+    // Clamped at the start: a block near the bottom of the heap has less
+    // preceding data than we asked for.
+    hg_window(POOL, POOL.start + 8, 192, 64, &from, &len);
+    CHECK(from == POOL.start && len == 8 + 64, "window clamped at heap start");
+
+    // Clamped at the end.
+    hg_window(POOL, POOL.end - 16, 192, 64, &from, &len);
+    CHECK(from == POOL.end - 16 - 192 && len == 192 + 16,
+          "window clamped at heap end");
+
+    hg_window(POOL, POOL.start, 192, 64, &from, &len);
+    CHECK(from == POOL.start && len == 64, "window at exact heap start");
+
+    // Nothing safe to copy when the anchor itself is wild — the caller then
+    // falls back to the last good block.
+    hg_window(POOL, 0xb26c6190u, 192, 64, &from, &len);
+    CHECK(len == 0, "wild centre yields an empty window");
+    hg_window(POOL, POOL.end, 192, 64, &from, &len);
+    CHECK(len == 0, "centre at heap end yields an empty window");
+}
+
+static void test_verdict_strings(void)
+{
+    printf("test_verdict_strings\n");
+    // Every verdict needs a distinct label: it is copied into the core dump's
+    // summary line, which is how the crash is triaged.
+    const hg_verdict_t all[] = { HG_OK, HG_BAD_PTR, HG_BAD_SIZE,
+                                 HG_BAD_BOUNDS, HG_BAD_ALIGN };
+    int ok = 1;
+    for (size_t i = 0; i < sizeof(all) / sizeof(all[0]); i++) {
+        if (!hg_verdict_str(all[i]) || !hg_verdict_str(all[i])[0]) ok = 0;
+        for (size_t j = i + 1; j < sizeof(all) / sizeof(all[0]); j++)
+            if (strcmp(hg_verdict_str(all[i]), hg_verdict_str(all[j])) == 0) ok = 0;
+    }
+    CHECK(ok, "all verdicts have distinct non-empty labels");
+}
+
+int main(void)
+{
+    test_healthy();
+    test_regression_1_5_1();
+    test_rejections();
+    test_window();
+    test_verdict_strings();
+
+    printf("\n%d checks, %d failed\n", tests_run, tests_failed);
+    return tests_failed ? 1 : 0;
+}


### PR DESCRIPTION
Forward-merge of the `dongle-1.5.x` release branch into `master` (release-branch-first, per CLAUDE.md). No firmware changes landed on `master` since the merge base, so this is conflict-free.

## Why

1.5.0 and 1.5.1 both crashed in `tlsf_walk_pool`, reached from `heap_caps_get_largest_free_block()` while `httpd` served `GET /api/status`. That code only *reads* heap metadata — it was simply the first thing to walk an already-corrupted heap, so every backtrace named the victim and never the culprit. A dump from 1.5.1 (verified same-build via `app_elf_sha256`) proves the SIP response-builder overflow fixed in 1.5.1 was **not** the only corruption source, so the underlying bug is still live in the field.

Two things made those dumps nearly useless: detection was unbounded in time (the smashed block sat there until somebody opened the dashboard, by which point the payload identifying the writer had been freed and reused), and a core dump preserves task stacks but not the heap — so the actual evidence is absent. Capturing all of DRAM is not an option either: the coredump partition is 52 KB wedged in the alignment gap before `ota_0`, and enlarging it means a USB reflash of every dongle in the field.

## What

**Heap sentinel** (`main/heap_guard.c`). Walks the heap every 5 s via the public, stoppable `heap_caps_walk_all()`; the callback validates each block *before* the walker steps onto it, so detection is clean where `tlsf_check()` would itself fault. On a hit it copies 256 bytes around the smashed block onto its own stack and panics deliberately — task stacks are what a dump preserves, so the evidence rides out behind the ASCII marker `PBHEAPGUARD1`.

The walk runs under the heap lock, which rules out a torn read from a concurrent `malloc`, so no confirmation pass is needed. It runs from an `esp_timer` callback rather than the scheduler task, which blocks for minutes inside OTA downloads and SMTP sends — exactly the heap-heavy moments most worth covering. Breadcrumbs (`heap_guard_note`) mark the paths that parse external data into heap buffers; the last four are kept rather than one, so the dashboard's own `/api/status` poll cannot mask a rarer operation.

The boot self-test runs the same walk over the known-good heap and **refuses to arm** if a healthy block trips the predicate — that would mean the assumption is wrong rather than the heap, and arming would reboot working dongles every few seconds.

**Chunked-reply fix.** Three response collectors gated their copy on `!esp_http_client_is_chunked_response()`. `esp_http_client` de-chunks before `ON_DATA` fires, so that gate discards the decoded payload whenever the peer answers chunked. Affected every phoneblock.net API response and every Fritz!Box SOAP response. `sync.c` already carried a comment about this; the fix had never reached the other three.

## Verification

Host tests: 23 checks in `test/test_heap_guard.c`, including a regression case pinned to the real 1.5.1 dump figures, and both boundary directions (a block ending exactly at heap end must **not** trip).

On-hardware, end to end on a real dongle — a staged 8-byte overflow across a 68-byte block gap produced this dump:

```
Crashed task: 'esp_timer'
Panic reason: heap corruption: block extends past heap end;
  bad blk=0x3ffdea10 size=1482184792 used;
  prev blk=0x3ffde9cc size=64 used;
  heap=0x3ffbf410..0x3ffe0000 blocks=459; win=0x3ffde950+256; up=503s;
  recent: http:api@-4713ms blocklist:sync@-369217ms
#2 hg_panic_with_evidence  heap_guard.c
#3 hg_check                heap_guard.c
```

`size=1482184792` is `0x58585858` — the `'X'` payload sitting in the smashed size field. `prev blk … size=64` names the overflowing allocation, which is exactly what the original dumps could never give. The marker and full summary are readable with `strings` alone, no matching ELF required.

Measured cost: 500–882 blocks walked in 565–898 µs, no false positive across several hundred walks. A walk overlapping flash traffic (daily blocklist sync, OTA, the boot-time coredump upload) measures tens of ms instead, because flash access disables the cache and the stall lands inside the critical section — routine and harmless against the 300 ms interrupt watchdog.

## Notes

- `CONFIG_HEAP_GUARD_ENABLE=y`, interval 5 s. Keep it on until the corruption is found.
- `POST /api/dev/heap-smash` exists only under `CONFIG_CRASH_TEST_ENABLE` (off in production; verified zero dev symbols in the production image).
- A self-triggered-panic cap was tried and removed: `RTC_NOINIT` is not retained across this chip's panic-reset path, so the counter read back as a cold start every time. Residual risk stated in the code — a trigger recurring on every boot can still loop.
- The non-SIP buffer audit that accompanied this found **no** unbounded write, which shifts suspicion to the class an overflow audit cannot see: use-after-free, double-free, or a write through a stale pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)