### PR TITLE
Dongle UI: say "translation unavailable" at once, stop re-polling

### DIFF
--- a/phoneblock-dongle/firmware/main/i18n_sync.c
+++ b/phoneblock-dongle/firmware/main/i18n_sync.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "freertos/FreeRTOS.h"
@@ -599,4 +600,18 @@ void i18n_sync_snapshot(i18n_sync_status_t *out)
     xSemaphoreTake(s_lock, portMAX_DELAY);
     *out = s_status;
     xSemaphoreGive(s_lock);
+}
+
+void i18n_sync_ui_path(char *out, size_t cap, const char *lang)
+{
+    snprintf(out, cap, "%s/ui-%s.json", SPIFFS_DIR, lang ? lang : "");
+}
+
+bool i18n_sync_have_ui_pack(const char *lang)
+{
+    if (!lang || !*lang) return false;
+    char path[48];
+    i18n_sync_ui_path(path, sizeof(path), lang);
+    struct stat st;
+    return stat(path, &st) == 0 && st.st_size > 0;
 }

--- a/phoneblock-dongle/firmware/main/i18n_sync.h
+++ b/phoneblock-dongle/firmware/main/i18n_sync.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // Downloads the localized device assets — the answer-bot announcement audio
@@ -63,3 +64,13 @@ typedef struct {
 } i18n_sync_status_t;
 
 void i18n_sync_snapshot(i18n_sync_status_t *out);
+
+// Path of the downloaded web-UI string pack for `lang` on SPIFFS. This module
+// owns the layout; web.c serves the file at /api/i18n/ui.
+void i18n_sync_ui_path(char *out, size_t cap, const char *lang);
+
+// Whether a downloaded UI pack for `lang` is present. False means
+// /api/i18n/ui falls back to the embedded English pack — which the web UI
+// needs to distinguish from "still downloading", so it can say
+// "translation unavailable" straight away instead of polling for a minute.
+bool i18n_sync_have_ui_pack(const char *lang);

--- a/phoneblock-dongle/firmware/main/web.c
+++ b/phoneblock-dongle/firmware/main/web.c
@@ -462,6 +462,22 @@ static esp_err_t handle_status(httpd_req_t *req)
     // Whether ui_lang is a real user choice or still the "en" default — the web
     // UI auto-selects the browser's language on first contact when unset.
     cJSON_AddBoolToObject(root, "ui_lang_set", config_ui_lang_is_set());
+    // State of the localized-asset download, so the page can tell "the pack is
+    // on its way" from "it will not come". Without this the UI could only
+    // observe that /api/i18n/ui keeps serving the English fallback, and had to
+    // poll for a minute before concluding the pack was unavailable — on every
+    // single page load. `sync_lang` is the locale the last pass handled: when
+    // it differs from ui_lang, that pass says nothing about the current
+    // locale (a switch was just requested), so the page keeps waiting.
+    cJSON *i18 = cJSON_AddObjectToObject(root, "i18n");
+    i18n_sync_status_t is;
+    i18n_sync_snapshot(&is);
+    cJSON_AddBoolToObject  (i18, "have_ui_pack", i18n_sync_have_ui_pack(config_ui_lang()));
+    cJSON_AddBoolToObject  (i18, "running",      is.running);
+    cJSON_AddBoolToObject  (i18, "ever_ran",     is.ever_ran);
+    cJSON_AddBoolToObject  (i18, "last_ok",      is.last_ok);
+    cJSON_AddStringToObject(i18, "sync_lang",    is.lang);
+    cJSON_AddStringToObject(i18, "last_error",   is.last_error);
     // Country of the line, used to expand national caller IDs to E.164.
     // Shown (and changed) under Setup ▸ Region; "+49" until a token
     // activation adopts the account's value or the user picks one.
