### PR TITLE
App: server-created wildcard rules reach call screening (#487)

### DIFF
--- a/phoneblock_mobile/lib/blocklist_sync_service.dart
+++ b/phoneblock_mobile/lib/blocklist_sync_service.dart
@@ -4,6 +4,7 @@ import 'package:phoneblock_mobile/api.dart' as api;
 import 'package:phoneblock_mobile/logging/app_logger.dart';
 import 'package:phoneblock_mobile/main.dart' show callPhoneBlockApi, getAuthToken, pbBaseUrl;
 import 'package:phoneblock_mobile/storage.dart';
+import 'package:phoneblock_mobile/wildcard_sync_service.dart';
 
 /// Service for syncing the community blocklist to the local SQLite cache.
 ///
@@ -86,6 +87,11 @@ class BlocklistSyncService {
       );
 
       AppLogger.instance.info('sync', 'blocklist sync done (upserted=$upserted, deleted=$deleted, version=${blocklist.version})');
+
+      // The user's own wildcard rules (#377) ride along on the same schedule: they are part of
+      // what screening needs and used to refresh only when the blacklist screen was opened
+      // (#487). A failure here does not fail the community sync that already succeeded.
+      await WildcardSyncService.instance.sync(authToken);
       return true;
     } catch (e, s) {
       AppLogger.instance.error('sync', 'blocklist sync failed', e, s);

--- a/phoneblock_mobile/lib/main.dart
+++ b/phoneblock_mobile/lib/main.dart
@@ -22,6 +22,7 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:phoneblock_mobile/blocklist_sync_service.dart';
+import 'package:phoneblock_mobile/wildcard_sync_service.dart';
 import 'package:phoneblock_mobile/logging/app_logger.dart';
 import 'package:phoneblock_mobile/logging/crash_handler.dart';
 import 'package:phoneblock_mobile/logging/log_viewer_screen.dart';
@@ -1160,7 +1161,21 @@ class _MainScreenState extends State<MainScreen> {
     _setupCallScreeningListener();
     _checkPendingSharedNumber();
     _loadAnswerbotEnabled();
+    _syncPersonalWildcards();
     _initFritzBox();
+  }
+
+  /// Brings the personal wildcard rules (#377) up to date with the server.
+  ///
+  /// Rules created on phoneblock.net or on another device only reached the native screening
+  /// service when the blacklist screen was opened, so they did not block (#487). Running it
+  /// here means opening the app is enough.
+  Future<void> _syncPersonalWildcards() async {
+    final token = await getAuthToken();
+    if (token == null || token.isEmpty) {
+      return;
+    }
+    await WildcardSyncService.instance.sync(token);
   }
 
   /// Initializes Fritz!Box service and syncs calls.
@@ -2889,9 +2904,18 @@ Future<void> registerBlocklistSync() async {
 }
 
 /// Syncs wildcard prefixes from SQLite to SharedPreferences for CallChecker access.
+///
+/// Best-effort: the MethodChannel is unavailable in a background isolate (no Activity), so a
+/// background sync only updates the local store and the next foreground run pushes the
+/// prefixes on. Same limitation — and same handling — as [getAuthToken].
 Future<void> syncWildcardPrefixesToNative() async {
   final prefixes = await ScreenedCallsDatabase.instance.getWildcardPrefixes();
-  await platform.invokeMethod('setWildcardPrefixes', {'prefixes': prefixes});
+  try {
+    await platform.invokeMethod('setWildcardPrefixes', {'prefixes': prefixes});
+  } catch (e) {
+    AppLogger.instance.info('sync',
+        'wildcard prefixes not handed to the screening service (no Activity): $e');
+  }
 }
 
 Future<bool> checkPermission() async {
@@ -3955,8 +3979,8 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
 
         List<WildcardBlock> wildcards = [];
         if (_isBlacklist) {
-          await _syncWildcards(serverWildcards);
-          wildcards = await ScreenedCallsDatabase.instance.getAllWildcardBlocks();
+          wildcards = await WildcardSyncService.instance
+              .reconcile(serverWildcards, widget.authToken);
         }
 
         setState(() {
@@ -3977,51 +4001,6 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
         _isLoading = false;
       });
     }
-  }
-
-  /// Reconciles local wildcard blocks with the server (#377).
-  ///
-  /// The server is the source of truth; the local copy exists only so the native
-  /// CallScreeningService can block offline. The app's pre-existing local-only wildcards are
-  /// lifted to the server once (migration); afterwards the local set mirrors the server, so
-  /// wildcards added or removed on any of the user's devices propagate here.
-  Future<void> _syncWildcards(List<api.PersonalizedNumber> serverWildcards) async {
-    final db = ScreenedCallsDatabase.instance;
-    final prefs = await SharedPreferences.getInstance();
-
-    // One-time migration of the app's existing local-only wildcards to the server.
-    if (!(prefs.getBool('wildcards_migrated') ?? false)) {
-      final onServer = serverWildcards.map((w) => w.phone).toSet();
-      for (final local in await db.getAllWildcardBlocks()) {
-        if (!onServer.contains(local.prefix) && await addWildcardToServer(local.prefix, widget.authToken)) {
-          serverWildcards.add(api.PersonalizedNumber(
-              phone: local.prefix, wildcard: true, created: local.created.millisecondsSinceEpoch));
-        }
-      }
-      await prefs.setBool('wildcards_migrated', true);
-    }
-
-    // Mirror the server set into the local store: add server-only, drop local-only.
-    final serverPrefixes = serverWildcards.map((w) => w.phone).toSet();
-    final local = await db.getAllWildcardBlocks();
-    final localPrefixes = local.map((w) => w.prefix).toSet();
-
-    for (final sw in serverWildcards) {
-      if (!localPrefixes.contains(sw.phone)) {
-        await db.insertWildcardBlock(WildcardBlock(
-          prefix: sw.phone,
-          comment: null,
-          created: sw.created > 0 ? DateTime.fromMillisecondsSinceEpoch(sw.created) : DateTime.now(),
-        ));
-      }
-    }
-    for (final lw in local) {
-      if (!serverPrefixes.contains(lw.prefix)) {
-        await db.deleteWildcardBlock(lw.id!);
-      }
-    }
-
-    await syncWildcardPrefixesToNative();
   }
 
   /// Edit the comment for a number in the list.
