### PR TITLE
Dongle: the community-range switch no longer silences your own wildcards (#516)

### DIFF
--- a/phoneblock-dongle/firmware/main/blocklist_sync.c
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.c
@@ -511,13 +511,13 @@ bool blocklist_sync_trigger_now(void)
 }
 
 blocklist_verdict_t blocklist_sync_check(const char *digits,
-                                         bool consult_wildcards)
+                                         bool community_wildcards)
 {
-    return blocklist_sync_check_ex(digits, consult_wildcards, NULL, NULL);
+    return blocklist_sync_check_ex(digits, community_wildcards, NULL, NULL);
 }
 
 blocklist_verdict_t blocklist_sync_check_ex(const char *digits,
-                                            bool consult_wildcards,
+                                            bool community_wildcards,
                                             bool *wildcard_out,
                                             bool *personal_out)
 {
@@ -529,7 +529,9 @@ blocklist_verdict_t blocklist_sync_check_ex(const char *digits,
 
     blocklist_t *personal = blocklist_open(BLOCKLIST_PERSONAL_PATH);
     if (personal != NULL) {
-        v = blocklist_lookup_ex(personal, digits, consult_wildcards, &wildcard);
+        // Always true, not community_wildcards: the personal prefixes are the
+        // user's own range rules — see blocklist_sync.h (#516).
+        v = blocklist_lookup_ex(personal, digits, true, &wildcard);
         blocklist_close(personal);
     }
     if (v != BLOCKLIST_UNKNOWN) {
@@ -540,7 +542,7 @@ blocklist_verdict_t blocklist_sync_check_ex(const char *digits,
 
     blocklist_t *community = blocklist_open(BLOCKLIST_COMMUNITY_PATH);
     if (community != NULL) {
-        v = blocklist_lookup_ex(community, digits, consult_wildcards, &wildcard);
+        v = blocklist_lookup_ex(community, digits, community_wildcards, &wildcard);
         blocklist_close(community);
     }
     if (v != BLOCKLIST_UNKNOWN && wildcard_out) {

--- a/phoneblock-dongle/firmware/main/blocklist_sync.h
+++ b/phoneblock-dongle/firmware/main/blocklist_sync.h
@@ -41,15 +41,21 @@ void blocklist_sync_run(void);
 bool blocklist_sync_trigger_now(void);
 
 // Combined verdict using the user's personal list first, then the
-// community list. The `consult_wildcards` flag (the user's
-// "wildcards on/off" preference) gates the prefix-section search in
-// both lists.
+// community list.
+//
+// `community_wildcards` is the user's "Wildcard-Sperren auswerten"
+// preference, which is documented as being about ranges *the community*
+// reports as spam — so it gates the prefix-section search of the community
+// list only. The personal list's prefix section is always consulted: those
+// prefixes are rules the user entered themselves on phoneblock.net, and
+// opting out of the community's range judgement is not opting out of one's
+// own (#516).
 //
 // Returns BLOCKLIST_UNKNOWN when neither file is available or when the
 // query matches no entry. The caller decides the UNKNOWN-vs-LEGIT
 // default policy.
 blocklist_verdict_t blocklist_sync_check(const char *digits,
-                                         bool consult_wildcards);
+                                         bool community_wildcards);
 
 // As blocklist_sync_check(), but also reports where and how the hit was
 // found so the caller can label it precisely:
@@ -59,7 +65,7 @@ blocklist_verdict_t blocklist_sync_check(const char *digits,
 //                   set themselves.
 // Both are set to false on a miss. Either out-pointer may be NULL.
 blocklist_verdict_t blocklist_sync_check_ex(const char *digits,
-                                            bool consult_wildcards,
+                                            bool community_wildcards,
                                             bool *wildcard_out,
                                             bool *personal_out);
 

--- a/phoneblock-dongle/firmware/release-notes/1.6.0.md
+++ b/phoneblock-dongle/firmware/release-notes/1.6.0.md
@@ -41,6 +41,12 @@
 
 ## Fixed
 
+- **The dongle now honours your own wildcard blocks.** A number range you had
+  blocked on phoneblock.net was let through: those rules never reached the
+  dongle at all, and the switch for community-reported ranges silenced them
+  too. The range is now blocked without asking the server, and "Evaluate
+  wildcard blocks" only governs the community's ranges.
+
 - **Spam callers are now caught on lines outside Germany.** Every number
   that arrived without a country code was treated as German, so the dongle
   looked up a different number than the one calling and never found a


### PR DESCRIPTION
Fixes #516. Follow-up to #514 / #515 — without this, that fix stays inert for
everyone who has the switch off.

`blocklist_sync_check_ex()` passed one `consult_wildcards` flag to both local
files, and `sip_register.c` fills it from `config_blocklist_wildcards()`, i.e.
the web-UI switch *Wildcard-Sperren auswerten*, whose help text is explicitly
about the community:

> Sperrt nicht nur exakte Nummern, sondern auch Rufnummern-Bereiche
> (z. B. „030 12 34 56*“), wenn die Gemeinschaft sie als Spam meldet.

Opting out of the community's range judgement is not opting out of one's own, so
the personal file's prefix section is now always consulted and the switch
governs the community lookup only. The parameter is renamed to
`community_wildcards` so the call site reads as what it now means.

Also adds the user-facing note to the 1.6.0 release notes (the dongle side of
#514 + this).

## Validation

- `idf.py build` clean (this checkout's `sdkconfig` predated the raised
  `CONFIG_SPIFFS_GC_MAX_RUNS`, so the intended `#error` guard from #499 fired
  first — regenerated from `sdkconfig.defaults` as that guard instructs).
- Host suite `cd firmware/test && make test`: 8 passed, 0 failed.
- Not host-testable end-to-end: `blocklist_sync.c` pulls in `esp_http_client` /
  SPIFFS, so the composed personal-vs-community flag choice has no unit test.
  The layer below it does (`test_blocklist_lookup.c`,
  `test_consult_wildcards_flag`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
