### PR TITLE
Personal wildcard blocks in the dongle's binary blocklist (#514)

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BlocklistServlet.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/BlocklistServlet.java
@@ -281,9 +281,11 @@ public class BlocklistServlet extends HttpServlet {
 			resp.getOutputStream().write(bytes);
 		} else if (TYPE_PERSONAL.equals(type)) {
 			DB.PersonalLists personal = db.getPersonalLists(userName);
-			List<Entry> entries = PersonalEntries.from(personal.blacklist(), personal.whitelist());
-			LOG.info("Sending binary personal blocklist ({} entries) to user '{}' (agent '{}')",
-				entries.size(), userName, userAgent);
+			List<Entry> entries = PersonalEntries.from(personal);
+			LOG.info("Sending binary personal blocklist ({} entries, {} of them wildcards) to user '{}' (agent '{}')",
+				entries.size(),
+				personal.blockedWildcards().size() + personal.allowedWildcards().size(),
+				userName, userAgent);
 			resp.setContentType(BINARY_CONTENT_TYPE);
 			BlocklistBinaryEncoder.write(resp.getOutputStream(), entries);
 		} else {

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PersonalEntries.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/api/PersonalEntries.java
@@ -8,14 +8,22 @@ import java.util.Collection;
 import java.util.List;
 
 import de.haumacher.phoneblock.analysis.NumberAnalyzer;
+import de.haumacher.phoneblock.db.DB;
 import de.haumacher.phoneblock.sync.binary.BlocklistBinaryEncoder.Entry;
 import de.haumacher.phoneblock.sync.binary.BlocklistRecord;
 
 /**
  * Converts personal blocklist phone IDs from the DB format ({@code 0xxx} for
- * German national, {@code 00xxx} for international, optional trailing
- * {@code *} for a wildcard prefix) into the bare-E.164 {@link Entry} form
- * expected by the binary encoder.
+ * German national, {@code 00xxx} for international) into the bare-E.164
+ * {@link Entry} form expected by the binary encoder.
+ *
+ * <p>
+ * Wildcard prefixes are <em>not</em> recognisable from the phone ID itself:
+ * {@code PERSONALIZATION} stores them bare, with the {@code WILDCARD} column
+ * carrying the distinction (#377). They are therefore passed in as their own
+ * lists (#514) — the source of the bug where the whole prefix section of the
+ * dongle's personal list came out empty.
+ * </p>
  *
  * <p>
  * Lives on the server side (not in {@code phoneblock-shared}) because the
@@ -29,42 +37,66 @@ public final class PersonalEntries {
 	}
 
 	/**
+	 * Builds the personal-list entries for the binary blocklist from a user's complete personal
+	 * lists.
+	 *
+	 * <p>
+	 * Takes the whole {@link DB.PersonalLists} rather than the individual lists so that a caller
+	 * cannot forget the wildcard prefixes — dropping them silently turns a blocked range into an
+	 * empty prefix section, which is exactly how #514 arose.
+	 * </p>
+	 */
+	public static List<Entry> from(DB.PersonalLists lists) {
+		return from(lists.blacklist(), lists.whitelist(),
+			lists.blockedWildcards(), lists.allowedWildcards());
+	}
+
+	/**
 	 * Builds the personal-list entries for the binary blocklist.
 	 *
-	 * @param blacklist Phone IDs the user has explicitly blocked.
-	 * @param whitelist Phone IDs the user has explicitly allowed.
+	 * @param blacklist        Exact phone IDs the user has explicitly blocked.
+	 * @param whitelist        Exact phone IDs the user has explicitly allowed.
+	 * @param blockedWildcards Prefixes (bare, no {@code *}) whose range the user has blocked.
+	 * @param allowedWildcards Prefixes (bare, no {@code *}) whose range the user has allowed.
 	 */
-	public static List<Entry> from(Collection<String> blacklist, Collection<String> whitelist) {
-		List<Entry> result = new ArrayList<>(blacklist.size() + whitelist.size());
-		for (String phoneId : blacklist) {
-			Entry e = convert(phoneId, true);
-			if (e != null) {
-				result.add(e);
-			}
-		}
-		for (String phoneId : whitelist) {
-			Entry e = convert(phoneId, false);
-			if (e != null) {
-				result.add(e);
-			}
-		}
+	static List<Entry> from(Collection<String> blacklist, Collection<String> whitelist,
+			Collection<String> blockedWildcards, Collection<String> allowedWildcards) {
+		List<Entry> result = new ArrayList<>(blacklist.size() + whitelist.size()
+			+ blockedWildcards.size() + allowedWildcards.size());
+		convertAll(result, blacklist, true, false);
+		convertAll(result, whitelist, false, false);
+		convertAll(result, blockedWildcards, true, true);
+		convertAll(result, allowedWildcards, false, true);
 		return result;
+	}
+
+	private static void convertAll(List<Entry> result, Collection<String> phoneIds, boolean black,
+			boolean wildcard) {
+		for (String phoneId : phoneIds) {
+			Entry e = convert(phoneId, black, wildcard);
+			if (e != null) {
+				result.add(e);
+			}
+		}
 	}
 
 	/**
 	 * Normalises a single personal phone ID. Returns {@code null} if the input
 	 * cannot be converted to bare E.164 digits.
 	 *
-	 * @param phoneId DB-format phone ID; may end in {@code *} for a wildcard.
-	 * @param black   {@code true} for a blacklist entry, {@code false} for a
-	 *                whitelist entry.
+	 * @param phoneId  DB-format phone ID. A trailing {@code *} is tolerated (and implies a
+	 *                 wildcard) but not what the DB stores — see the class comment.
+	 * @param black    {@code true} for a blacklist entry, {@code false} for a
+	 *                 whitelist entry.
+	 * @param wildcard {@code true} if the ID is a prefix matching a whole number range.
 	 */
-	static Entry convert(String phoneId, boolean black) {
+	static Entry convert(String phoneId, boolean black, boolean wildcard) {
 		if (phoneId == null || phoneId.isEmpty()) {
 			return null;
 		}
-		boolean wildcard = phoneId.charAt(phoneId.length() - 1) == '*';
-		String stripped = wildcard ? phoneId.substring(0, phoneId.length() - 1) : phoneId;
+		boolean starred = phoneId.charAt(phoneId.length() - 1) == '*';
+		String stripped = starred ? phoneId.substring(0, phoneId.length() - 1) : phoneId;
+		wildcard |= starred;
 		if (stripped.isEmpty()) {
 			return null;
 		}

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/controller/BlacklistController.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/app/render/controller/BlacklistController.java
@@ -24,7 +24,7 @@ public class BlacklistController extends PersonalListController {
 	@Override
 	protected List<WildcardEntry> loadWildcards(BlockList blocklist, long userId) {
 		List<WildcardEntry> result = new ArrayList<>();
-		for (String prefix : blocklist.getBlockedWildcards(userId)) {
+		for (String prefix : blocklist.getWildcards(userId, true)) {
 			result.add(new WildcardEntry(prefix, NumberAnalyzer.toInternationalFormat(prefix)));
 		}
 		return result;

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/carddav/resource/AddressBookCache.java
@@ -145,7 +145,7 @@ public class AddressBookCache implements ServletContextListener {
 			long userId = users.getUserId(principal);
 			List<String> personalizations = blocklist.getPersonalizations(userId);
 			Set<String> exclusions = blocklist.getExcluded(userId);
-			List<String> wildcards = blocklist.getBlockedWildcards(userId);
+			List<String> wildcards = blocklist.getWildcards(userId, true);
 
 			if (personalizations.isEmpty() && exclusions.isEmpty() && wildcards.isEmpty()) {
 				CommonList common = getCommonList(reports, listType, now);

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
@@ -188,14 +188,15 @@ public interface BlockList {
 	int updatePersonalizationHash(String phone, byte[] sha1);
 
 	/**
-	 * All blocked wildcard prefixes (phone-ID form) of the user with the given user ID (#377).
+	 * Wildcard prefixes (phone-ID form, stored bare without a trailing {@code *}) of the given
+	 * block state for the user with the given user ID (#377).
 	 */
 	@Select("""
 			select PHONE from PERSONALIZATION
-			where USERID = #{userId} and BLOCKED and WILDCARD
+			where USERID = #{userId} and WILDCARD and BLOCKED = #{blocked}
 			order by PHONE
 			""")
-	List<String> getBlockedWildcards(long userId);
+	List<String> getWildcards(long userId, boolean blocked);
 
 	/**
 	 * Wildcard prefixes of the given block state for the user with the given user ID, with

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -2044,26 +2044,66 @@ public class DB {
 		return (int) Math.round(Math.max(0.0, spam - legit));
 	}
 
-	/** A user's personal black and white phone-ID lists, in raw DB format. */
+	/**
+	 * A user's personal black and white lists, in raw DB format: the exact phone IDs plus the
+	 * wildcard prefixes (#377), which are a separate row kind and must be matched by prefix.
+	 *
+	 * <p>
+	 * Both kinds belong together in every consumer of the personal lists — omitting the
+	 * wildcards silently downgrades a blocked range to "unknown" (#514) — so they travel in one
+	 * object rather than being fetched separately per call site.
+	 * </p>
+	 */
 	public static final class PersonalLists {
 
 		private final List<String> _blacklist;
 
 		private final List<String> _whitelist;
 
-		PersonalLists(List<String> blacklist, List<String> whitelist) {
+		private final List<String> _blockedWildcards;
+
+		private final List<String> _allowedWildcards;
+
+		/**
+		 * Creates a {@link PersonalLists}.
+		 *
+		 * @param blacklist        See {@link #blacklist()}.
+		 * @param whitelist        See {@link #whitelist()}.
+		 * @param blockedWildcards See {@link #blockedWildcards()}.
+		 * @param allowedWildcards See {@link #allowedWildcards()}.
+		 */
+		public PersonalLists(List<String> blacklist, List<String> whitelist,
+				List<String> blockedWildcards, List<String> allowedWildcards) {
 			_blacklist = blacklist;
 			_whitelist = whitelist;
+			_blockedWildcards = blockedWildcards;
+			_allowedWildcards = allowedWildcards;
 		}
 
-		/** Phone IDs the user has explicitly blocked (BLOCKED = true). */
+		/** Exact phone IDs the user has explicitly blocked (BLOCKED = true). */
 		public List<String> blacklist() {
 			return _blacklist;
 		}
 
-		/** Phone IDs the user has explicitly allowed (BLOCKED = false). */
+		/** Exact phone IDs the user has explicitly allowed (BLOCKED = false). */
 		public List<String> whitelist() {
 			return _whitelist;
+		}
+
+		/**
+		 * Prefixes (phone-ID form, no trailing {@code *}) whose whole number range the user has
+		 * blocked.
+		 */
+		public List<String> blockedWildcards() {
+			return _blockedWildcards;
+		}
+
+		/**
+		 * Prefixes (phone-ID form, no trailing {@code *}) whose whole number range the user has
+		 * allowed.
+		 */
+		public List<String> allowedWildcards() {
+			return _allowedWildcards;
 		}
 
 	}
@@ -2072,8 +2112,10 @@ public class DB {
 	 * Loads the user's personal black/white lists in raw DB phone-ID format.
 	 *
 	 * <p>
-	 * Entries may end in {@code *} to mark a wildcard prefix; otherwise they
-	 * are exact phone IDs in national or {@code 00}-international notation.
+	 * Exact entries are phone IDs in national or {@code 00}-international notation. The wildcard
+	 * prefixes are returned separately (and stored bare, without a trailing {@code *}) because
+	 * they are a distinct row kind in {@code PERSONALIZATION}, matched by prefix rather than by
+	 * equality.
 	 * </p>
 	 */
 	public PersonalLists getPersonalLists(String login) {
@@ -2081,12 +2123,15 @@ public class DB {
 			Users users = session.getMapper(Users.class);
 			Long userId = users.getUserId(login);
 			if (userId == null) {
-				return new PersonalLists(List.of(), List.of());
+				return new PersonalLists(List.of(), List.of(), List.of(), List.of());
 			}
 			BlockList blocklist = session.getMapper(BlockList.class);
-			List<String> black = blocklist.getPersonalizations(userId.longValue());
-			List<String> white = blocklist.getWhiteList(userId.longValue());
-			return new PersonalLists(black, white);
+			long id = userId.longValue();
+			List<String> black = blocklist.getPersonalizations(id);
+			List<String> white = blocklist.getWhiteList(id);
+			List<String> blackWildcards = blocklist.getWildcards(id, true);
+			List<String> whiteWildcards = blocklist.getWildcards(id, false);
+			return new PersonalLists(black, white, blackWildcards, whiteWildcards);
 		}
 	}
 
@@ -2757,7 +2802,7 @@ public class DB {
 	 */
 	public double wildcardReportWeight(BlockList blocklist, long userId, String phoneId) {
 		int bestPrefixLength = -1;
-		for (String prefix : blocklist.getBlockedWildcards(userId)) {
+		for (String prefix : blocklist.getWildcards(userId, true)) {
 			if (phoneId.startsWith(prefix) && prefix.length() > bestPrefixLength) {
 				bestPrefixLength = prefix.length();
 			}

--- a/phoneblock/src/main/webapp/api/phoneblock.json
+++ b/phoneblock/src/main/webapp/api/phoneblock.json
@@ -475,7 +475,7 @@
 				{
 					"name": "type",
 					"in": "query",
-					"description": "Selects which list to return when `format=binary`. `community` (default) returns the shared blocklist; `personal` returns the authenticated user's black/white list. Ignored for `json`/`xml`.",
+					"description": "Selects which list to return when `format=binary`. `community` (default) returns the shared blocklist; `personal` returns the authenticated user's black/white list, including the wildcard prefixes of both (encoded in the file's prefix section). Ignored for `json`/`xml`.",
 					"required": false,
 					"schema": {
 						"type": "string",

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestPersonalEntries.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/app/api/TestPersonalEntries.java
@@ -8,22 +8,30 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import de.haumacher.phoneblock.db.DB;
+import de.haumacher.phoneblock.sync.binary.BlocklistBinaryDecoder;
+import de.haumacher.phoneblock.sync.binary.BlocklistBinaryEncoder;
 import de.haumacher.phoneblock.sync.binary.BlocklistBinaryEncoder.Entry;
+import de.haumacher.phoneblock.sync.binary.BlocklistLookup;
+import de.haumacher.phoneblock.sync.binary.BlocklistLookup.Verdict;
 
 /**
  * Tests {@link PersonalEntries}: phone-ID normalisation from DB format
- * ({@code 0xxx} national, {@code 00xxx} international, optional trailing
- * {@code *} for wildcards) to bare E.164 digits.
+ * ({@code 0xxx} national, {@code 00xxx} international) to bare E.164 digits,
+ * with the wildcard distinction coming from the caller — not from the ID.
  */
 class TestPersonalEntries {
 
 	@Test
 	void germanNationalExact() {
-		Entry e = PersonalEntries.convert("030123456", true);
+		Entry e = PersonalEntries.convert("030123456", true, false);
 		assertEquals("4930123456", e.digits());
 		assertFalse(e.wildcard());
 		assertTrue(e.black());
@@ -31,14 +39,23 @@ class TestPersonalEntries {
 
 	@Test
 	void germanNationalWildcard() {
-		Entry e = PersonalEntries.convert("030*", true);
+		// The DB shape: bare prefix, wildcard-ness passed in (#514).
+		Entry e = PersonalEntries.convert("030", true, true);
 		assertEquals("4930", e.digits());
 		assertTrue(e.wildcard());
+		assertTrue(e.black());
+	}
+
+	@Test
+	void trailingStarIsToleratedAndImpliesWildcard() {
+		Entry e = PersonalEntries.convert("030*", true, false);
+		assertEquals("4930", e.digits());
+		assertTrue(e.wildcard(), "trailing '*' implies a wildcard even without the flag");
 	}
 
 	@Test
 	void internationalDoubleZeroExact() {
-		Entry e = PersonalEntries.convert("0018886749072", false);
+		Entry e = PersonalEntries.convert("0018886749072", false, false);
 		assertEquals("18886749072", e.digits());
 		assertFalse(e.wildcard());
 		assertFalse(e.black(), "white from the whitelist input list");
@@ -46,60 +63,116 @@ class TestPersonalEntries {
 
 	@Test
 	void internationalDoubleZeroWildcard() {
-		Entry e = PersonalEntries.convert("00188*", false);
+		Entry e = PersonalEntries.convert("00188", false, true);
 		assertEquals("188", e.digits());
 		assertTrue(e.wildcard());
 	}
 
 	@Test
 	void rejectsEmptyAndDegenerate() {
-		assertNull(PersonalEntries.convert(null, true));
-		assertNull(PersonalEntries.convert("", true));
-		assertNull(PersonalEntries.convert("*", true));
+		assertNull(PersonalEntries.convert(null, true, false));
+		assertNull(PersonalEntries.convert("", true, false));
+		assertNull(PersonalEntries.convert("*", true, true));
 	}
 
 	@Test
 	void rejectsNonDigitsAfterNormalisation() {
-		assertNull(PersonalEntries.convert("030 12 34", true));
-		assertNull(PersonalEntries.convert("030-123-456", true));
+		assertNull(PersonalEntries.convert("030 12 34", true, false));
+		assertNull(PersonalEntries.convert("030-123-456", true, false));
 	}
 
 	@Test
 	void rejectsOverlyLongNumber() {
-		assertNull(PersonalEntries.convert("01234567890123456", true),
+		assertNull(PersonalEntries.convert("01234567890123456", true, false),
 			"15-digit international part overflows MAX_DIGITS once 49 is prepended");
 	}
 
 	@Test
 	void fromMergesListsWithCorrectColors() {
 		List<Entry> result = PersonalEntries.from(
-			List.of("030111", "030222*"),
-			List.of("030333", "0018886749072"));
+			List.of("030111"),
+			List.of("030333", "0018886749072"),
+			List.of("030222"),
+			List.of("0049800"));
 
-		assertEquals(4, result.size());
+		assertEquals(5, result.size());
 
 		assertEquals("4930111", result.get(0).digits());
 		assertTrue(result.get(0).black());
 		assertFalse(result.get(0).wildcard());
 
-		assertEquals("4930222", result.get(1).digits());
-		assertTrue(result.get(1).black());
-		assertTrue(result.get(1).wildcard());
+		assertEquals("4930333", result.get(1).digits());
+		assertFalse(result.get(1).black());
+		assertFalse(result.get(1).wildcard());
 
-		assertEquals("4930333", result.get(2).digits());
+		assertEquals("18886749072", result.get(2).digits());
 		assertFalse(result.get(2).black());
 
-		assertEquals("18886749072", result.get(3).digits());
-		assertFalse(result.get(3).black());
+		assertEquals("4930222", result.get(3).digits());
+		assertTrue(result.get(3).black());
+		assertTrue(result.get(3).wildcard(), "blocked wildcard list must produce prefix entries");
+
+		assertEquals("49800", result.get(4).digits());
+		assertFalse(result.get(4).black());
+		assertTrue(result.get(4).wildcard(), "allowed wildcard list must produce prefix entries");
 	}
 
 	@Test
 	void malformedEntriesAreSilentlyDropped() {
 		List<Entry> result = PersonalEntries.from(
 			List.of("030 12 34", "030111"),
-			List.of(""));
+			List.of(""),
+			List.of("07 11"),
+			List.of());
 		assertEquals(1, result.size());
 		assertEquals("4930111", result.get(0).digits());
+	}
+
+	/**
+	 * The wildcards of a {@link DB.PersonalLists} must reach the encoder — the regression guarded
+	 * here is #514, where the personal list was built from the exact entries alone and every
+	 * dongle got a personal file with an empty prefix section.
+	 */
+	@Test
+	void personalListsCarryWildcardsIntoTheEncoding() throws IOException {
+		DB.PersonalLists lists = new DB.PersonalLists(
+			List.of("030123456"),
+			List.of("030999999"),
+			List.of("0900"),
+			List.of("0800"));
+
+		BlocklistLookup lookup = encodeAndRead(PersonalEntries.from(lists));
+
+		assertEquals(Verdict.SPAM, lookup.lookup("4930123456"), "exact blacklist entry");
+		assertEquals(Verdict.LEGIT, lookup.lookup("4930999999"), "exact whitelist entry");
+		assertEquals(Verdict.SPAM, lookup.lookup("49900123456"), "number in a blocked range");
+		assertEquals(Verdict.LEGIT, lookup.lookup("49800123456"), "number in an allowed range");
+		assertEquals(Verdict.UNKNOWN, lookup.lookup("4930555555"), "unrelated number");
+	}
+
+	/**
+	 * An exact whitelist entry inside a blocked range keeps its exception: the exact section is
+	 * searched before the prefix section.
+	 */
+	@Test
+	void exactWhitelistBeatsBlockedRange() throws IOException {
+		DB.PersonalLists lists = new DB.PersonalLists(
+			List.of(),
+			List.of("0900123456"),
+			List.of("0900"),
+			List.of());
+
+		BlocklistLookup lookup = encodeAndRead(PersonalEntries.from(lists));
+
+		assertEquals(Verdict.LEGIT, lookup.lookup("49900123456"));
+		assertEquals(Verdict.SPAM, lookup.lookup("49900123457"));
+	}
+
+	private static BlocklistLookup encodeAndRead(List<Entry> entries) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		BlocklistBinaryEncoder.write(out, entries);
+		return BlocklistLookup.of(
+			BlocklistBinaryDecoder.read(new ByteArrayInputStream(out.toByteArray())));
 	}
 
 }

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -579,6 +579,32 @@ public class TestDB {
 		}
 	}
 
+	/**
+	 * The personal lists handed to the binary blocklist download must carry the wildcards
+	 * (#514) — without them the dongle's personal file has an empty prefix section and a blocked
+	 * range is never caught locally.
+	 */
+	@Test
+	void testPersonalListsIncludeWildcards() {
+		_db.createUser("wc-lists", "WC", "de", "+49");
+		assertEquals("030123", _db.addWildcard("wc-lists", "+4930123", true, 100));
+		assertEquals("0800", _db.addWildcard("wc-lists", "+49800", false, 100));
+
+		try (SqlSession tx = _db.openSession()) {
+			BlockList bl = tx.getMapper(BlockList.class);
+			long userId = tx.getMapper(Users.class).getUserId("wc-lists").longValue();
+			bl.addPersonalization(userId, "0501234567", null, 1);
+			bl.addExclude(userId, "0301235555", null, 1);
+			tx.commit();
+		}
+
+		DB.PersonalLists lists = _db.getPersonalLists("wc-lists");
+		assertEquals(List.of("0501234567"), lists.blacklist());
+		assertEquals(List.of("0301235555"), lists.whitelist());
+		assertEquals(List.of("030123"), lists.blockedWildcards());
+		assertEquals(List.of("0800"), lists.allowedWildcards());
+	}
+
 	@Test
 	void testWildcardBlockHidesButKeepsCoveredExactBlocks() {
 		_db.createUser("wc-subsume", "WC", "de", "+49");


### PR DESCRIPTION
Fixes #514.

The personal list the dongle downloads was built from `getPersonalizations()` /
`getWhiteList()`, and both queries filter `and not WILDCARD`. `personal.bin` was
therefore always encoded with an **empty prefix section**: a call from a range
the user had blocked by prefix was not caught locally, fell through to
`/api/check-prefix` — which cannot see wildcard rows either, they carry
`SHA1 = null` — and was let through.

Wildcard-ness could not be recovered later in the pipeline either:
`PersonalEntries.convert()` derived it from a trailing `'*'`, which
`PERSONALIZATION` never stores (the prefix is stored bare; the `WILDCARD` column
carries the distinction). Including the rows *without* passing the flag would
have encoded them as exact numbers and still not matched.

## Changes

- `DB.PersonalLists` carries the blocked and allowed wildcard prefixes next to
  the exact entries; `PersonalEntries.from(PersonalLists)` takes the whole
  object, so a caller cannot silently drop them again.
- `PersonalEntries.convert()` takes the wildcard flag explicitly. A trailing
  `'*'` is still tolerated and still implies a wildcard.
- `BlockList.getBlockedWildcards(userId)` folded into
  `getWildcards(userId, blocked)` — the whitelist side needs the same query.
  Three call sites updated (CardDAV export, `wildcardReportWeight`,
  `BlacklistController`).
- OpenAPI: `type=binary&type=personal` documents that wildcards are included.

## Tests

- `TestDB.testPersonalListsIncludeWildcards` — the SQL layer returns both
  wildcard kinds.
- `TestPersonalEntries` — end-to-end through the real codec (encode → decode →
  `BlocklistLookup`): a number in a blocked range is SPAM, a number in an
  allowed range is LEGIT, and an exact whitelist entry inside a blocked range
  still wins. Plus the wildcard-by-flag conversion cases the old suite could not
  express (it only fed `'*'`-suffixed literals the DB never produces, which is
  why this stayed green).

Full `phoneblock` suite: 400 tests, green.

## Not in this PR

No firmware change: the dongle's prefix lookup and its wildcards setting already
work, they simply never had personal data to match against. Two related gaps are
tracked separately — the dongle's wildcards toggle currently also gates the
user's *own* wildcards, and the API fallback path (#482, and the blocking half of
#487) still cannot see wildcard rows at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