@@ -4285,6 +4264,13 @@ class _PersonalizedNumberListScreenState extends State<PersonalizedNumberListScr
   /// Returns null if the input cannot be normalized.
   Future<String?> _normalizeWildcardPrefix(String input) async {
     var cleaned = input.replaceAll(RegExp(r'[\s\-\(\)\/]'), '');
+
+    // A user who types the rule the way it is written ("+49900*") means the prefix "+49900" —
+    // the '*' is the notation for the range, not a digit of it. Rejecting such input as
+    // unparseable is what produced the misleading "too short" complaint in #487.
+    if (cleaned.endsWith('*')) {
+      cleaned = cleaned.substring(0, cleaned.length - 1);
+    }
 
     // Handle 00XX format → +XX
     if (cleaned.startsWith('00') && cleaned.length >= 4) {

--- a/phoneblock_mobile/lib/wildcard_sync_service.dart
+++ b/phoneblock_mobile/lib/wildcard_sync_service.dart
@@ -1,0 +1,128 @@
+import 'package:phoneblock_mobile/api.dart' as api;
+import 'package:phoneblock_mobile/logging/app_logger.dart';
+import 'package:phoneblock_mobile/main.dart'
+    show addWildcardToServer, fetchBlacklist, syncWildcardPrefixesToNative;
+import 'package:phoneblock_mobile/storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// What reconciling the local wildcard store against the server implies.
+///
+/// Pure data so the decision can be tested without a database — see
+/// [WildcardSyncService.diff].
+class WildcardDiff {
+  /// Server rules missing from the local store; to be inserted.
+  final List<api.PersonalizedNumber> toInsert;
+
+  /// Local rules the server no longer has; to be deleted.
+  final List<WildcardBlock> toDelete;
+
+  /// Local-only rules to be lifted to the server (one-time migration of the
+  /// app's pre-#377 local wildcards). They are kept locally either way.
+  final List<WildcardBlock> toUpload;
+
+  WildcardDiff({required this.toInsert, required this.toDelete, required this.toUpload});
+}
+
+/// Keeps the user's personal wildcard blocks (#377) in sync between the server, the local
+/// SQLite store and the native call-screening service.
+///
+/// The server is the source of truth: rules created on phoneblock.net or on another device
+/// must reach this device's screening service, and rules deleted there must disappear from it.
+/// The local copy exists only so screening works offline.
+///
+/// Runs on every blocklist sync and when the app starts, not only when the blacklist screen
+/// happens to be opened — a rule the user entered on the website used to have no effect until
+/// they navigated to that screen (#487).
+class WildcardSyncService {
+  static final WildcardSyncService instance = WildcardSyncService._();
+
+  WildcardSyncService._();
+
+  /// Key of the one-time migration flag: the app had local-only wildcards before the server
+  /// learned about them (#377), and those must be lifted up rather than deleted.
+  static const String migratedKey = 'wildcards_migrated';
+
+  /// Computes what to change locally, given the server's rules and the local ones.
+  ///
+  /// Before the migration has run, local-only rules are uploaded and kept; afterwards a rule
+  /// missing on the server means the user deleted it somewhere, so it goes.
+  static WildcardDiff diff({
+    required List<api.PersonalizedNumber> server,
+    required List<WildcardBlock> local,
+    required bool migrated,
+  }) {
+    final serverPrefixes = server.map((w) => w.phone).toSet();
+    final localPrefixes = local.map((w) => w.prefix).toSet();
+
+    return WildcardDiff(
+      toInsert: server.where((w) => !localPrefixes.contains(w.phone)).toList(),
+      toDelete: migrated ? local.where((w) => !serverPrefixes.contains(w.prefix)).toList() : [],
+      toUpload: migrated ? [] : local.where((w) => !serverPrefixes.contains(w.prefix)).toList(),
+    );
+  }
+
+  /// Fetches the user's blacklist and reconciles its wildcard rules.
+  ///
+  /// Returns `true` if the reconciliation ran (the list could be fetched).
+  Future<bool> sync(String authToken) async {
+    try {
+      final numberList = await fetchBlacklist(authToken);
+      if (numberList == null) {
+        AppLogger.instance.info('sync', 'wildcard sync: blacklist unavailable, skipping');
+        return false;
+      }
+      await reconcile(numberList.numbers.where((n) => n.wildcard).toList(), authToken);
+      return true;
+    } catch (e, s) {
+      AppLogger.instance.error('sync', 'wildcard sync failed', e, s);
+      return false;
+    }
+  }
+
+  /// Reconciles the given server wildcard rules into the local store and hands the resulting
+  /// prefixes to the native screening service.
+  ///
+  /// Returns the local rules after reconciliation, ready for display.
+  Future<List<WildcardBlock>> reconcile(
+      List<api.PersonalizedNumber> serverWildcards, String authToken) async {
+    final db = ScreenedCallsDatabase.instance;
+    final prefs = await SharedPreferences.getInstance();
+    final migrated = prefs.getBool(migratedKey) ?? false;
+
+    final plan = WildcardSyncService.diff(
+      server: serverWildcards,
+      local: await db.getAllWildcardBlocks(),
+      migrated: migrated,
+    );
+
+    for (final w in plan.toInsert) {
+      await db.insertWildcardBlock(WildcardBlock(
+        prefix: w.phone,
+        comment: null,
+        created: w.created > 0
+            ? DateTime.fromMillisecondsSinceEpoch(w.created)
+            : DateTime.now(),
+      ));
+    }
+    for (final w in plan.toDelete) {
+      await db.deleteWildcardBlock(w.id!);
+    }
+
+    // The migration is only complete once every local-only rule is on the server. A rule whose
+    // upload failed stays local and is retried on the next run — deleting it (which is what a
+    // completed migration implies for a server-less rule) would silently lose it.
+    bool allUploaded = true;
+    for (final w in plan.toUpload) {
+      if (!await addWildcardToServer(w.prefix, authToken)) {
+        allUploaded = false;
+        AppLogger.instance.info('sync', 'wildcard ${w.prefix} could not be uploaded, retrying later');
+      }
+    }
+    if (!migrated && allUploaded) {
+      await prefs.setBool(migratedKey, true);
+    }
+
+    await syncWildcardPrefixesToNative();
+    return db.getAllWildcardBlocks();
+  }
+}

--- a/phoneblock_mobile/test/wildcard_sync_service_test.dart
+++ b/phoneblock_mobile/test/wildcard_sync_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phoneblock_mobile/api.dart' as api;
+import 'package:phoneblock_mobile/storage.dart';
+import 'package:phoneblock_mobile/wildcard_sync_service.dart';
+
+api.PersonalizedNumber server(String prefix, {int created = 1000}) =>
+    api.PersonalizedNumber(phone: prefix, wildcard: true, created: created);
+
+WildcardBlock local(String prefix, {int id = 1}) => WildcardBlock(
+      id: id,
+      prefix: prefix,
+      comment: null,
+      created: DateTime.fromMillisecondsSinceEpoch(1000),
+    );
+
+void main() {
+  group('WildcardSyncService.diff', () {
+    test('adopts rules the server has and this device does not', () {
+      // The #487 case: created on the website, never seen by this device.
+      final diff = WildcardSyncService.diff(
+        server: [server('+4930123')],
+        local: [],
+        migrated: true,
+      );
+
+      expect(diff.toInsert.map((w) => w.phone), ['+4930123']);
+      expect(diff.toDelete, isEmpty);
+      expect(diff.toUpload, isEmpty);
+    });
+
+    test('drops rules deleted on the server once migrated', () {
+      final diff = WildcardSyncService.diff(
+        server: [server('+4930123')],
+        local: [local('+4930123', id: 1), local('+49900', id: 2)],
+        migrated: true,
+      );
+
+      expect(diff.toInsert, isEmpty);
+      expect(diff.toDelete.map((w) => w.id), [2]);
+    });
+
+    test('uploads local-only rules instead of dropping them before migration', () {
+      final diff = WildcardSyncService.diff(
+        server: [],
+        local: [local('+49900')],
+        migrated: false,
+      );
+
+      expect(diff.toUpload.map((w) => w.prefix), ['+49900']);
+      expect(diff.toDelete, isEmpty,
+          reason: 'a rule that only exists locally must survive the migration');
+    });
+
+    test('leaves rules both sides already agree on alone', () {
+      final diff = WildcardSyncService.diff(
+        server: [server('+4930123')],
+        local: [local('+4930123')],
+        migrated: true,
+      );
+
+      expect(diff.toInsert, isEmpty);
+      expect(diff.toDelete, isEmpty);
+      expect(diff.toUpload, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Addresses the wildcard part of #487. Independent of #515 / #518 (app-only
changes), so it can merge in any order.

## What was wrong

Two different things, and it is worth separating them:

1. **The released 1.3.1 (Play Store, built 2026-04) predates the app-side
   wildcard sync.** `#377`'s mobile two-way sync landed on `master` on
   2026-06-14, after `1.3.1+12` was tagged. That build ignores the
   `wildcard: true` flag `/api/blacklist` sends, so a website-created rule shows
   up as a plain number — literally "aus `+49*` wird `+49`", since the server
   stores prefixes bare. Nothing to fix there beyond shipping a release.

2. **Even on `master` the rule only takes effect if you open the blacklist
   screen.** The reconciliation lived in `_NumberListScreenState._syncWildcards`,
   so a rule created on the website or on another device never reached the native
   `CallScreeningService` until the user navigated there — and blocked nothing in
   the meantime. That is what this PR fixes.

## Changes

- `WildcardSyncService` owns the reconciliation. Its decision is a pure function
  (`diff(server:, local:, migrated:)`) over the two rule sets, so it is
  unit-testable without a database; the DB/native side effects are applied
  around it.
- It runs **on app start** and **as part of every blocklist sync** (the daily
  WorkManager task and the manual "sync now"), in addition to the list screen.
- The one-time migration of pre-#377 local-only rules no longer marks itself
  complete when an upload failed. Previously such a rule stayed local while the
  flag was set, and the next run — considering the migration done — deleted it:
  silent data loss.
- `syncWildcardPrefixesToNative()` tolerates the absent MethodChannel in a
  background isolate (no Activity), the same way `getAuthToken()` already does.
- A rule typed the way it is displayed (`+49900*`) is accepted instead of being
  rejected as "too short" — the `*` is the notation for the range, not a digit.
  That is the "kaum lesbare und unpassende Fehlermeldung" from the report.

## Tests

`test/wildcard_sync_service_test.dart` covers the diff: adopt a server-only rule
(the #487 case), drop a rule deleted on the server, upload rather than delete a
local-only rule before migration, and leave agreed rules alone.

**Not run here:** this machine has no Flutter SDK (only a standalone Dart SDK
and no `.dart_tool`), so `flutter analyze` and `flutter test` were not executed —
the changed files were verified to parse via `dart format --output=none`. Please
run both before merging.

## Not addressed (from the same report)

- The floating "add" button covering the last list entry.
- Whitelist wildcards (allowed ranges) are split out of the number list but not
  displayed and not synced — the app's local store and the native screening path
  only model *blocked* prefixes. Needs UI + new strings (i.e. the DeepL ARB
  flow), so it is its own change.
- Refreshing the native prefix list from the background isolate would need the
  `setWildcardPrefixes` handler moved into an auto-registered plugin (as
  `LogBridge` is). Today the background run updates the local store and the next
  foreground start pushes the prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
