### PR TITLE
Cloud-AB: honour the owner's personal wildcard blocks (#482)

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/ab/SipService.java
@@ -206,16 +206,21 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 						return null;
 					}
 					
-					Boolean state = blocklist.getPersonalizationState(userId, phoneId);
+					// Exact entry or wildcard prefix — a range the user blocked must be
+					// caught here too (#482); the hash-based /api/check path this method
+					// replaces cannot see wildcards at all.
+					DB.PersonalVerdict personal = db.resolvePersonalization(blocklist, userId, phoneId);
 
 					PhoneInfo info;
-					if (state != null) {
+					if (personal != null) {
 						// There is a personalization for the calling number.
-						if (state.booleanValue()) {
+						if (personal.blocked()) {
 							// Locally blocked.
-							LOG.info("Caller is on blacklist of {}: {}", botName, phoneId);
+							LOG.info("Caller is on blacklist of {}: {} (matched {})", botName, phoneId,
+								personal.phoneId());
 							info = NumberAnalyzer.phoneInfoFromId(phoneId)
 								.setRating(Rating.B_MISSED)
+								.setBlackListed(true)
 								.setVotes(1000)
 								.setVotesWildcard(1000);
 						} else {
@@ -223,6 +228,7 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 							LOG.info("Call form white-listed number of {}.", botName);
 							info = NumberAnalyzer.phoneInfoFromId(phoneId)
 								.setRating(Rating.A_LEGITIMATE)
+								.setWhiteListed(true)
 								.setVotes(0);
 						}
 					} else {
@@ -262,7 +268,14 @@ public class SipService implements ServletContextListener, RegistrationClientLis
 						String phoneId = NumberAnalyzer.getPhoneId(number);
 						// Spam evidence is capped per user (the answer-bot owner) inside recordCall.
 						BlockList blocklist = session.getMapper(BlockList.class);
-						db.recordCall(reports, blocklist, ownerUserId, number, phoneId, dialPrefix, startTime);
+						// A pickup decided by one of the owner's prefix wildcards is reported
+						// with the rule's weight, not at full strength (#377) — same resolver
+						// (and therefore the same precedence) fetchPhoneInfo used to decide.
+						DB.PersonalVerdict personal =
+							db.resolvePersonalization(blocklist, ownerUserId, phoneId);
+						double weight = personal != null ? personal.reportWeight(phoneId) : 1.0;
+						db.recordCall(reports, blocklist, ownerUserId, number, phoneId, dialPrefix,
+							startTime, weight);
 					}
 
 					session.commit();

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
@@ -188,6 +188,21 @@ public interface BlockList {
 	int updatePersonalizationHash(String phone, byte[] sha1);
 
 	/**
+	 * The user's most specific wildcard prefix covering the given phone ID (#377), or
+	 * {@code null} if none of their wildcards matches.
+	 *
+	 * <p>Longest prefix wins, mirroring the client-side lookups (binary blocklist, mobile app):
+	 * a narrow rule under a broad one decides, whichever block state it carries.</p>
+	 */
+	@Select("""
+			select PHONE, BLOCKED from PERSONALIZATION
+			where USERID = #{userId} and WILDCARD and #{phoneId} like PHONE || '%'
+			order by length(PHONE) desc
+			limit 1
+			""")
+	DBPersonalization resolveWildcard(long userId, String phoneId);
+
+	/**
 	 * Wildcard prefixes (phone-ID form, stored bare without a trailing {@code *}) of the given
 	 * block state for the user with the given user ID (#377).
 	 */

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -2794,6 +2794,50 @@ public class DB {
 	}
 
 	/**
+	 * A user's personalization verdict for one number: their exact entry if they have one,
+	 * otherwise their most specific matching wildcard prefix (#377).
+	 */
+	public record PersonalVerdict(
+			/** Whether the number is blocked ({@code true}) or explicitly allowed. */
+			boolean blocked,
+			/** Whether the verdict comes from a wildcard prefix rather than an exact entry. */
+			boolean wildcard,
+			/** The matched phone ID: the number itself, or the wildcard prefix. */
+			String phoneId) {
+
+		/**
+		 * Report weight for a call caught by this verdict, relative to the given number: full
+		 * weight for an exact entry, reduced by the wildcard's breadth otherwise (see
+		 * {@link DB#wildcardReportWeight(int, int)}).
+		 */
+		public double reportWeight(String caughtNumber) {
+			return wildcard ? wildcardReportWeight(phoneId.length(), caughtNumber.length()) : 1.0;
+		}
+
+	}
+
+	/**
+	 * Resolves what the given user has decided about the given number themselves: their exact
+	 * personalization if there is one, else their most specific matching wildcard prefix.
+	 *
+	 * <p>Exact before wildcard, and the longest wildcard among several — the same precedence the
+	 * on-device lookups apply, so every path reaches the same verdict (#482).</p>
+	 *
+	 * @return the user's verdict, or {@code null} if they have no rule covering the number.
+	 */
+	public PersonalVerdict resolvePersonalization(BlockList blocklist, long userId, String phoneId) {
+		Boolean exact = blocklist.getPersonalizationState(userId, phoneId);
+		if (exact != null) {
+			return new PersonalVerdict(exact.booleanValue(), false, phoneId);
+		}
+		DBPersonalization wildcard = blocklist.resolveWildcard(userId, phoneId);
+		if (wildcard == null) {
+			return null;
+		}
+		return new PersonalVerdict(wildcard.isBlocked(), true, wildcard.getPhone());
+	}
+
+	/**
 	 * Report weight for a wildcard-triggered catch (#377): the longest of the user's blocked
 	 * wildcards that is a prefix of the reported number decides the weight.
 	 *

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -665,6 +665,50 @@ public class TestDB {
 		}
 	}
 
+	/**
+	 * The resolver every server-side call path shares (#482): exact entry first, then the most
+	 * specific matching wildcard.
+	 */
+	@Test
+	void testResolvePersonalizationWithWildcards() {
+		_db.createUser("wc-resolve", "WC", "de", "+49");
+		assertEquals("030123", _db.addWildcard("wc-resolve", "+4930123", true, 100));
+		assertEquals("0301234", _db.addWildcard("wc-resolve", "+49301234", false, 100));
+		assertEquals("0800", _db.addWildcard("wc-resolve", "+49800", false, 100));
+
+		try (SqlSession tx = _db.openSession()) {
+			BlockList bl = tx.getMapper(BlockList.class);
+			long userId = tx.getMapper(Users.class).getUserId("wc-resolve").longValue();
+			bl.addPersonalization(userId, "0301230000", null, 1);
+			tx.commit();
+
+			// An exact entry wins over any wildcard, and reports at full weight.
+			DB.PersonalVerdict exact = _db.resolvePersonalization(bl, userId, "0301230000");
+			assertTrue(exact.blocked());
+			assertFalse(exact.wildcard());
+			assertEquals(1.0, exact.reportWeight("0301230000"));
+
+			// Otherwise the blocking wildcard catches the number — weighted by its breadth:
+			// 030123 (6) vs 0301239999 (10) omits 4 digits -> 0.25.
+			DB.PersonalVerdict blocked = _db.resolvePersonalization(bl, userId, "0301239999");
+			assertTrue(blocked.blocked());
+			assertTrue(blocked.wildcard());
+			assertEquals("030123", blocked.phoneId());
+			assertEquals(0.25, blocked.reportWeight("0301239999"));
+
+			// The narrower allowing wildcard wins over the broader blocking one.
+			DB.PersonalVerdict allowed = _db.resolvePersonalization(bl, userId, "0301234567");
+			assertFalse(allowed.blocked());
+			assertTrue(allowed.wildcard());
+			assertEquals("0301234", allowed.phoneId());
+
+			// A number covered by nothing has no verdict — and a prefix is not matched by a
+			// number that merely starts like it in the other direction.
+			assertNull(_db.resolvePersonalization(bl, userId, "0401234567"));
+			assertNull(_db.resolvePersonalization(bl, userId, "030"));
+		}
+	}
+
 	@Test
 	void testWildcardReportWeightLookup() {
 		_db.createUser("wc-user", "WC", "de", "+49");


### PR DESCRIPTION
Fixes #482.

**Chained on #515** (`issue-514-personal-wildcards-binary-blocklist`) — both
touch `BlockList` / `DB`. Merge #515 first; this PR's base retargets to `master`
afterwards.

## Cause

The Cloud answer bot does not go through the public API: `SipService` overrides
`AnswerBot.fetchPhoneInfo()` and resolves the caller in-process against the DB.
That override consulted `getPersonalizationState()` only — the **exact**
`PERSONALIZATION` row — so a range the user had blocked by prefix was never
recognised, the bot did not pick up, and the call rang through exactly as
reported.

Falling back to the HTTP path would not have helped: wildcard rows are stored
with `SHA1 = null` (they are matched by prefix, not by equality), so neither
`/api/check` nor `/api/check-prefix` can return one. That is also why the
self-hosted Docker bot still cannot see them — #297.

## Changes

- `DB.resolvePersonalization(blocklist, userId, phoneId)` — one resolver for
  "what has this user decided about this number themselves": exact entry first,
  then their most specific matching wildcard (`BlockList.resolveWildcard`,
  longest prefix wins). Same precedence as the on-device lookups, so every path
  reaches the same verdict.
- `SipService.fetchPhoneInfo()` uses it, and sets `blackListed` / `whiteListed`
  on the synthesised `PhoneInfo` so the in-process path reports the same flags
  as the HTTP one. The bot's `isBlackListed()` branch now handles the pickup,
  which also makes the log line say *why* it picked up (including which prefix
  matched).
- `processCallData()` reports a wildcard-decided pickup with that rule's weight
  (#377) rather than at full strength, asking the *same* resolver — so the
  catch decision and the report weight cannot drift apart.

## Tests

`TestDB.testResolvePersonalizationWithWildcards`: exact beats wildcard, longest
wildcard wins (a narrow *allowing* rule under a broad *blocking* one decides),
report weight follows the prefix breadth (0.25 for four omitted digits), and a
number covered by nothing gets no verdict. Full `phoneblock` suite: 401 tests,
green.

The `SipService` wiring itself has no test — it needs a live SIP stack; the
logic it now calls is covered at the DB layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