@@ -1576,7 +1592,7 @@ static esp_err_t handle_i18n_ui(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Cache-Control", "no-store");
 
     char path[48];
-    snprintf(path, sizeof(path), "/spiffs/ui-%s.json", config_ui_lang());
+    i18n_sync_ui_path(path, sizeof(path), config_ui_lang());
     FILE *f = fopen(path, "rb");
     if (f) {
         char buf[1024];

--- a/phoneblock-dongle/firmware/main/web/index.html
+++ b/phoneblock-dongle/firmware/main/web/index.html
@@ -180,6 +180,25 @@ function storePack(reqLang, dict){
 // restore the current state.
 let g_i18nStatus = '';   // '' | 'loading' | 'unavailable'
 function setLangStatus(kind){ g_i18nStatus = kind || ''; applyLangStatus(); }
+
+// The device's view of the localized-asset download (status.i18n), refreshed by
+// every /api/status poll. The page asks it whether a pack is still coming
+// instead of inferring that from /api/i18n/ui serving the English fallback —
+// which is indistinguishable from "it will never come" and used to cost a
+// 60-second poll on every page load.
+let g_i18nState = null;
+function noteI18nState(st){ if (st) g_i18nState = st; }
+// True while the device could still produce a pack for `lang`: it has never
+// synced, a pass is in flight, or the last pass was about a different locale
+// (a switch was just requested — the trigger runs on the scheduler task, so
+// `running` is briefly still false). Unknown state (no status yet) counts as
+// "wait": better a short orange bubble than a wrong red one.
+function i18nPackPending(lang){
+  const st = g_i18nState;
+  if (!st) return true;
+  if (st.have_ui_pack) return true;      // present; the next fetch serves it
+  return !st.ever_ran || !!st.running || st.sync_lang !== lang;
+}
 function applyLangStatus(){
   const el = document.getElementById('langStatus');   // only on the status page
   if (!el) return;
@@ -365,6 +384,7 @@ function pickBrowserLang(){
 // announcement — without overriding a real user choice on later visits.
 function loadDeviceLang(){
   return fetch('/api/status').then(r => r.ok ? r.json() : null).then(d => {
+    noteI18nState(d && d.i18n);
     LANG = (d && d.ui_lang) ? String(d.ui_lang) : 'en';
     if (d && d.ui_lang_set === false){
       const auto = pickBrowserLang();
@@ -393,6 +413,10 @@ function awaitUiPack(lang, tries){
   tries = tries || 0;
   if (LANG !== lang) return;                          // user switched again
   if (I18N[lang] && I18N[lang]['@@locale'] === lang) { setLangStatus(''); return; }
+  // The device says no pack is coming for this locale — say so at once instead
+  // of polling. Re-checked on every tick, so a download that fails mid-poll
+  // also stops here rather than running the bound out.
+  if (!i18nPackPending(lang)) { setLangStatus('unavailable'); return; }
   if (tries > 30) { setLangStatus('unavailable'); return; }  // gave up polling
   setLangStatus('loading');
   setTimeout(() => {
@@ -1147,6 +1171,9 @@ async function refreshAll(){
   ]);
   if (!s) return;
   hideLoginState();
+  // Keeps the "is a pack still coming?" answer fresh for awaitUiPack without
+  // any request of its own — this poll runs every 3 s anyway.
+  noteI18nState(s.i18n);
   resetNonce = s.reset_nonce || '';
   syncRegionSelectors(s);
   const sipConfigured = !!(s.sip.host && s.sip.user);


### PR DESCRIPTION
When no localized pack is published for the active locale, **every page load** showed the orange *"Translation is loading …"* bubble for a full minute before flipping to the red *"not available"* note — and hit `/api/i18n/ui` 31 times to get there.

## Where the waste was

Not on the CDN side: `GET /api/i18n/ui` is a plain read (the SPIFFS pack if present, otherwise the baked-in English pack), and a download only runs daily, shortly after boot, and on a `ui_lang` change. The device never re-downloaded per page load.

It was in the browser. `awaitUiPack()` could only observe that the device kept serving the embedded English fallback — which is indistinguishable from *"the pack is still on its way"* — so it polled out its full `31 × 2 s` bound before concluding anything.

## Fix

The device already tracked the answer in `i18n_sync_snapshot()`; it just wasn't exposed. `/api/status` now carries an `i18n` object (`have_ui_pack`, `running`, `ever_ran`, `last_ok`, `sync_lang`, `last_error`) and the page decides from it:

| device state | bubble |
| --- | --- |
| pack present | none |
| never synced, or a pass running | "loading", poll as before |
| `sync_lang` ≠ `ui_lang` | "loading" |
| a finished pass for *this* locale left no pack | **"unavailable" immediately, no polling** |

The `sync_lang` comparison matters: `i18n_sync_trigger_now()` only *asks* the scheduler to run the pass, so right after a language switch `running` is still false — without that row the UI would wrongly declare failure a second after the user picked a language.

The predicate is re-checked on every poll tick against state refreshed by the dashboard's existing 3 s `/api/status` poll, so a download that fails *mid*-poll also stops right there instead of running the bound out. No extra requests — that poll happens anyway.

`i18n_sync` gains `i18n_sync_ui_path()` / `i18n_sync_have_ui_pack()` so the `"/spiffs/ui-<lang>.json"` layout lives in the module that owns it; `web.c`'s handler uses the helper instead of rebuilding the path.

## Verification

A dev build has no CDN bundle for its version, so the manifest 404s — exactly the reported situation. On the test dongle:

- `/api/status` → `i18n: {have_ui_pack: false, running: false, ever_ran: true, last_ok: false, sync_lang: "es", last_error: "HTTP 404"}`
- Driving a real browser against it: the red *"Translation not available – default language is displayed."* appears on first render, with **one** `/api/i18n/ui` request instead of 31.
- Switching to another unpublished locale shows "loading" while the pass is in flight and settles on "unavailable" after ~8 s instead of ~62 s.
- `idf.py build` clean; `cd firmware/test && make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)