### PR TITLE
Absorb duplicate personalization inserts instead of failing the request (#520)

### DIFF
--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/BlockList.java
@@ -91,12 +91,23 @@ public interface BlockList {
 	 * Adds a blocklist entry for the user with the given user ID. {@code LAST_ACTIVITY} is seeded to
 	 * the creation time — the moment of the first spam signal — so the initial capped contribution
 	 * {@code Ema.increment(1, created)} can be reconstructed (and later topped up) from the row.
+	 *
+	 * <p>Inserts only when the user has no entry for the number yet, and reports that as the
+	 * affected-row count: callers check for {@code 0} and absorb the duplicate instead of failing
+	 * on the primary key (#520). Two submissions for the same {@code (user, number)} overlapping in
+	 * time — a repeated rating, a retried report — otherwise both pass their own existence check
+	 * and the second one 500s.</p>
+	 *
+	 * @return {@code 1} if the entry was created, {@code 0} if the user already had one.
 	 */
 	@Insert("""
 			insert into PERSONALIZATION (USERID, PHONE, SHA1, BLOCKED, CREATED, LAST_ACTIVITY)
-			values (#{userId}, #{phone}, #{sha1}, true, #{created}, #{created})
+			select #{userId}, #{phone}, #{sha1}, true, #{created}, #{created}
+			where not exists (
+				select 1 from PERSONALIZATION where USERID = #{userId} and PHONE = #{phone}
+			)
 			""")
-	void addPersonalization(long userId, String phone, byte[] sha1, long created);
+	int addPersonalization(long userId, String phone, byte[] sha1, long created);
 
 	/**
 	 * Records new spam/legit activity (a topped-up call or re-rating) for an existing
@@ -143,12 +154,18 @@ public interface BlockList {
 	/**
 	 * Adds an exclusion from the blocklist for the user with the given user ID. {@code LAST_ACTIVITY}
 	 * is seeded to the creation time (see {@link #addPersonalization}).
+	 *
+	 * @return {@code 1} if the entry was created, {@code 0} if the user already had one — see
+	 *         {@link #addPersonalization} for why the insert is conditional.
 	 */
 	@Insert("""
 			insert into PERSONALIZATION (USERID, PHONE, SHA1, BLOCKED, CREATED, LAST_ACTIVITY)
-			values (#{userId}, #{phone}, #{sha1}, false, #{created}, #{created})
+			select #{userId}, #{phone}, #{sha1}, false, #{created}, #{created}
+			where not exists (
+				select 1 from PERSONALIZATION where USERID = #{userId} and PHONE = #{phone}
+			)
 			""")
-	void addExclude(long userId, String phone, byte[] sha1, long created);
+	int addExclude(long userId, String phone, byte[] sha1, long created);
 
 	/**
 	 * Resolves a personalization entry by its SHA1 hash.

--- a/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
+++ b/phoneblock/src/main/java/de/haumacher/phoneblock/db/DB.java
@@ -1074,7 +1074,12 @@ public class DB {
 		if (entry == null) {
 			// First contact via a call: auto-add the concrete number to the user's blacklist so the
 			// contribution is tracked (hidden from display when a wildcard already covers it).
-			blocklist.addPersonalization(userId, phoneId, hash, now);
+			if (blocklist.addPersonalization(userId, phoneId, hash, now) == 0) {
+				// Another report for the same number committed between the check above and this
+				// insert (#520). That request counted the contribution; counting it again here
+				// would double it, and inserting again would fail the request.
+				return 0.0;
+			}
 			return Ema.increment(1.0, now, Ema.CLASSIFICATION_TAU_MILLIS);
 		}
 		if (!entry.isBlocked()) {
@@ -1325,13 +1330,28 @@ public class DB {
 					if (existing != null) {
 						// Flip to the opposite list: remember the entry so its residual capped
 						// contribution can be reversed once the dial prefix is resolved below.
+						// The row is deleted in this transaction, so the insert below sees no
+						// entry and always applies.
 						flipFrom = existing;
 						blocklist.removePersonalization(userId, phone);
-					}
-					if (block) {
-						blocklist.addPersonalization(userId, phone, sha1, now);
+						if (block) {
+							blocklist.addPersonalization(userId, phone, sha1, now);
+						} else {
+							blocklist.addExclude(userId, phone, sha1, now);
+						}
 					} else {
-						blocklist.addExclude(userId, phone, sha1, now);
+						int inserted = block
+							? blocklist.addPersonalization(userId, phone, sha1, now)
+							: blocklist.addExclude(userId, phone, sha1, now);
+						if (inserted == 0) {
+							// Another rating for the same number committed between the check above
+							// and this insert (#520) — a double submit or a client retry. Its vote
+							// is already recorded, so ours must not count twice, and the request
+							// must not fail over a duplicate the user cannot see.
+							LOG.info("Concurrent rating for number {} ({}) by {}, entry already present.",
+								phone, rating, userName);
+							recordVote = false;
+						}
 					}
 				}
 

--- a/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
+++ b/phoneblock/src/test/java/de/haumacher/phoneblock/db/TestDB.java
@@ -681,6 +681,61 @@ public class TestDB {
 		}
 	}
 
+	/** Runs one blocklist insert in its own transaction, like one request would. */
+	private int addBlockTx(long userId, String phone, long created) {
+		try (SqlSession tx = _db.openSession()) {
+			int rows = tx.getMapper(BlockList.class).addPersonalization(userId, phone, null, created);
+			tx.commit();
+			return rows;
+		}
+	}
+
+	/** Runs one allow-list insert in its own transaction, like one request would. */
+	private int addAllowTx(long userId, String phone, long created) {
+		try (SqlSession tx = _db.openSession()) {
+			int rows = tx.getMapper(BlockList.class).addExclude(userId, phone, null, created);
+			tx.commit();
+			return rows;
+		}
+	}
+
+	/**
+	 * The personalization inserts must absorb a duplicate instead of violating the primary key
+	 * (#520). Each insert runs in its own transaction, mirroring the two overlapping requests that
+	 * produce the failure: the second request's existence check ran before the first one committed,
+	 * so only the insert itself can still detect the row.
+	 */
+	@Test
+	void testPersonalizationInsertsAbsorbDuplicates() {
+		_db.createUser("dup-user", "DUP", "de", "+49");
+		long userId;
+		try (SqlSession tx = _db.openSession()) {
+			userId = tx.getMapper(Users.class).getUserId("dup-user").longValue();
+		}
+
+		assertEquals(1, addBlockTx(userId, "0301230000", 100));
+		assertEquals(0, addBlockTx(userId, "0301230000", 200), "the duplicate must be absorbed, not throw");
+
+		assertEquals(1, addAllowTx(userId, "0409999999", 100));
+		assertEquals(0, addAllowTx(userId, "0409999999", 200));
+
+		// Neither list may overwrite the other's entry for the same number.
+		assertEquals(0, addAllowTx(userId, "0301230000", 300));
+		assertEquals(0, addBlockTx(userId, "0409999999", 300));
+
+		try (SqlSession tx = _db.openSession()) {
+			BlockList bl = tx.getMapper(BlockList.class);
+
+			// The existing entries are untouched — a duplicate must not reset the activity
+			// timestamp the per-user evidence cap is computed from, nor flip the block state.
+			assertEquals(100, bl.getPersonalizationActivity(userId, "0301230000").getLastActivity());
+			assertTrue(bl.getPersonalizationState(userId, "0301230000").booleanValue(),
+				"an allow must not silently replace an existing block");
+			assertFalse(bl.getPersonalizationState(userId, "0409999999").booleanValue(),
+				"a block must not silently replace an existing allow");
+		}
+	}
+
 	@Test
 	void testQuote() {
 		assertEquals("\"\" 0x0 \"33a0a838-7b11-427a-\" 0x9 \"\" 0xD \"\" 0xA \"\" 0xC \"9c84-59b6ab6d3b0e\" 0x20 \"\"", DB.saveChars("\00033a0a838-7b11-427a-\t\r\n\f9c84-59b6ab6d3b0e "));


### PR DESCRIPTION
Fixes #520. Base `master`, independent of the wildcard PRs (#518, #519).

`DB.addRating` reads `getPersonalizationActivity` and then inserts, with nothing
in between, so two submissions for the same `(user, number)` that overlap in time
both see no entry and both insert — the second one 500s and the user's rating is
lost. `cappedCallSpamContribution` (`DB.java:1073`) has the same shape and is one
report collision away from the same failure.

Both inserts are now conditional and return the affected count:

```sql
insert into PERSONALIZATION (USERID, PHONE, SHA1, BLOCKED, CREATED, LAST_ACTIVITY)
select #{userId}, #{phone}, #{sha1}, true, #{created}, #{created}
where not exists (
    select 1 from PERSONALIZATION where USERID = #{userId} and PHONE = #{phone}
)
```

On `0` the caller absorbs the duplicate: `addRating` takes the same branch as an
ignored repeated rating (comment kept, vote **not** counted twice — today's 500 at
least had the side effect of not double-counting, and that property is preserved),
and the call path returns no evidence increment because the other request already
counted its own.

Conditional insert rather than H2's `MERGE` or catching the exception: `MERGE` has
no PostgreSQL equivalent (#355), and catching poisons the transaction there.

## Three H2 behaviours this shape depends on

Verified directly against H2 2.4.240 (throwaway JDBC probe, not part of the PR):

| situation | guard sees the row? | consequence |
|---|---|---|
| row committed by **another** transaction | yes → `rows=0` | the 500 is gone — this *is* the production case, duplicates arrive seconds apart |
| this transaction's own `DELETE` | yes → insert applies | the flip-to-the-other-list path (delete, then insert) is unaffected |
| this transaction's own `INSERT` | **no** → PK violation | a caller must not insert twice in one transaction; none does |

The last row is why the test uses **one transaction per insert** — which is also
the faithful reproduction of two competing requests.

## Tests

`TestDB.testPersonalizationInsertsAbsorbDuplicates`: the second insert is
absorbed rather than thrown; the surviving entry keeps its `LAST_ACTIVITY` (the
per-user evidence cap is computed from it); and neither list silently replaces the
other's entry for the same number. Full `phoneblock` suite: 401 tests, green.

## Residual

A genuinely simultaneous pair — the other transaction still uncommitted when our
insert runs — can still collide, since neither the guard nor a preceding delete
can see an uncommitted row. Closing that needs `insert … on conflict do nothing`,
i.e. after the PostgreSQL move (#355). Given the observed pattern (retries and
double submits, seconds apart) this should take the ~7.6/day to about zero; worth
re-checking the signature after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
